### PR TITLE
ci: support python 3.10

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,7 +90,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" PyPDF2 "weasyprint<53"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.7 "pycairo<1.20" PyPDF2 "weasyprint<53"
         
     - name: Generate Valid Tests
       run: |
@@ -151,7 +151,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" PyPDF2 "weasyprint<53"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.7 "pycairo<1.20" PyPDF2 "weasyprint<53"
         
     - name: Generate Valid Tests
       run: |
@@ -198,7 +198,7 @@ jobs:
 #         echo "Installing pip + wheel..."
 #         python -m pip install --upgrade pip wheel
 #         echo "Installing requirements.txt + test dependencies..."
-#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 pycairo PyPDF2 "weasyprint<53"
+#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.7 pycairo PyPDF2 "weasyprint<53"
         
 #     - name: Generate Valid Tests
 #       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         
     steps:
     - name: Checkout repository

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ configargparse>=1.2.3
 google-i18n-address>=2.3.2
 html5lib>=1.0.1
 intervaltree>=2.1.0,!=3.0.0
-jinja2>=2.11,<3.0
+jinja2>=3.0.3
 kitchen>=1.2.6
 lxml>=2.2.8,!=4.3.1
 pycountry>=1.8,!=19.7.15

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     license="BSD-3-Clause",
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,39}-{linux,macos,windows}
+envlist = py{36,37,38,39,310}-{linux,macos,windows}
 
 [gh-actions]
 python =
@@ -12,6 +12,7 @@ python =
 	3.7: py37
 	3.8: py38
 	3.9: py39
+	3.10: py310
 	
 [gh-actions:env]
 PLATFORM =

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ whitelist_externals =
 deps =
 	-rrequirements.txt
         decorator
-        dict2xml==1.6
+        dict2xml==1.7
         pycairo<1.20
         pypdf2
         weasyprint<53


### PR DESCRIPTION
This indicates that xml2rfc should work fine with python 3.10 as well
as the earlier versions.

I haven't tested (nor do i fully understand) the tox.ini and
.github/workflows/checks.yml changes, but hopefully some automated CI
will run against them and report if there are any problems.