### PR TITLE
Move sourcecode classes

### DIFF
--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -791,7 +791,7 @@ tt, code, pre, code {
 }
 
 /* Fix the height/width aspect for ascii art*/
-pre.sourcecode,
+.sourcecode pre,
 .art-text pre {
   line-height: 1.12;
 }
@@ -1123,7 +1123,7 @@ dd > div.artwork:first-child,
 dd > aside:first-child,
 dd > figure:first-child,
 dd > ol:first-child,
-dd > div:first-child > pre.sourcecode,
+dd > div.sourcecode:first-child,
 dd > table:first-child,
 dd > ul:first-child {
   clear: left;

--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -616,7 +616,7 @@ hr.addr {
   figure {
     overflow: scroll;
   }
-  pre.breakable {
+  .breakable pre {
     break-inside: auto;
   }
   h1, h2, h3, h4, h5, h6 {

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -2456,9 +2456,9 @@ class HtmlWriter(BaseV3Writer):
             classes += ' lang-%s' % type
         if (len(x.text.split('\n')) > 50):
             classes += ' breakable'
-        div = add.div(h, x)
+        div = add.div(h, x, classes=classes)
         div.text = None
-        pre = add.pre(div, None, x.text, classes=classes)
+        pre = add.pre(div, None, x.text)
         if mark:
             text = pre.text
             if file:


### PR DESCRIPTION
The HTML elements created for a `<sourcecode>` element have class
attributes attached to the `<pre>` element.  In comparison, `<artwork>`
is rendered with class attritributes attached to the outer `<div>`.

Having the classes on the outer `<div>` makes it a LOT easier to style
these properly, so I've moved them in this CL.