### PR TITLE
feat: Update weasyprint to 55.0 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,11 +71,10 @@ COPY requirements.txt .
 
 # build xml2rfc
 RUN pip3 install -r requirements.txt \
-    "weasyprint==55.0" \
+    "weasyprint>=53.0" \
     decorator \
     dict2xml \
-    typing-extensions \
-    pdfplumber
+    "pypdf2>=2.6.0"
 RUN make install
 
 # cleanup
@@ -84,7 +83,7 @@ RUN rm roboto-mono.zip
 RUN apt-get remove --purge -y software-properties-common wget unzip
 RUN apt-get autoclean
 RUN apt-get clean
-RUN pip3 uninstall -y decorator dict2xml typing-extensions pdfplumber
+RUN pip3 uninstall -y decorator dict2xml pypdf2
 RUN rm setup.py README.md Makefile configtest.py requirements.txt
 RUN rm -r xml2rfc build dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM ubuntu:focal
-# deadsnakes has Python3.6 for focal but not jammy
+FROM ubuntu:latest
 LABEL maintainer="Kesara Rathnayake <kesara@staff.ietf.org>"
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -10,41 +9,43 @@ RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update --fix-missing
 
 # Install dependencies
-RUN apt-get install -y \
-    libcairo2 \
-    libcairo2-dev \
+RUN apt-get install -y --fix-missing \
     libpango-1.0-0 \
-    libpangocairo-1.0-0 \
     libssl-dev \
     fontconfig \
+    libharfbuzz0b \
+    libpangoft2-1.0-0 \
     pkg-config \
     libxml2-utils \
     groff \
     wget \
     unzip \
     locales
-
 # Set locale
 RUN locale-gen en_US.UTF-8
 
 # Install Pythons
-# From the OS - Python 3.8
+# From the OS - Python 3.10
 RUN apt-get install -y \
-    python3 \
-    python3-dev \
-    python3-pip
+    python3.10 \
+    python3.10-dev \
+    python3-pip \
+    python3.10-distutils
 
 # From deadsnakes
 RUN apt-get install -y \
     python3.7 \
     python3.7-dev \
     python3.7-distutils \
+    python3.8 \
+    python3.8-dev \
+    python3.8-distutils \
     python3.9 \
     python3.9-dev \
-    python3.9-distutils \
-    python3.10 \
-    python3.10-dev \
-    python3.10-distutils
+    python3.9-distutils
+
+# Update pip
+RUN pip install --upgrade pip
 
 # Instal tox
 RUN pip3 install tox
@@ -70,11 +71,11 @@ COPY requirements.txt .
 
 # build xml2rfc
 RUN pip3 install -r requirements.txt \
-    "weasyprint==52.5" \
-    "pycairo<1.20" \
+    "weasyprint==55.0" \
     decorator \
-    "dict2xml==1.6" \
-    "pypdf2<1.27.0"
+    dict2xml \
+    typing-extensions \
+    pdfplumber
 RUN make install
 
 # cleanup
@@ -83,7 +84,7 @@ RUN rm roboto-mono.zip
 RUN apt-get remove --purge -y software-properties-common wget unzip
 RUN apt-get autoclean
 RUN apt-get clean
-RUN pip3 uninstall -y decorator dict2xml pypdf2
+RUN pip3 uninstall -y decorator dict2xml typing-extensions pdfplumber
 RUN rm setup.py README.md Makefile configtest.py requirements.txt
 RUN rm -r xml2rfc build dist
 

--- a/configtest.py
+++ b/configtest.py
@@ -5,7 +5,6 @@ import importlib
 import sys
 import warnings
 
-warnings.filterwarnings("ignore", message='There are known rendering problems and missing features with cairo < 1.15.4')
 
 errors = 0
 
@@ -13,7 +12,6 @@ sys.stderr.write("Checking installation of test and development packages:\n")
 for (pname, mname) in [
             ('decorator', 'decorator'),
             ('dict2xml', 'dict2xml'),
-            ('pycairo', 'cairo'),
             ('PyPDF2', 'PyPDF2'),
         ]:
     try:

--- a/test.py
+++ b/test.py
@@ -510,7 +510,7 @@ class PdfWriterTests(unittest.TestCase):
                 self.assertIn(t, text)
 
     def test_included_fonts(self):
-        if xml2rfc.HAVE_WEASYPRINT and xml2rfc.HAVE_PYCAIRO and xml2rfc.HAVE_CAIRO and xml2rfc.HAVE_PANGO:
+        if xml2rfc.HAVE_WEASYPRINT and xml2rfc.HAVE_PANGO:
             font_families = set([ f.text for f in self.pdfxml.xpath('.//FontFamily') ])
             for script in self.root.get('scripts').split(','):
                 family = xml2rfc.util.fonts.get_noto_serif_family_for_script(script)

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,5 @@ deps =
     -rrequirements.txt
     decorator
     dict2xml==1.7
-    pycairo<1.20
     pypdf2<1.27.0
-    weasyprint<53
+    weasyprint==55.0

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,6 @@ allowlist_externals =
 deps =
     -rrequirements.txt
     decorator
-    dict2xml==1.7
-    pypdf2<1.27.0
-    weasyprint==55.0
+    dict2xml
+    pypdf2>=2.6.0
+    weasyprint>=53.0

--- a/xml2rfc/__init__.py
+++ b/xml2rfc/__init__.py
@@ -35,20 +35,7 @@ except (ImportError, OSError, ValueError):
     weasyprint = False
     HAVE_WEASYPRINT = False
 try:
-    import cairo
-    HAVE_PYCAIRO = True
-except (ImportError, OSError):
-    cairo = False
-    HAVE_PYCAIRO = False
-try:
-    from weasyprint.text import cairo
-    HAVE_CAIRO = True
-    CAIRO_VERSION = cairo.cairo_version()
-except (ImportError, OSError):
-    HAVE_CAIRO = False
-    CAIRO_VERSION = None
-try:
-    from weasyprint.text import pango
+    from weasyprint.text.ffi import pango
     HAVE_PANGO = True
     PANGO_VERSION = pango.pango_version
 except (ImportError, OSError, AttributeError):
@@ -59,7 +46,7 @@ except (ImportError, OSError, AttributeError):
 def get_versions():
     import sys
     versions = []
-    extras = set(['pycairo', 'weasyprint'])
+    extras = set(['weasyprint'])
     try:
         import pkg_resources
         this = pkg_resources.working_set.by_key[NAME]

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -87,7 +87,7 @@ def get_pdf_help(missing_libs=""):
 
     2. Next, install weasyprint python modules using pip.
 
-        pip install 'weasyprint==55.0'
+        pip install 'weasyprint>=53.0'
 
 
     3. Finally, install the full Noto Font and Roboto Mono packages:

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -33,10 +33,6 @@ def get_missing_pdf_libs():
     missing = ""
     if not xml2rfc.HAVE_WEASYPRINT:
         missing += "\nCould not import weasyprint"
-    if not xml2rfc.HAVE_PYCAIRO:
-        missing += "\nCould not import pycairo"
-    if not xml2rfc.HAVE_CAIRO:
-        missing += "\nCould not find the cairo lib"
     if not xml2rfc.HAVE_PANGO:
         missing += "\nCould not find the pango lib"
     return missing
@@ -84,29 +80,14 @@ def get_pdf_help(missing_libs=""):
     In order to generate PDFs, xml2rfc uses the WeasyPrint library, which
     depends on external libaries that must be installed as native packages.
 
-    1. First, install the Cairo, Pango, and GDK-PixBuf library files on your
+    1. First, install the Pango, and other required libraries on your
     system.  See installation instructions on the WeasyPrint Docs:
     
-        https://weasyprint.readthedocs.io/en/stable/install.html
+        https://doc.courtbouillon.org/weasyprint/stable/first_steps.html
 
-    (Python 3 is not needed if your system Python is 2.7, though).
+    2. Next, install weasyprint python modules using pip.
 
-
-    2. Next, install the pycairo and weasyprint python modules using pip.
-    Depending on your system, you may need to use 'sudo' or install in
-    user-specific directories, using the --user switch.  On OS X in
-    particular, you may also need to install a newer version of setuptools
-    using --user before weasyprint can be installed.  If you install with 
-    the --user switch, you may need to also set PYTHONPATH, e.g.,
-    
-        PYTHONPATH=/Users/username/Library/Python/2.7/lib/python/site-packages
-
-    for Python 2.7.
-
-    The basic pip commands (modify as needed according to the text above)
-    are:
-
-        pip install 'pycairo>=1.18' 'weasyprint<=0.42.3'
+        pip install 'weasyprint==55.0'
 
 
     3. Finally, install the full Noto Font and Roboto Mono packages:
@@ -212,7 +193,7 @@ def main():
                            help='outputs formatted HTML to file')
     formatgroup.add_argument('--nroff', action='store_true',
                            help='outputs formatted nroff to file (only v2 input)')
-    if xml2rfc.HAVE_CAIRO and xml2rfc.HAVE_PANGO:
+    if xml2rfc.HAVE_PANGO:
         formatgroup.add_argument('--pdf', action='store_true',
                                help='outputs formatted PDF to file')
     else:

--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -8,8 +8,6 @@ import os
 
 import warnings
 
-warnings.filterwarnings("ignore", message='There are known rendering problems with Cairo <= 1.14.0')
-warnings.filterwarnings("ignore", message='There are known rendering problems and missing features with cairo < 1.15.4')
 warnings.filterwarnings("ignore", message='@font-face support needs Pango >= 1.38')
 
 try:
@@ -44,6 +42,8 @@ class PdfWriter(BaseV3Writer):
             return
 
         logging.basicConfig(level=logging.INFO)
+
+        # Weasyprint logger
         wplogger = logging.getLogger('weasyprint')
         if   self.options.quiet:
             wplogger.setLevel(logging.CRITICAL)
@@ -51,6 +51,15 @@ class PdfWriter(BaseV3Writer):
             wplogger.setLevel(logging.WARNING)
         else:
             wplogger.setLevel(logging.ERROR)
+
+        # fontTools logger
+        ftlogger = logging.getLogger('fontTools')
+        if self.options.quiet:
+            ftlogger.setLevel(logging.CRITICAL)
+        elif self.options.verbose:
+            ftlogger.setLevel(logging.WARNING)
+        else:
+            ftlogger.setLevel(logging.ERROR)
 
     def pdf(self):
         if not weasyprint:


### PR DESCRIPTION
* Update weasyprint to 55.0.
* Replace PyPDF2 with pdfplumber.

This changes PDF generation from cairo to pydyf.

Fixes #696