### PR TITLE
fix: Fix odd page break inside rows in PDF output

### DIFF
--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -1031,6 +1031,9 @@ table {
 td {
   border-top: 1px solid #ddd;
 }
+tr {
+  break-inside: avoid;
+}
 tr:nth-child(2n+1) > td {
   background-color: #f8f8f8;
 }


### PR DESCRIPTION
Fixes #878 