### PR TITLE
test: Update PyPDF2 for PDF tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,7 +90,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" PyPDF2 "weasyprint<53"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" "PyPDF2<1.28.0" "weasyprint<53"
         
     - name: Generate Valid Tests
       run: |
@@ -151,7 +151,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" PyPDF2 "weasyprint<53"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" "PyPDF2<1.28.0" "weasyprint<53"
         
     - name: Generate Valid Tests
       run: |
@@ -198,7 +198,7 @@ jobs:
 #         echo "Installing pip + wheel..."
 #         python -m pip install --upgrade pip wheel
 #         echo "Installing requirements.txt + test dependencies..."
-#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 pycairo PyPDF2 "weasyprint<53"
+#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 pycairo "PyPDF2<1.28.0" "weasyprint<53"
         
 #     - name: Generate Valid Tests
 #       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ deps =
         decorator
         dict2xml==1.6
         pycairo<1.20
-        pypdf2
+        pypdf2<1.28.0
         weasyprint<53

--- a/xml2rfc/walkpdf.py
+++ b/xml2rfc/walkpdf.py
@@ -22,7 +22,7 @@ def walk(obj, seen):
             dobj[k] = d
             iobj += i
         if hasattr(obj, 'extractText'):
-            dobj['text'] = obj.extractText()
+            dobj['text'] = obj.extractText(TJ_sep='')
     elif isinstance(obj, pypdf2.generic.ArrayObject):
         dobj = []
         for o in obj:


### PR DESCRIPTION
PyPDF2 [1.27.0](https://github.com/py-pdf/PyPDF2/releases/tag/1.27.0) release has introduced breaking changes for `extractText()` method.