### PR TITLE
chore: Update deprecated tox configuration option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,29 +8,29 @@ envlist = py{36,37,38,39}-{linux,macos,windows}
 
 [gh-actions]
 python =
-	3.6: py36
-	3.7: py37
-	3.8: py38
-	3.9: py39
-	
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+
 [gh-actions:env]
 PLATFORM =
-        ubuntu-latest: linux
-        macos-latest: macos
-        windows-latest: windows
+    ubuntu-latest: linux
+    macos-latest: macos
+    windows-latest: windows
 
 [testenv]
 commands = 
-	python --version
-        make {posargs}
+    python --version
+    make {posargs}
 
 allowlist_externals =
-	make
+    make
 
 deps =
-	-rrequirements.txt
-        decorator
-        dict2xml==1.6
-        pycairo<1.20
-        pypdf2
-        weasyprint<53
+    -rrequirements.txt
+    decorator
+    dict2xml==1.6
+    pycairo<1.20
+    pypdf2
+    weasyprint<53

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 	python --version
         make {posargs}
 
-whitelist_externals =
+allowlist_externals =
 	make
 
 deps =


### PR DESCRIPTION
* chore: Update deprecated tox configuration option. See https://tox.wiki/en/latest/config.html#conf-allowlist_externals
* chore: Update tox configuration file format