### PR TITLE
fix: Display ASCII names for authors in references 

### DIFF
--- a/tests/input/elements.xml
+++ b/tests/input/elements.xml
@@ -1332,6 +1332,20 @@ for opt, value in opts:
                   </front>
                </reference>
 
+               <reference anchor="AUTHORS">
+                 <front>
+                   <title>Lots of authors</title>
+                   <author fullname="&#928;&#965;&#952;&#945;&#947;&#972;&#961;&#945;&#962; &#8001; &#931;&#940;&#956;&#953;&#959;&#962;" asciiFullname="Pythagoras of Samos"><organization/></author>
+                   <author fullname="John Doe"><organization/></author>
+                   <author fullname="Armin Bergström"><organization>Example Org.</organization></author>
+                   <author fullname="Jane Doe"><organization/></author>
+                   <date year="2015" month="may"/>
+                   <abstract><t>This is a fun document.</t></abstract>
+                 </front>
+                 <seriesInfo name='RFC' value='7539'/>
+                 <seriesInfo name='DOI' value='10.17487/RFC7539'/>
+               </reference>
+
             </references>
 
          </references>

--- a/tests/valid/draft-v3-features.text
+++ b/tests/valid/draft-v3-features.text
@@ -1392,13 +1392,14 @@ Table of Contents
 
               <https://www.rfc-editor.org/info/std78>
 
-   [STPETER]  ᏚᎢᎵᎬᎢᎬᏒ Inc., "ᏚᎢᎵᎬᎢᎬᏒ's document".  A document where the
-              author element specifies just an organization, and both
-              title and organization name have an ASCII equivalent.
+   [STPETER]  ᏚᎢᎵᎬᎢᎬᏒ Inc. (STPETER Inc.), "ᏚᎢᎵᎬᎢᎬᏒ's document".  A
+              document where the author element specifies just an
+              organization, and both title and organization name have an
+              ASCII equivalent.
 
-   [SVG11]    Ferraiolo, J., 藤沢, 淳, and D. Jackson, "Scalable Vector
-              Graphics (SVG) 1.1 Specification", W3C Recommendation REC-
-              SVG11-20030114, January 14, 2003,
+   [SVG11]    Ferraiolo, J., 藤沢, 淳 (Fujisawa, J.), and D. Jackson,
+              "Scalable Vector Graphics (SVG) 1.1 Specification", W3C
+              Recommendation REC-SVG11-20030114, January 14, 2003,
               <http://www.w3.org/TR/2003/REC-SVG11-20030114/>.  Latest
               version available at http://www.w3.org/TR/SVG11/.
 

--- a/tests/valid/elements.bom.text
+++ b/tests/valid/elements.bom.text
@@ -1391,8 +1391,8 @@ MIME-SPEC References
 
 Other References
 
-   [DATE-RANGE]
-              Moe, J., "Document with date range", 2002-2003.
+
+
 
 
 
@@ -1402,6 +1402,14 @@ Author, et al.           Expires 13 January 2019               [Page 25]
 Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
+   [AUTHORS]  Πυθαγόρας ὁ Σάμιος (Samos, P. O.), Doe, J., Bergström, A.,
+              and J. Doe, "Lots of authors", RFC 7539,
+              DOI 10.17487/RFC7539, May 2015,
+              <https://www.rfc-editor.org/rfc/rfc7539>.
+
+   [DATE-RANGE]
+              Moe, J., "Document with date range", 2002-2003.
+
    [FUZZY-DATE]
               Mae, J., "Document with fuzzy date", Second quarter 2010.
 
@@ -1410,7 +1418,7 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    [NO-DATE]  Mae, N., "Document — with no date", Advances in Cryptology
               - AACC Edition pp. 235-265.
 
-   [REPUBLIC] Πλάτων, "Πολιτεία", 375 BC.
+   [REPUBLIC] Πλάτων (Plato), "Πολιτεία", 375 BC.
 
    [RFC0952]  Harrenstien, K., Stahl, M., and E. Feinler, "DoD Internet
               host table specification", RFC 952, DOI 10.17487/RFC0952,
@@ -1441,6 +1449,15 @@ A.1.  Contributors
 
    Additional contact information:
 
+
+
+
+
+Author, et al.           Expires 13 January 2019               [Page 26]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       רוני אבן
       וואווי
       דוד המלך 14
@@ -1450,13 +1467,6 @@ A.1.  Contributors
 
    Reviews and helpful comments have also been received from ანა
    კიკაბიძე (Ana Kikabidze).
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 26]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
 A.2.  Arbitrary^superscript in section _title_
 
@@ -1497,21 +1507,19 @@ Authors' Addresses
 
    Additional contact information:
 
+
+
+Author, et al.           Expires 13 January 2019               [Page 27]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       田中花子 様
       日本
       〒112-0001
       東京都
       文京区 白山4丁目3番2号
       3階B号室
-
-
-
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 27]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
    No Org
@@ -1536,14 +1544,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    Sevedstorp 125
    Mariannelund
    Sweden
-
-
-
-
-
-
-
-
 
 
 

--- a/tests/valid/elements.pages.text
+++ b/tests/valid/elements.pages.text
@@ -1391,8 +1391,8 @@ MIME-SPEC References
 
 Other References
 
-   [DATE-RANGE]
-              Moe, J., "Document with date range", 2002-2003.
+
+
 
 
 
@@ -1402,6 +1402,14 @@ Author, et al.          Expires January 13, 2019               [Page 25]
 Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
+   [AUTHORS]  Πυθαγόρας ὁ Σάμιος (Samos, P. O.), Doe, J., Bergström, A.,
+              and J. Doe, "Lots of authors", RFC 7539,
+              DOI 10.17487/RFC7539, May 2015,
+              <https://www.rfc-editor.org/rfc/rfc7539>.
+
+   [DATE-RANGE]
+              Moe, J., "Document with date range", 2002-2003.
+
    [FUZZY-DATE]
               Mae, J., "Document with fuzzy date", Second quarter 2010.
 
@@ -1410,7 +1418,7 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    [NO-DATE]  Mae, N., "Document — with no date", Advances in Cryptology
               - AACC Edition pp. 235-265.
 
-   [REPUBLIC] Πλάτων, "Πολιτεία", 375 BC.
+   [REPUBLIC] Πλάτων (Plato), "Πολιτεία", 375 BC.
 
    [RFC0952]  Harrenstien, K., Stahl, M., and E. Feinler, "DoD Internet
               host table specification", RFC 952, DOI 10.17487/RFC0952,
@@ -1441,6 +1449,15 @@ A.1.  Contributors
 
    Additional contact information:
 
+
+
+
+
+Author, et al.          Expires January 13, 2019               [Page 26]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       רוני אבן
       וואווי
       דוד המלך 14
@@ -1450,13 +1467,6 @@ A.1.  Contributors
 
    Reviews and helpful comments have also been received from ანა
    კიკაბიძე (Ana Kikabidze).
-
-
-
-Author, et al.          Expires January 13, 2019               [Page 26]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
 A.2.  Arbitrary^superscript in section _title_
 
@@ -1497,21 +1507,19 @@ Authors' Addresses
 
    Additional contact information:
 
+
+
+Author, et al.          Expires January 13, 2019               [Page 27]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       田中花子 様
       日本
       〒112-0001
       東京都
       文京区 白山4丁目3番2号
       3階B号室
-
-
-
-
-
-
-Author, et al.          Expires January 13, 2019               [Page 27]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
    No Org
@@ -1536,14 +1544,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    Sevedstorp 125
    Mariannelund
    Sweden
-
-
-
-
-
-
-
-
 
 
 

--- a/tests/valid/elements.prepped.xml
+++ b/tests/valid/elements.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" docName="elements-00" indexInclude="false" ipr="trust200902" obsoletes="1234,5678,9012,3456,7890" prepTime="2022-04-12T02:25:45" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" docName="elements-00" indexInclude="false" ipr="trust200902" obsoletes="1234,5678,9012,3456,7890" prepTime="2022-05-09T06:41:10" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
   
    
    
@@ -1704,6 +1704,29 @@ for opt, value in opts:
         </references>
         <references pn="section-18.2.4">
           <name slugifiedName="name-other-references">Other References</name>
+          <reference anchor="AUTHORS" quoteTitle="true" target="https://www.rfc-editor.org/rfc/rfc7539" derivedAnchor="AUTHORS">
+            <front>
+              <title>Lots of authors</title>
+              <author fullname="Πυθαγόρας ὁ Σάμιος" asciiFullname="Pythagoras of Samos">
+                <organization showOnFrontPage="true"/>
+              </author>
+              <author fullname="John Doe">
+                <organization showOnFrontPage="true"/>
+              </author>
+              <author fullname="Armin Bergström">
+                <organization showOnFrontPage="true">Example Org.</organization>
+              </author>
+              <author fullname="Jane Doe">
+                <organization showOnFrontPage="true"/>
+              </author>
+              <date year="2015" month="may"/>
+              <abstract>
+                <t indent="0">This is a fun document.</t>
+              </abstract>
+            </front>
+            <seriesInfo name="RFC" value="7539"/>
+            <seriesInfo name="DOI" value="10.17487/RFC7539"/>
+          </reference>
           <reference anchor="DATE-RANGE" quoteTitle="true" derivedAnchor="DATE-RANGE">
             <front>
               <title>Document with date range</title>

--- a/tests/valid/elements.text
+++ b/tests/valid/elements.text
@@ -1141,6 +1141,11 @@ MIME-SPEC References
 
 Other References
 
+   [AUTHORS]  Πυθαγόρας ὁ Σάμιος (Samos, P. O.), Doe, J., Bergström, A.,
+              and J. Doe, "Lots of authors", RFC 7539,
+              DOI 10.17487/RFC7539, May 2015,
+              <https://www.rfc-editor.org/rfc/rfc7539>.
+
    [DATE-RANGE]
               Moe, J., "Document with date range", 2002-2003.
 
@@ -1152,7 +1157,7 @@ Other References
    [NO-DATE]  Mae, N., "Document — with no date", Advances in Cryptology
               - AACC Edition pp. 235-265.
 
-   [REPUBLIC] Πλάτων, "Πολιτεία", 375 BC.
+   [REPUBLIC] Πλάτων (Plato), "Πολιτεία", 375 BC.
 
    [RFC0952]  Harrenstien, K., Stahl, M., and E. Feinler, "DoD Internet
               host table specification", RFC 952, DOI 10.17487/RFC0952,

--- a/tests/valid/elements.v3.py36.html
+++ b/tests/valid/elements.v3.py36.html
@@ -15,7 +15,7 @@
 <meta content="
        This is the abstract. 
     " name="description">
-<meta content="xml2rfc 3.12.4" name="generator">
+<meta content="xml2rfc 3.12.5" name="generator">
 <meta content="elements-00" name="ietf.draft">
 <link href="tests/input/elements.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -1733,6 +1733,10 @@ for opt, value in opts:
 <a href="#name-other-references" class="section-name selfRef">Other References</a>
           </h4>
 <dl class="references">
+<dt id="AUTHORS">[AUTHORS]</dt>
+          <dd>
+<span class="refAuthor"><span class="non-ascii">Πυθαγόρας ὁ Σάμιος</span> (<span class="ascii">Samos, P. O.</span>)</span>, <span class="refAuthor">Doe, J.</span>, <span class="refAuthor">Bergström, A.</span>, and <span class="refAuthor">J. Doe</span>, <span class="refTitle">"Lots of authors"</span>, <span class="seriesInfo">RFC 7539</span>, <span class="seriesInfo">DOI 10.17487/RFC7539</span>, <time datetime="2015-05" class="refDate">May 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc7539">https://www.rfc-editor.org/rfc/rfc7539</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="DATE-RANGE">[DATE-RANGE]</dt>
           <dd>
 <span class="refAuthor">Moe, J.</span>, <span class="refTitle">"Document with date range"</span>, <span>2002-2003</span>. </dd>

--- a/tests/valid/elements.v3.py37.html
+++ b/tests/valid/elements.v3.py37.html
@@ -15,7 +15,7 @@
 <meta content="
        This is the abstract. 
     " name="description">
-<meta content="xml2rfc 3.12.4" name="generator">
+<meta content="xml2rfc 3.12.5" name="generator">
 <meta content="elements-00" name="ietf.draft">
 <link href="tests/input/elements.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -1733,6 +1733,10 @@ for opt, value in opts:
 <a href="#name-other-references" class="section-name selfRef">Other References</a>
           </h4>
 <dl class="references">
+<dt id="AUTHORS">[AUTHORS]</dt>
+          <dd>
+<span class="refAuthor"><span class="non-ascii">Πυθαγόρας ὁ Σάμιος</span> (<span class="ascii">Samos, P. O.</span>)</span>, <span class="refAuthor">Doe, J.</span>, <span class="refAuthor">Bergström, A.</span>, and <span class="refAuthor">J. Doe</span>, <span class="refTitle">"Lots of authors"</span>, <span class="seriesInfo">RFC 7539</span>, <span class="seriesInfo">DOI 10.17487/RFC7539</span>, <time datetime="2015-05" class="refDate">May 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc7539">https://www.rfc-editor.org/rfc/rfc7539</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="DATE-RANGE">[DATE-RANGE]</dt>
           <dd>
 <span class="refAuthor">Moe, J.</span>, <span class="refTitle">"Document with date range"</span>, <span>2002-2003</span>. </dd>

--- a/tests/valid/elements.v3.py38.html
+++ b/tests/valid/elements.v3.py38.html
@@ -15,7 +15,7 @@
 <meta content="
        This is the abstract. 
     " name="description">
-<meta content="xml2rfc 3.12.4" name="generator">
+<meta content="xml2rfc 3.12.5" name="generator">
 <meta content="elements-00" name="ietf.draft">
 <link href="tests/input/elements.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -1733,6 +1733,10 @@ for opt, value in opts:
 <a href="#name-other-references" class="section-name selfRef">Other References</a>
           </h4>
 <dl class="references">
+<dt id="AUTHORS">[AUTHORS]</dt>
+          <dd>
+<span class="refAuthor"><span class="non-ascii">Πυθαγόρας ὁ Σάμιος</span> (<span class="ascii">Samos, P. O.</span>)</span>, <span class="refAuthor">Doe, J.</span>, <span class="refAuthor">Bergström, A.</span>, and <span class="refAuthor">J. Doe</span>, <span class="refTitle">"Lots of authors"</span>, <span class="seriesInfo">RFC 7539</span>, <span class="seriesInfo">DOI 10.17487/RFC7539</span>, <time datetime="2015-05" class="refDate">May 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/rfc/rfc7539">https://www.rfc-editor.org/rfc/rfc7539</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="DATE-RANGE">[DATE-RANGE]</dt>
           <dd>
 <span class="refAuthor">Moe, J.</span>, <span class="refTitle">"Document with date range"</span>, <span>2002-2003</span>. </dd>

--- a/tests/valid/elements.wip.text
+++ b/tests/valid/elements.wip.text
@@ -1391,8 +1391,8 @@ MIME-SPEC References
 
 Other References
 
-   [DATE-RANGE]
-              Moe, J., "Document with date range", 2002-2003.
+
+
 
 
 
@@ -1402,6 +1402,14 @@ Author, et al.           Expires 13 January 2019               [Page 25]
 Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
+   [AUTHORS]  Πυθαγόρας ὁ Σάμιος (Samos, P. O.), Doe, J., Bergström, A.,
+              and J. Doe, "Lots of authors", RFC 7539,
+              DOI 10.17487/RFC7539, May 2015,
+              <https://www.rfc-editor.org/rfc/rfc7539>.
+
+   [DATE-RANGE]
+              Moe, J., "Document with date range", 2002-2003.
+
    [FUZZY-DATE]
               Mae, J., "Document with fuzzy date", Second quarter 2010.
 
@@ -1410,7 +1418,7 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    [NO-DATE]  Mae, N., "Document — with no date", Advances in Cryptology
               - AACC Edition pp. 235-265.
 
-   [REPUBLIC] Πλάτων, "Πολιτεία", 375 BC.
+   [REPUBLIC] Πλάτων (Plato), "Πολιτεία", 375 BC.
 
    [RFC0952]  Harrenstien, K., Stahl, M., and E. Feinler, "DoD Internet
               host table specification", RFC 952, DOI 10.17487/RFC0952,
@@ -1441,6 +1449,15 @@ A.1.  Contributors
 
    Additional contact information:
 
+
+
+
+
+Author, et al.           Expires 13 January 2019               [Page 26]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       רוני אבן
       וואווי
       דוד המלך 14
@@ -1450,13 +1467,6 @@ A.1.  Contributors
 
    Reviews and helpful comments have also been received from ანა
    კიკაბიძე (Ana Kikabidze).
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 26]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
 A.2.  Arbitrary^superscript in section _title_
 
@@ -1497,21 +1507,19 @@ Authors' Addresses
 
    Additional contact information:
 
+
+
+Author, et al.           Expires 13 January 2019               [Page 27]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       田中花子 様
       日本
       〒112-0001
       東京都
       文京区 白山4丁目3番2号
       3階B号室
-
-
-
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 27]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
    No Org
@@ -1536,14 +1544,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    Sevedstorp 125
    Mariannelund
    Sweden
-
-
-
-
-
-
-
-
 
 
 

--- a/xml2rfc/writers/text.py
+++ b/xml2rfc/writers/text.py
@@ -28,8 +28,9 @@ from xml2rfc.writers.base import default_options, BaseV3Writer, RfcWriterError
 from xml2rfc import utils
 from xml2rfc.uniscripts import is_script
 from xml2rfc.util.date import extract_date, augment_date, get_expiry_date, format_date
-from xml2rfc.util.name import short_author_name, short_author_ascii_name, short_author_name_parts, short_org_name_set
-
+from xml2rfc.util.name import (short_author_name, short_author_ascii_name,
+                               short_org_name_set, ref_author_name_first,
+                               ref_author_name_last)
 from xml2rfc.util.name import full_author_name_set
 from xml2rfc.util.num import ol_style_formatter, num_width
 from xml2rfc.util.unicode import expand_unicode_element, textwidth
@@ -1126,28 +1127,21 @@ class TextWriter(BaseV3Writer):
         for i, author in enumerate(authors):
             if i == len(authors) - 1 and len(authors) > 1:
                 buf.append('and ')
-            organization = author.find('organization')
-            initials, surname = short_author_name_parts(author)
-            if surname:
-                initials = initials or ''
-                if i == len(authors) - 1 and len(authors) > 1:
-                    # Last author is rendered in reverse
-                    if len(initials) > 0:
-                        buf.append(initials + ' ' + \
-                                     surname)
-                    else:
-                        buf.append(surname)
-                elif len(initials) > 0:
-                    buf.append(surname + ', ' + initials)
-                else:
-                    buf.append(surname)
-                if author.attrib.get('role', '') == 'editor':
-                    buf.append(', Ed.')
-            elif organization is not None and organization.text:
-                # Use organization instead of name
-                buf.append(organization.text.strip(stripspace))
+
+            if i == len(authors) - 1 and len(authors) > 1:
+                # Last author is rendered in reverse
+                name, ascii = ref_author_name_last(author)
             else:
-                continue
+                name, ascii = ref_author_name_first(author)
+
+            if ascii:
+                buf.append('{name} ({ascii})'.format(name=name, ascii=ascii))
+            elif name:
+                buf.append(name)
+
+            if author.attrib.get('role', '') == 'editor':
+                buf.append(', Ed.')
+
             if len(authors) == 2 and i == 0:
                 buf.append(' ')
             elif i < len(authors) - 1:


### PR DESCRIPTION
Display ASCII names for authors in references with non-Latin characters in
their names.

Fixes #768 