### PR TITLE
fix: Display long ASCII art correctly in PDF

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.12.7</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.12.8</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.12.7" name="generator">
-<meta content="xml2rfc-docs-3.12.7" name="ietf.draft">
+<meta content="xml2rfc 3.12.8" name="generator">
+<meta content="xml2rfc-docs-3.12.8" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">May 2022</td>
+<td class="right">June 2022</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -45,7 +45,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.12.7</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.12.8</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -367,7 +367,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://xml2rfc.ietf.org/xml2rfc-doc">https://xml2rfc.ietf.org/xml2rfc-doc</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.12.7.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.12.8.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6342,7 +6342,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.12.7:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.12.8:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              May 23, 2022
+Internet-Draft                                              June 2, 2022
 Intended status: Experimental                                           
-Expires: November 24, 2022
+Expires: December 4, 2022
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 24, 2022.
+   This Internet-Draft will expire on December 4, 2022.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                  Expires November 24, 2022               [Page 1]
+Person                  Expires December 4, 2022                [Page 1]
 
-Internet-Draft             xml2rfc index tests                  May 2022
+Internet-Draft             xml2rfc index tests                 June 2022
 
 
    This is another section!
@@ -109,9 +109,9 @@ Index
 
 
 
-Person                  Expires November 24, 2022               [Page 2]
+Person                  Expires December 4, 2022                [Page 2]
 
-Internet-Draft             xml2rfc index tests                  May 2022
+Internet-Draft             xml2rfc index tests                 June 2022
 
 
       E
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires November 24, 2022               [Page 3]
+Person                  Expires December 4, 2022                [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2022-05-23T04:13:11" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.12.7 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2022-06-02T13:42:36" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.12.8 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="23" month="05" year="2022"/>
+    <date day="02" month="06" year="2022"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 24 November 2022.
+        This Internet-Draft will expire on 4 December 2022.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              May 23, 2022
+Internet-Draft                                              June 2, 2022
 Intended status: Experimental                                           
-Expires: November 24, 2022
+Expires: December 4, 2022
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 24, 2022.
+   This Internet-Draft will expire on December 4, 2022.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.12.7" name="generator">
+<meta content="xml2rfc 3.12.8" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">May 2022</td>
+<td class="right">June 2022</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires November 24, 2022</td>
+<td class="center">Expires December 4, 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-05-23" class="published">May 23, 2022</time>
+<time datetime="2022-06-02" class="published">June 2, 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-11-24">November 24, 2022</time></dd>
+<dd class="expires"><time datetime="2022-12-04">December 4, 2022</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on November 24, 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 4, 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                             23 May 2022
+                                                             2 June 2022
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.12.7
-                          xml2rfc-docs-3.12.7
+                         xml2rfc release 3.12.8
+                          xml2rfc-docs-3.12.8
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://xml2rfc.ietf.org/xml2rfc-doc.
 
-   This documentation applies to xml2rfc version 3.12.7.
+   This documentation applies to xml2rfc version 3.12.8.
 
 2.  Schema Version 3 Elements
 
@@ -4307,7 +4307,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.12.7:
+   Jinja2 template, as of xml2rfc version 3.12.8:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              May 23, 2022
+Internet-Draft                                              June 2, 2022
 Intended status: Experimental                                           
-Expires: November 24, 2022
+Expires: December 4, 2022
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 24, 2022.
+   This Internet-Draft will expire on December 4, 2022.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                  Expires November 24, 2022               [Page 1]
+Person                  Expires December 4, 2022                [Page 1]
 
-Internet-Draft          xml2rfc sourcecode tests                May 2022
+Internet-Draft          xml2rfc sourcecode tests               June 2022
 
 
    print("01")
@@ -109,9 +109,9 @@ Internet-Draft          xml2rfc sourcecode tests                May 2022
 
 
 
-Person                  Expires November 24, 2022               [Page 2]
+Person                  Expires December 4, 2022                [Page 2]
 
-Internet-Draft          xml2rfc sourcecode tests                May 2022
+Internet-Draft          xml2rfc sourcecode tests               June 2022
 
 
    print("49")
@@ -165,9 +165,9 @@ Internet-Draft          xml2rfc sourcecode tests                May 2022
 
 
 
-Person                  Expires November 24, 2022               [Page 3]
+Person                  Expires December 4, 2022                [Page 3]
 
-Internet-Draft          xml2rfc sourcecode tests                May 2022
+Internet-Draft          xml2rfc sourcecode tests               June 2022
 
 
    print("47")
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires November 24, 2022               [Page 4]
+Person                  Expires December 4, 2022                [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="sourcecode-00" indexInclude="true" ipr="trust200902" prepTime="2022-05-23T04:19:29" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.12.7 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="sourcecode-00" indexInclude="true" ipr="trust200902" prepTime="2022-06-02T13:42:45" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.12.8 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="23" month="05" year="2022"/>
+    <date day="02" month="06" year="2022"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 24 November 2022.
+        This Internet-Draft will expire on 4 December 2022.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              May 23, 2022
+Internet-Draft                                              June 2, 2022
 Intended status: Experimental                                           
-Expires: November 24, 2022
+Expires: December 4, 2022
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 24, 2022.
+   This Internet-Draft will expire on December 4, 2022.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.12.7" name="generator">
+<meta content="xml2rfc 3.12.8" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc sourcecode tests</td>
-<td class="right">May 2022</td>
+<td class="right">June 2022</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires November 24, 2022</td>
+<td class="center">Expires December 4, 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-05-23" class="published">May 23, 2022</time>
+<time datetime="2022-06-02" class="published">June 2, 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-11-24">November 24, 2022</time></dd>
+<dd class="expires"><time datetime="2022-12-04">December 4, 2022</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on November 24, 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 4, 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -137,10 +137,6 @@ svg {
 }
 .alignCenter > *:first-child {
   border: none;
-  /* this isn't optimal, but it's an existence proof.  PrinceXML doesn't
-     support flexbox yet.
-  */
-  display: table;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
Fixes #787

This change removes `display: table` property from `alignCenter` class.
This seems to be a hack to make PrinceXML happy, WeasyPrint doesn't play nicely with the table, hence the cut-off issue.
`alignLeft` and `alignRight` classes doesn't have `display: table` property set.