### PR TITLE
Compact index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,11 @@ tests/out/%.txt tests/out/%.raw.txt tests/out/%.nroff tests/out/%.html tests/out
 	@echo -e "\n Processing $<"
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --base tests/out/ --text --html --strict $<"
 
+tests/out/%.compact_index.text tests/out/%.compact_index.html : tests/input/%.xml install
+	@echo -e "\n Generating with a compact index $<"
+	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --base tests/out/ --$(subst .,,$(suffix $@)) --strict --compact-index --no-pagination $< --out $@"
+
+
 tests/out/%.v2v3.xml: tests/input/%.xml install
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --v2v3 --strict --legacy-date-format $< --out $@"
 	@doc=$(basename $@); printf ' '; xmllint --noout --xinclude --relaxng xml2rfc/data/v3.rng $$doc.xml
@@ -227,12 +232,12 @@ rfcregressiontest: cleantmp install
 drafttest: cleantmp env/bin/python install $(drafttests) dateshifttest
 
 # rfctest: cleantmp env/bin/python install $(rfctests)
-# 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --utf8tests/input/rfc6787.xml --base tmp/ --raw --legacy --text --nroff --html --exp --v2v3 --prep"
-# 	doc=rfc6787 ; postnrofffix="cat" ; type=ascii; $(CHECKOUTPUT)
-# 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --utf8tests/input/rfc7754.edited.xml --base tmp/ --raw --legacy --text --nroff --html --exp --v2v3 --prep"
-# 	doc=rfc7754.edited ; postnrofffix="cat" ; type=ascii; $(CHECKOUTPUT)
-# 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --utf8tests/input/rfc7911.xml --base tmp/ --raw --legacy --text --nroff --html --exp --v2v3 --prep"
-# 	doc=rfc7911 ; postnrofffix="cat" ; type=ascii; $(CHECKOUTPUT)
+#	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --utf8tests/input/rfc6787.xml --base tmp/ --raw --legacy --text --nroff --html --exp --v2v3 --prep"
+#	doc=rfc6787 ; postnrofffix="cat" ; type=ascii; $(CHECKOUTPUT)
+#	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --utf8tests/input/rfc7754.edited.xml --base tmp/ --raw --legacy --text --nroff --html --exp --v2v3 --prep"
+#	doc=rfc7754.edited ; postnrofffix="cat" ; type=ascii; $(CHECKOUTPUT)
+#	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --utf8tests/input/rfc7911.xml --base tmp/ --raw --legacy --text --nroff --html --exp --v2v3 --prep"
+#	doc=rfc7911 ; postnrofffix="cat" ; type=ascii; $(CHECKOUTPUT)
 
 unicodetest: cleantmp  env/bin/python install
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --base tmp/ --raw --legacy --text --nroff --html --no-inline-version --exp --v2v3 --prep tests/input/unicode.xml "
@@ -246,11 +251,11 @@ v3featuretest: tests/out/draft-v3-features.prepped.xml.test tests/out/draft-v3-f
 
 dateshifttest: cleantmp install
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --date 2013-02-01 --legacy --out tmp/draft-miek-test.dateshift.txt --text tests/input/draft-miek-test.xml"
-	@diff -u -I '$(datetime_regex)' -I '$(version_regex)' -I '$(date_regex)' tests/valid/draft-miek-test.dateshift.txt tmp/draft-miek-test.dateshift.txt || { echo "Diff failed for draft-miek-test.dateshift.txt output"; exit 1; } 
+	@diff -u -I '$(datetime_regex)' -I '$(version_regex)' -I '$(date_regex)' tests/valid/draft-miek-test.dateshift.txt tmp/draft-miek-test.dateshift.txt || { echo "Diff failed for draft-miek-test.dateshift.txt output"; exit 1; }
 
 elementstest: install tests/out/elements.prepped.xml.test tests/out/elements.text.test tests/out/elements.pages.text.test tests/out/elements.v3.html.test
 
-indextest: install tests/out/indexes.prepped.xml.test tests/out/indexes.text.test tests/out/indexes.pages.text.test tests/out/indexes.v3.html.test
+indextest: install tests/out/indexes.prepped.xml.test tests/out/indexes.text.test tests/out/indexes.pages.text.test tests/out/indexes.v3.html.test tests/out/indexes.compact_index.text.test
 
 sourcecodetest: install tests/out/sourcecode.prepped.xml.test tests/out/sourcecode.text.test tests/out/sourcecode.pages.text.test tests/out/sourcecode.v3.html.test
 

--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -5709,86 +5709,95 @@ start |= rfc
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.3">
-<div id="option--debug">
-<code>--debug</code>                    </div>
+<div id="option--compact-index">
+<code>--compact-index</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.4">
             <p id="appendix-B.4-1.4.1">
-                          Show debugging output.<a href="#appendix-B.4-1.4.1" class="pilcrow">¶</a></p>
+                          Generate a compact index.<a href="#appendix-B.4-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.5">
-<div id="option--no-network">
-<code>--no-network</code>, <code>-N</code>                    </div>
+<div id="option--debug">
+<code>--debug</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.6">
             <p id="appendix-B.4-1.6.1">
-                          Don't use the network to resolve references.<a href="#appendix-B.4-1.6.1" class="pilcrow">¶</a></p>
+                          Show debugging output.<a href="#appendix-B.4-1.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.7">
-<div id="option--no-org-info">
-<code>--no-org-info</code>, <code>-O</code>                    </div>
+<div id="option--no-network">
+<code>--no-network</code>, <code>-N</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.8">
             <p id="appendix-B.4-1.8.1">
-                          Don't show author orgainzation info on page one (legacy only).<a href="#appendix-B.4-1.8.1" class="pilcrow">¶</a></p>
+                          Don't use the network to resolve references.<a href="#appendix-B.4-1.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.9">
-<div id="option--quiet">
-<code>--quiet</code>, <code>-q</code>                    </div>
+<div id="option--no-org-info">
+<code>--no-org-info</code>, <code>-O</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.10">
             <p id="appendix-B.4-1.10.1">
-                          Don't print anything while working.<a href="#appendix-B.4-1.10.1" class="pilcrow">¶</a></p>
+                          Don't show author orgainzation info on page one (legacy only).<a href="#appendix-B.4-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.11">
-<div id="option--skip-config-files">
-<code>--skip-config-files</code>                    </div>
+<div id="option--quiet">
+<code>--quiet</code>, <code>-q</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.12">
             <p id="appendix-B.4-1.12.1">
-                          Ignore config file settings.<a href="#appendix-B.4-1.12.1" class="pilcrow">¶</a></p>
-<p id="appendix-B.4-1.12.2">
-       Use this to ignore values in config files, even if there are config files in the search path.  Somewhat ironically, this option can itself be set in a config file, and cause all other config file settings to be ignored.<a href="#appendix-B.4-1.12.2" class="pilcrow">¶</a></p>
+                          Don't print anything while working.<a href="#appendix-B.4-1.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.13">
-<div id="option--allow-local-file-access">
-<code>--allow-local-file-access</code>                    </div>
+<div id="option--skip-config-files">
+<code>--skip-config-files</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.14">
             <p id="appendix-B.4-1.14.1">
-                          Allow local file system references.<a href="#appendix-B.4-1.14.1" class="pilcrow">¶</a></p>
+                          Ignore config file settings.<a href="#appendix-B.4-1.14.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-1.14.2">
+       Use this to ignore values in config files, even if there are config files in the search path.  Somewhat ironically, this option can itself be set in a config file, and cause all other config file settings to be ignored.<a href="#appendix-B.4-1.14.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.15">
-<div id="option--remove-pis">
-<code>--remove-pis</code>, <code>-r</code>                    </div>
+<div id="option--allow-local-file-access">
+<code>--allow-local-file-access</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.16">
             <p id="appendix-B.4-1.16.1">
-                          Remove XML processing instructions.<a href="#appendix-B.4-1.16.1" class="pilcrow">¶</a></p>
+                          Allow local file system references.<a href="#appendix-B.4-1.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.17">
-<div id="option--utf8">
-<code>--utf8</code>, <code>-u</code>                    </div>
+<div id="option--remove-pis">
+<code>--remove-pis</code>, <code>-r</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.18">
             <p id="appendix-B.4-1.18.1">
-                          Generate utf8 output.<a href="#appendix-B.4-1.18.1" class="pilcrow">¶</a></p>
+                          Remove XML processing instructions.<a href="#appendix-B.4-1.18.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.4-1.19">
-<div id="option--verbose">
-<code>--verbose</code>, <code>-v</code>                    </div>
+<div id="option--utf8">
+<code>--utf8</code>, <code>-u</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.4-1.20">
             <p id="appendix-B.4-1.20.1">
-                          Print extra information.<a href="#appendix-B.4-1.20.1" class="pilcrow">¶</a></p>
+                          Generate utf8 output.<a href="#appendix-B.4-1.20.1" class="pilcrow">¶</a></p>
+</dd>
+          <dd class="break"></dd>
+<dt id="appendix-B.4-1.21">
+<div id="option--verbose">
+<code>--verbose</code>, <code>-v</code>                    </div>
+          </dt>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.22">
+            <p id="appendix-B.4-1.22.1">
+                          Print extra information.<a href="#appendix-B.4-1.22.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>

--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.13.1</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.14.0</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.13.1" name="generator">
-<meta content="xml2rfc-docs-3.13.1" name="ietf.draft">
+<meta content="xml2rfc 3.14.0" name="generator">
+<meta content="xml2rfc-docs-3.14.0" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -45,7 +45,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.13.1</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.14.0</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -367,7 +367,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://ietf-tools.github.io/xml2rfc/">https://ietf-tools.github.io/xml2rfc/</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.13.1.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.14.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6351,7 +6351,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.13.1:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.14.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.13.1" name="generator">
+<meta content="xml2rfc 3.14.0" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -26,8 +26,8 @@
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.13.1
-    Python 3.9.13
+  xml2rfc 3.14.0
+    Python 3.10.4
     appdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 2.5.2
@@ -40,7 +40,7 @@
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.28.1
-    setuptools 63.2.0
+    setuptools 63.4.1
     six 1.16.0
     weasyprint 56.1
 -->

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -11,12 +11,12 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.13.1" name="generator">
+<meta content="xml2rfc 3.14.0" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.13.1
-    Python 3.9.13
+  xml2rfc 3.14.0
+    Python 3.10.4
     appdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 2.5.2
@@ -29,7 +29,7 @@
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.28.1
-    setuptools 63.2.0
+    setuptools 63.4.1
     six 1.16.0
     weasyprint 56.1
 -->

--- a/tests/valid/indexes.compact_index.text
+++ b/tests/valid/indexes.compact_index.text
@@ -1,0 +1,139 @@
+
+
+
+
+Network Working Group                                     H. Person, Ed.
+Internet-Draft                                            17 August 2022
+Intended status: Experimental                                           
+Expires: 18 February 2023
+
+
+                          xml2rfc index tests
+                               indexes-00
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 18 February 2023.
+
+Copyright Notice
+
+   Copyright (c) 2022 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+Table of Contents
+
+   1.  First Section
+   2.  References
+   Index
+   Author's Address
+
+1.  First Section
+
+   This is a section!  _Emphatically._ *Loudly.* _(Subscripted.)
+   ^(Superscripted.)  Typewritten.
+
+   This is another section!
+
+   TASK
+
+   dt  dd
+
+   *  unnumbered item
+
+   1.  numbered item
+
+      |  This is an aside.
+
+   |  This is a blockquote.
+
+    +===============+
+    |Table heading  |
+    +===============+
+    |                                       printf("Hello world!\n");|
+    +---------------+
+
+                                 Table 1
+
+2.  References
+
+   [ref0]     Author, R. Q., "Reference".  This is a reference not in a
+              reference group.
+
+   [refgroup0]
+              Author, R. Q., "Reference Group".  This is a reference in
+              a reference group.
+
+Index
+
+   A B D E F L S T
+
+      A
+
+         annotation  Reference [ref0]
+            in reference group  Reference [refgroup0]
+
+      B
+
+         blockquote  §1
+
+      D
+
+         dd  §1
+         dt  §1
+
+      E
+
+         em  §1 ⁋1
+
+      F
+
+         figure  §1 ⁋9.1.2.1.1
+
+      L
+
+         li
+            ol  *_§1 ⁋6 #1_*
+            ul  §1 ⁋5 •1
+
+      S
+
+         section  §1
+         strong  *_§1 ⁋1_*
+         sub  §1 ⁋1
+         sup  §1 ⁋1
+
+      T
+
+         t  §1 ⁋1, §1 ⁋2
+            in an aside tag  §1 ⁋7.1
+         table  §1
+         TASK  §1 ⁋3
+         td  §1 ⁋9.1.2.1.1
+         th  §1
+         tt  §1 ⁋1
+
+Author's Address
+
+   Human Person (editor)
+   line 1
+   line 2
+   line 3

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 9, 2022
+Internet-Draft                                           August 17, 2022
 Intended status: Experimental                                           
-Expires: February 10, 2023
+Expires: February 18, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 10, 2023.
+   This Internet-Draft will expire on February 18, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires February 10, 2023               [Page 1]
+Person                  Expires February 18, 2023               [Page 1]
 
 Internet-Draft             xml2rfc index tests               August 2022
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires February 10, 2023               [Page 2]
+Person                  Expires February 18, 2023               [Page 2]
 
 Internet-Draft             xml2rfc index tests               August 2022
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires February 10, 2023               [Page 3]
+Person                  Expires February 18, 2023               [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2022-08-09T04:14:34" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.13.1 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2022-08-17T01:51:55" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.14.0 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="09" month="08" year="2022"/>
+    <date day="17" month="08" year="2022"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 10 February 2023.
+        This Internet-Draft will expire on 18 February 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 9, 2022
+Internet-Draft                                           August 17, 2022
 Intended status: Experimental                                           
-Expires: February 10, 2023
+Expires: February 18, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 10, 2023.
+   This Internet-Draft will expire on February 18, 2023.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.13.1" name="generator">
+<meta content="xml2rfc 3.14.0" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires February 10, 2023</td>
+<td class="center">Expires February 18, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-08-09" class="published">August 9, 2022</time>
+<time datetime="2022-08-17" class="published">August 17, 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-02-10">February 10, 2023</time></dd>
+<dd class="expires"><time datetime="2023-02-18">February 18, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on February 10, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on February 18, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -4008,6 +4008,9 @@ B.4.  Generic Switch Options
    --clear-cache, -C
       Purge the cache and exit.
 
+   --compact-index
+      Generate a compact index.
+
    --debug
       Show debugging output.
 

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                           9 August 2022
+                                                          17 August 2022
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.13.1
-                          xml2rfc-docs-3.13.1
+                         xml2rfc release 3.14.0
+                          xml2rfc-docs-3.14.0
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://ietf-tools.github.io/xml2rfc/.
 
-   This documentation applies to xml2rfc version 3.13.1.
+   This documentation applies to xml2rfc version 3.14.0.
 
 2.  Schema Version 3 Elements
 
@@ -4310,7 +4310,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.13.1:
+   Jinja2 template, as of xml2rfc version 3.14.0:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -16,11 +16,11 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.13.1" name="generator">
+<meta content="xml2rfc 3.14.0" name="generator">
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.13.1
-    Python 3.9.13
+  xml2rfc 3.14.0
+    Python 3.10.4
     appdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 2.5.2
@@ -33,7 +33,7 @@
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.28.1
-    setuptools 63.2.0
+    setuptools 63.4.1
     six 1.16.0
     weasyprint 56.1
 -->

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 9, 2022
+Internet-Draft                                           August 17, 2022
 Intended status: Experimental                                           
-Expires: February 10, 2023
+Expires: February 18, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 10, 2023.
+   This Internet-Draft will expire on February 18, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires February 10, 2023               [Page 1]
+Person                  Expires February 18, 2023               [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2022
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests             August 2022
 
 
 
-Person                  Expires February 10, 2023               [Page 2]
+Person                  Expires February 18, 2023               [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2022
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests             August 2022
 
 
 
-Person                  Expires February 10, 2023               [Page 3]
+Person                  Expires February 18, 2023               [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2022
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires February 10, 2023               [Page 4]
+Person                  Expires February 18, 2023               [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="sourcecode-00" indexInclude="true" ipr="trust200902" prepTime="2022-08-09T04:14:43" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.13.1 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="sourcecode-00" indexInclude="true" ipr="trust200902" prepTime="2022-08-17T01:52:05" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.14.0 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="09" month="08" year="2022"/>
+    <date day="17" month="08" year="2022"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 10 February 2023.
+        This Internet-Draft will expire on 18 February 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 9, 2022
+Internet-Draft                                           August 17, 2022
 Intended status: Experimental                                           
-Expires: February 10, 2023
+Expires: February 18, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 10, 2023.
+   This Internet-Draft will expire on February 18, 2023.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.13.1" name="generator">
+<meta content="xml2rfc 3.14.0" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires February 10, 2023</td>
+<td class="center">Expires February 18, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-08-09" class="published">August 9, 2022</time>
+<time datetime="2022-08-17" class="published">August 17, 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-02-10">February 10, 2023</time></dd>
+<dd class="expires"><time datetime="2023-02-18">February 18, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on February 10, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on February 18, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -266,6 +266,8 @@ def main():
                            help='with --text and --html: use the legacy output formatters, rather than the v3 ones')
     formatoptions.add_argument('--id-is-work-in-progress', default=True, action='store_true',
                            help='in references, refer to Internet-Drafts as "Work in Progress"')
+    formatoptions.add_argument('--compact-index', action='store_true',
+                           help='Generate a compact index')
 
     textoptions = optionparser.add_argument_group('Text Format Options')
     textoptions.add_argument('--no-headers', dest='omit_headers', action='store_true',

--- a/xml2rfc/writers/base.py
+++ b/xml2rfc/writers/base.py
@@ -53,6 +53,7 @@ default_options.__dict__ = {
         'cache': None,
         'clear_cache': False,
         'css': None,
+        'compact_index': False,
         'config_file': None,
         'country_help': False,
         'date': None,


### PR DESCRIPTION
I've tried to implement #862 here.  It seems to make the index much less bulky, but I don't find that it is less usable.  This uses Unicode symbols in place of words like "Section" or "Paragraph", so it's not a great default option, especially if you care about pure ASCII for text documents.

This is behind a `--compact-index` flag.