### PR TITLE
test: Pin PyPDF2 to 2.16.* versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,7 +90,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" PyPDF2 "weasyprint<53"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" "PyPDF2<1.27.0" "weasyprint<53"
         
     - name: Generate Valid Tests
       run: |
@@ -151,7 +151,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" PyPDF2 "weasyprint<53"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 "pycairo<1.20" "PyPDF2<1.27.0" "weasyprint<53"
         
     - name: Generate Valid Tests
       run: |
@@ -198,7 +198,7 @@ jobs:
 #         echo "Installing pip + wheel..."
 #         python -m pip install --upgrade pip wheel
 #         echo "Installing requirements.txt + test dependencies..."
-#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 pycairo PyPDF2 "weasyprint<53"
+#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml==1.6 pycairo "PyPDF2<1.27.0" "weasyprint<53"
         
 #     - name: Generate Valid Tests
 #       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ deps =
     decorator
     dict2xml==1.6
     pycairo<1.20
-    pypdf2
+    pypdf2<1.27.0
     weasyprint<53


### PR DESCRIPTION
PyPDF2 2.17.* versions have introduced breaking changes for PDF tests.