### PR TITLE
chore: Revert Jinja2 3.* update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ configargparse>=1.2.3
 google-i18n-address>=2.3.2
 html5lib>=1.0.1
 intervaltree>=2.1.0,!=3.0.0
-jinja2>=3.0.3
+jinja2>=2.11,<3.0
+markupsafe==2.0.1
 kitchen>=1.2.6
 lxml>=2.2.8,!=4.3.1
 pycountry>=1.8,!=19.7.15


### PR DESCRIPTION
Pin Jinja2 dependecy `markupsafe` to 2.0.1