### PR TITLE
fix: build PDF with Weasyprint 53

### DIFF
--- a/test.py
+++ b/test.py
@@ -499,18 +499,18 @@ class PdfWriterTests(unittest.TestCase):
         self.pdfxml = copy.deepcopy(self.elements_pdfxml)
         self.root = copy.deepcopy(self.elements_root)
 
-    def test_text_content(self):
-        def norm(t):
-            return re.sub(r'\s+', ' ', t).strip()
-        #
-        text = norm('\n'.join( p.text for p in self.pdfxml.xpath('.//Page/text') ))
-        for e in self.root.xpath('./middle//*'):
-            if e.text and e.text.strip() and e.tag not in xml2rfc.util.unicode.unicode_content_tags:
-                t =  norm(e.text.split(None, 1)[0])
-                self.assertIn(t, text)
+    #def test_text_content(self):
+    #    def norm(t):
+    #        return re.sub(r'\s+', ' ', t).strip()
+    #    #
+    #    text = norm('\n'.join( p.text for p in self.pdfxml.xpath('.//Page/text') ))
+    #    for e in self.root.xpath('./middle//*'):
+    #        if e.text and e.text.strip() and e.tag not in xml2rfc.util.unicode.unicode_content_tags:
+    #            t =  norm(e.text.split(None, 1)[0])
+    #            self.assertIn(t, text)
 
     def test_included_fonts(self):
-        if xml2rfc.HAVE_WEASYPRINT and xml2rfc.HAVE_PYCAIRO and xml2rfc.HAVE_CAIRO and xml2rfc.HAVE_PANGO:
+        if xml2rfc.HAVE_WEASYPRINT:
             font_families = set([ f.text for f in self.pdfxml.xpath('.//FontFamily') ])
             for script in self.root.get('scripts').split(','):
                 family = xml2rfc.util.fonts.get_noto_serif_family_for_script(script)

--- a/xml2rfc/__init__.py
+++ b/xml2rfc/__init__.py
@@ -34,32 +34,10 @@ try:
 except (ImportError, OSError, ValueError):
     weasyprint = False
     HAVE_WEASYPRINT = False
-try:
-    import cairo
-    HAVE_PYCAIRO = True
-except (ImportError, OSError):
-    cairo = False
-    HAVE_PYCAIRO = False
-try:
-    from weasyprint.text import cairo
-    HAVE_CAIRO = True
-    CAIRO_VERSION = cairo.cairo_version()
-except (ImportError, OSError):
-    HAVE_CAIRO = False
-    CAIRO_VERSION = None
-try:
-    from weasyprint.text import pango
-    HAVE_PANGO = True
-    PANGO_VERSION = pango.pango_version
-except (ImportError, OSError, AttributeError):
-    HAVE_PANGO = False
-    PANGO_VERSION = None
-
-
 def get_versions():
     import sys
     versions = []
-    extras = set(['pycairo', 'weasyprint'])
+    extras = set(['weasyprint'])
     try:
         import pkg_resources
         this = pkg_resources.working_set.by_key[NAME]

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -33,12 +33,6 @@ def get_missing_pdf_libs():
     missing = ""
     if not xml2rfc.HAVE_WEASYPRINT:
         missing += "\nCould not import weasyprint"
-    if not xml2rfc.HAVE_PYCAIRO:
-        missing += "\nCould not import pycairo"
-    if not xml2rfc.HAVE_CAIRO:
-        missing += "\nCould not find the cairo lib"
-    if not xml2rfc.HAVE_PANGO:
-        missing += "\nCould not find the pango lib"
     return missing
 
 
@@ -212,7 +206,7 @@ def main():
                            help='outputs formatted HTML to file')
     formatgroup.add_argument('--nroff', action='store_true',
                            help='outputs formatted nroff to file (only v2 input)')
-    if xml2rfc.HAVE_CAIRO and xml2rfc.HAVE_PANGO:
+    if xml2rfc.HAVE_WEASYPRINT:
         formatgroup.add_argument('--pdf', action='store_true',
                                help='outputs formatted PDF to file')
     else:


### PR DESCRIPTION
This patch is from @kitterma, i'm just forwarding it from https://trac.ietf.org/trac/xml2rfc/ticket/696 (it's also at https://bugs.debian.org/1001824)

Weasyprint 53 and later no longer use cairo and pango, so xml2rfc tests for PDF generation capability need updating.  Also, it appears that test_text_ content is obsolete with the new Weasyprint.  The test fails even though PDF generation succeeds.

On debian and debian-derived systems, the suggestions that remain in run.py when weasyprint isn't available are rather over-complicated,but debian can continue to patch in more streamlined suggestions for its distribution.

