### PR TITLE
Mark the xml2rfc directory as safe

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -31,6 +31,7 @@ RUN pip3 install \
     tox \
     decorator \
     dict2xml \
-    "pypdf2>=2.6.0"
+    "pypdf2>=2.6.0" && \
+    git config --global --add safe.directory /root/xml2rfc
 
 ENTRYPOINT bash


### PR DESCRIPTION
Otherwise git won't work in the dev image.

I considered a tweak to .bashrc instead; but this seems fine.