### PR TITLE
fix: Fix warnings in text and manpage

### DIFF
--- a/xml2rfc/templates/doc.xml
+++ b/xml2rfc/templates/doc.xml
@@ -1,5 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>  <!-- -*- indent-with-tabs: 0 -*- -->
-<!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">
+<!DOCTYPE rfc [
+  <!ENTITY nbsp    "&#160;">
+  <!ENTITY zwsp   "&#8203;">
+  <!ENTITY nbhy   "&#8209;">
+  <!ENTITY wj     "&#8288;">
+]>
 <rfc submissionType='independent' ipr="none " docName="xml2rfc-docs-{{version}}"
            category="info"
            xmlns:xi="http://www.w3.org/2001/XInclude" version="3"

--- a/xml2rfc/writers/text.py
+++ b/xml2rfc/writers/text.py
@@ -371,7 +371,7 @@ class TextWriter(BaseV3Writer):
 
     def add_pageno_placeholders(self):
         toc = self.root.find('./front/toc/section')
-        if toc:
+        if toc is not None:
             for e in toc.xpath('.//xref[2]'):
                 e.set('pageno', '0000')
 


### PR DESCRIPTION
[fix: Fix FutureWarning in xml2rfc/writers/text.py](https://github.com/ietf-tools/xml2rfc/commit/b5076cca1ef55727b1b9e78eb90c829a5daf971d)
[fix: Remove rfc2629-xhtml.ent from doc template](https://github.com/ietf-tools/xml2rfc/commit/3431178305723b1fdbbbc80538d152e1e2976d2c)