### PR TITLE
fix: Include the published date when ipr is none

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -37,6 +37,10 @@
 <dl id="identifiers">
 <dt class="label-workgroup">Workgroup:</dt>
 <dd class="workgroup">xml2rfc(1)</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2022-09-22" class="published">22 September 2022</time>
+    </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -1663,6 +1663,8 @@ class HtmlWriter(BaseV3Writer):
                     if wg.text and wg.text.strip():
                         entry(dl, 'Workgroup', wg.text.strip())
                         found = True
+                # Publication date
+                entry(dl, 'Published', self.render_date(None, x.find('date')))
             else:
                 if self.options.rfc:
                     # Stream


### PR DESCRIPTION
In HTML & PDF outputs, add the published date when `ipr` attribute is not set or set to none.

Fixes #893 