### PR TITLE
Use wcwidth to determine the monospace textual length of a string

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyyaml>=5.3.1
 requests>=2.5.0
 setuptools>=24.2.0
 six>=1.4.1
+wcwidth>=0.2.5

--- a/xml2rfc/util/unicode.py
+++ b/xml2rfc/util/unicode.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     pass
 
+from wcwidth import wcswidth
 
 unicode_content_tags = set([
     'artwork',
@@ -197,7 +198,7 @@ def isascii(u):
 
 def textwidth(u):
     "Length of string, disregarding zero-width code points"
-    return len(re.sub('[\u200B\u200C\u2060\uE060]', '', u))
+    return wcswidth(u)
 
 def downcode_punctuation(str):
     while True:


### PR DESCRIPTION
This is supplementary to https://github.com/ietf-tools/xml2rfc/pull/913, which dropped the dependency on kitchen. Here we add a dependency on wcwidth, which is an maintained library to determine the monospace textual length of a string.