### PR TITLE
fix: evaluate date.today() on class init, not import

### DIFF
--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                               May 6, 2022
+Internet-Draft                                              May 10, 2022
 Intended status: Experimental                                           
-Expires: November 7, 2022
+Expires: November 11, 2022
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 7, 2022.
+   This Internet-Draft will expire on November 11, 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires November 7, 2022                [Page 1]
+Person                  Expires November 11, 2022               [Page 1]
 
 Internet-Draft             xml2rfc index tests                  May 2022
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires November 7, 2022                [Page 2]
+Person                  Expires November 11, 2022               [Page 2]
 
 Internet-Draft             xml2rfc index tests                  May 2022
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires November 7, 2022                [Page 3]
+Person                  Expires November 11, 2022               [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2022-05-06T00:20:27" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2022-05-10T16:21:25" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.12.5 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="06" month="05" year="2022"/>
+    <date day="10" month="05" year="2022"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 7 November 2022.
+        This Internet-Draft will expire on 11 November 2022.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                               May 6, 2022
+Internet-Draft                                              May 10, 2022
 Intended status: Experimental                                           
-Expires: November 7, 2022
+Expires: November 11, 2022
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 7, 2022.
+   This Internet-Draft will expire on November 11, 2022.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.py37.html
+++ b/tests/valid/indexes.v3.py37.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires November 7, 2022</td>
+<td class="center">Expires November 11, 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-05-06" class="published">May 6, 2022</time>
+<time datetime="2022-05-10" class="published">May 10, 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-11-07">November 7, 2022</time></dd>
+<dd class="expires"><time datetime="2022-11-11">November 11, 2022</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on November 7, 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on November 11, 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                              6 May 2022
+                                                             10 May 2022
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc6787.exp.xml
+++ b/tests/valid/rfc6787.exp.xml
@@ -11141,7 +11141,7 @@ identification-tag =    token
     <references title="Normative References">
       <!--RTP-->
 
-      <reference anchor="RFC3550" target="https://www.rfc-editor.org/info/rfc3550" xml:base="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3550.xml" quote-title="true">
+      <reference anchor="RFC3550" target="https://www.rfc-editor.org/info/rfc3550" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3550.xml" quote-title="true">
 <front>
 <title>RTP: A Transport Protocol for Real-Time Applications</title>
 <author initials="H." surname="Schulzrinne" fullname="H. Schulzrinne"><organization/></author>
@@ -11338,7 +11338,7 @@ identification-tag =    token
 
       <!--Internet Message Format-->
 
-      <reference anchor="RFC5322" target="https://www.rfc-editor.org/info/rfc5322" xml:base="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5322.xml" quote-title="true">
+      <reference anchor="RFC5322" target="https://www.rfc-editor.org/info/rfc5322" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5322.xml" quote-title="true">
 <front>
 <title>Internet Message Format</title>
 <author initials="P." surname="Resnick" fullname="P. Resnick" role="editor"><organization/></author>
@@ -11420,7 +11420,7 @@ identification-tag =    token
 
       <!--Domain names - implementation and specification-->
 
-      <reference anchor="RFC1035" target="https://www.rfc-editor.org/info/rfc1035" xml:base="https://www.rfc-editor.org/refs/bibxml/reference.RFC.1035.xml" quote-title="true">
+      <reference anchor="RFC1035" target="https://www.rfc-editor.org/info/rfc1035" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.1035.xml" quote-title="true">
 <front>
 <title>Domain names - implementation and specification</title>
 <author initials="P.V." surname="Mockapetris" fullname="P.V. Mockapetris"><organization/></author>

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                               May 6, 2022
+Internet-Draft                                              May 10, 2022
 Intended status: Experimental                                           
-Expires: November 7, 2022
+Expires: November 11, 2022
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 7, 2022.
+   This Internet-Draft will expire on November 11, 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires November 7, 2022                [Page 1]
+Person                  Expires November 11, 2022               [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests                May 2022
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests                May 2022
 
 
 
-Person                  Expires November 7, 2022                [Page 2]
+Person                  Expires November 11, 2022               [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests                May 2022
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests                May 2022
 
 
 
-Person                  Expires November 7, 2022                [Page 3]
+Person                  Expires November 11, 2022               [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests                May 2022
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires November 7, 2022                [Page 4]
+Person                  Expires November 11, 2022               [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="sourcecode-00" indexInclude="true" ipr="trust200902" prepTime="2022-05-06T00:21:36" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="sourcecode-00" indexInclude="true" ipr="trust200902" prepTime="2022-05-10T16:24:15" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.12.5 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="06" month="05" year="2022"/>
+    <date day="10" month="05" year="2022"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 7 November 2022.
+        This Internet-Draft will expire on 11 November 2022.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                               May 6, 2022
+Internet-Draft                                              May 10, 2022
 Intended status: Experimental                                           
-Expires: November 7, 2022
+Expires: November 11, 2022
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 7, 2022.
+   This Internet-Draft will expire on November 11, 2022.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.py37.html
+++ b/tests/valid/sourcecode.v3.py37.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires November 7, 2022</td>
+<td class="center">Expires November 11, 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-05-06" class="published">May 6, 2022</time>
+<time datetime="2022-05-10" class="published">May 10, 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-11-07">November 7, 2022</time></dd>
+<dd class="expires"><time datetime="2022-11-11">November 11, 2022</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on November 7, 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on November 11, 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -265,7 +265,7 @@ def main():
     value_options.add_argument(      '--config-file', dest="config_file", metavar='FILE', is_config_file_arg=True,
                             help='specify a configuration file')
     value_options.add_argument('-d', '--dtd', dest='dtd', metavar='DTDFILE', help='specify an alternate dtd file')
-    value_options.add_argument('-D', '--date', dest='datestring', metavar='DATE', default=datetime.date.today(),
+    value_options.add_argument('-D', '--date', dest='datestring', metavar='DATE', default=None,
                             help="run as if the date is DATE (format: yyyy-mm-dd).  Default: Today's date")
     value_options.add_argument('-f', '--filename', dest='filename', metavar='FILE',
                             help='Deprecated.  The same as -o')
@@ -498,14 +498,12 @@ def main():
                 print('Cache directory is not writable: %s' % options.cache)
                 sys.exit(1)
     #
-    if options.datestring:
-        if isinstance(options.datestring, str):
-            options.date = datetime.datetime.strptime(options.datestring, "%Y-%m-%d").date()
-        elif isinstance(options.datestring, datetime.date):
-            options.date = options.datestring
-        else:
-            xml2rfc.log.warn("Unexpected type for options.datestring: %s" % type(options.datestring))
+    if options.datestring is not None:
+        options.date = datetime.datetime.strptime(options.datestring, "%Y-%m-%d").date()
     else:
+        # Use today by default. Even though date = None is later translated to today(), set it
+        # explicitly to ensure there's no date skew between instance inits if we happen to be run
+        # exactly at midnight.
         options.date = datetime.date.today()
 
     if options.omit_headers and not options.text:

--- a/xml2rfc/writers/base.py
+++ b/xml2rfc/writers/base.py
@@ -55,7 +55,7 @@ default_options.__dict__ = {
         'css': None,
         'config_file': None,
         'country_help': False,
-        'date': datetime.date.today(),
+        'date': None,
         'datestring': None,
         'debug': False,
         'docfile': False,
@@ -442,11 +442,11 @@ class BaseRfcWriter:
 
     # -------------------------------------------------------------------------
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None):
         if not quiet is None:
             options.quiet = quiet
         self.options = options
-        self.date = date
+        self.date = date if date is not None else datetime.date.today()
         self.expire_string = ''
         self.ascii = False
         self.nbws_cond = u'\u00A0'
@@ -1717,13 +1717,13 @@ xref_tags   = get_xref_tags()
 
 class BaseV3Writer(object):
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None):
         global v3_rnc_file, v3_rng_file, v3_schema
         self.xmlrfc = xmlrfc
         self.tree = xmlrfc.tree if xmlrfc else None
         self.root = self.tree.getroot() if xmlrfc else None
         self.options = options
-        self.date = date
+        self.date = date if date is not None else datetime.date.today()
         self.v3_rnc_file = v3_rnc_file
         self.v3_rng_file = v3_rng_file
         self.v3_rng = lxml.etree.RelaxNG(file=self.v3_rng_file)

--- a/xml2rfc/writers/doc.py
+++ b/xml2rfc/writers/doc.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals, print_function, division
 
 import collections
-import datetime
 import io
 import jinja2
 import lxml
@@ -25,7 +24,7 @@ def capfirst(value):
     return value and value[0].upper() + value[1:]
 
 class DocWriter(base.BaseV3Writer):
-    def __init__(self, xmlrfc, quiet=None, options=base.default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, quiet=None, options=base.default_options, date=None):
         super(DocWriter, self).__init__(xmlrfc, quiet=quiet, options=options, date=date)
         rfc7991_rng_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'rfc7991.rng')
         self.rfc7991_schema = lxml.etree.ElementTree(file=rfc7991_rng_file)

--- a/xml2rfc/writers/expanded_xml.py
+++ b/xml2rfc/writers/expanded_xml.py
@@ -4,7 +4,6 @@
 
 import lxml.etree
 import xml2rfc
-import datetime
 from io import open
 from xml2rfc.writers.base import default_options
 
@@ -14,7 +13,7 @@ class ExpandedXmlWriter:
     # Note -- we don't need to subclass BaseRfcWriter because the behavior
     # is so different and so trivial
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None):
         if not quiet is None:
             options.quiet = quiet
         self.root = xmlrfc.getroot()

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, print_function, division
 
-import datetime
 import lxml
 import os
 import re
@@ -232,7 +231,7 @@ def get_bidi_alignment(address):
 
 class HtmlWriter(BaseV3Writer):
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None):
         super(HtmlWriter, self).__init__(xmlrfc, quiet=quiet, options=options, date=date)
         self.anchor_tags = self.get_tags_with_anchor()
         self.duplicate_html_ids = set()

--- a/xml2rfc/writers/legacy_html.py
+++ b/xml2rfc/writers/legacy_html.py
@@ -42,7 +42,7 @@ class HtmlRfcWriter(BaseRfcWriter):
     }
 
     def __init__(self, xmlrfc, quiet=None, options=default_options,
-                               date=datetime.date.today(), templates_dir=None):
+                               date=None, templates_dir=None):
         if not quiet is None:
             options.quiet = quiet
         BaseRfcWriter.__init__(self, xmlrfc, options=options)

--- a/xml2rfc/writers/nroff.py
+++ b/xml2rfc/writers/nroff.py
@@ -50,7 +50,7 @@ class NroffRfcWriter(PaginatedTextRfcWriter):
 
     in_list = False
 
-    def __init__(self, xmlrfc, width=72, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, width=72, quiet=None, options=default_options, date=None):
         if not quiet is None:
             options.quiet = quiet
         PaginatedTextRfcWriter.__init__(self, xmlrfc, width=width, options=options, date=date)

--- a/xml2rfc/writers/paginated_txt.py
+++ b/xml2rfc/writers/paginated_txt.py
@@ -3,7 +3,6 @@
 # --------------------------------------------------
 
 # Python libs
-import datetime
 import calendar
 import six
 
@@ -26,7 +25,7 @@ class PaginatedTextRfcWriter(RawTextRfcWriter):
     """
 
     def __init__(self, xmlrfc, width=72, quiet=None, options=default_options,
-                               date=datetime.date.today(), omit_headers=False):
+                               date=None, omit_headers=False):
         if not quiet is None:
             options.quiet = quiet
         RawTextRfcWriter.__init__(self, xmlrfc, options=options, date=date)

--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, print_function, division
 
-import datetime
 import io
 import logging
 import os
@@ -38,7 +37,7 @@ except ImportError:
 
 class PdfWriter(BaseV3Writer):
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None):
         super(PdfWriter, self).__init__(xmlrfc, quiet=quiet, options=options, date=date)
         if not weasyprint:
             self.err(None, "Cannot run PDF formatter: %s" % import_error)

--- a/xml2rfc/writers/preptool.py
+++ b/xml2rfc/writers/preptool.py
@@ -97,7 +97,7 @@ def slugify_name(name):
 class PrepToolWriter(BaseV3Writer):
     """ Writes an XML file where the input has been modified according to RFC 7998"""
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today(), liberal=None, keep_pis=['v3xml2rfc']):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None, liberal=None, keep_pis=['v3xml2rfc']):
         super(PrepToolWriter, self).__init__(xmlrfc, quiet=quiet, options=options, date=date)
         if not quiet is None:
             options.quiet = quiet

--- a/xml2rfc/writers/raw_txt.py
+++ b/xml2rfc/writers/raw_txt.py
@@ -4,7 +4,6 @@
 
 # Python libs
 import textwrap
-import datetime
 import lxml
 import re
 
@@ -26,7 +25,7 @@ class RawTextRfcWriter(BaseRfcWriter):
         The page width is controlled by the *width* parameter.
     """
 
-    def __init__(self, xmlrfc, width=72, margin=3, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, width=72, margin=3, quiet=None, options=default_options, date=None):
         if not quiet is None:
             options.quiet = quiet
         BaseRfcWriter.__init__(self, xmlrfc, options=options, date=date)

--- a/xml2rfc/writers/text.py
+++ b/xml2rfc/writers/text.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals, print_function, division
 
 import copy
-import datetime
 import inspect
 import re
 import sys
@@ -290,7 +289,7 @@ def format_address(address, latin=False, normalize=False):
 
 class TextWriter(BaseV3Writer):
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None):
         super(TextWriter, self).__init__(xmlrfc, quiet=quiet, options=options, date=date)
         self.options.min_section_start_lines = 5
         self.refname_mapping = self.get_refname_mapping()

--- a/xml2rfc/writers/unprep.py
+++ b/xml2rfc/writers/unprep.py
@@ -24,7 +24,7 @@ from xml2rfc.writers.base import default_options, BaseV3Writer, RfcWriterError
 class UnPrepWriter(BaseV3Writer):
     """ Writes an XML file where many of the preptool additions have been removed"""
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today(), liberal=None, keep_pis=['v3xml2rfc']):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None, liberal=None, keep_pis=['v3xml2rfc']):
         super(UnPrepWriter, self).__init__(xmlrfc, quiet=quiet, options=options, date=date)
         if not quiet is None:
             options.quiet = quiet

--- a/xml2rfc/writers/v2v3.py
+++ b/xml2rfc/writers/v2v3.py
@@ -5,7 +5,6 @@
 import os
 import re
 import lxml.etree
-import datetime
 import traceback as tb
 
 from collections import OrderedDict
@@ -43,7 +42,7 @@ def copyattr(a, b):
 class V2v3XmlWriter(BaseV3Writer):
     """ Writes an XML file with v2 constructs converted to v3"""
 
-    def __init__(self, xmlrfc, quiet=None, options=default_options, date=datetime.date.today()):
+    def __init__(self, xmlrfc, quiet=None, options=default_options, date=None):
         super(V2v3XmlWriter, self).__init__(xmlrfc, quiet=quiet, options=options, date=date)
         if not quiet is None:
             options.quiet = quiet


### PR DESCRIPTION
Replaces calls to `datetime.date.today()` with the value `None` in various class `__init__()` method signatures and in the default options dictionary. At instance init time, translates `None` into the `today()` call. In `run.py`, simplifies the date argument parsing and is more explicit about calling `today()` when the argument is omitted.

Tests are updated to pass on my system (only running against python 3.7)

Fixes #773. Probably related to https://github.com/ietf-tools/datatracker/issues/3944