### PR TITLE
fix: Remove redundant code labels from CSS

### DIFF
--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -263,7 +263,7 @@ a.selfRef:hover {
 } */
 
 /* Figures */
-tt, code, pre, code {
+tt, code, pre {
   background-color: #f9f9f9;
   font-family: 'Roboto Mono', monospace;
 }
@@ -835,7 +835,7 @@ section {
 }
 
 /* prevent monospace from becoming overly large */
-tt, code, pre, code {
+tt, code, pre {
   font-size: 95%;
 }
 

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -252,7 +252,7 @@ a.selfRef:hover {
 } */
 
 /* Figures */
-tt, code, pre, code {
+tt, code, pre {
   background-color: #f9f9f9;
   font-family: 'Roboto Mono', monospace;
 }
@@ -824,7 +824,7 @@ section {
 }
 
 /* prevent monospace from becoming overly large */
-tt, code, pre, code {
+tt, code, pre {
   font-size: 95%;
 }
 

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 11, 2022
+Internet-Draft                                          October 12, 2022
 Intended status: Experimental                                           
-Expires: April 14, 2023
+Expires: April 15, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 14, 2023.
+   This Internet-Draft will expire on April 15, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                   Expires April 14, 2023                 [Page 1]
+Person                   Expires April 15, 2023                 [Page 1]
 
 Internet-Draft             xml2rfc index tests              October 2022
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                   Expires April 14, 2023                 [Page 2]
+Person                   Expires April 15, 2023                 [Page 2]
 
 Internet-Draft             xml2rfc index tests              October 2022
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                   Expires April 14, 2023                 [Page 3]
+Person                   Expires April 15, 2023                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2022-10-11T03:44:28" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2022-10-12T18:49:39" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.15.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="11" month="10" year="2022"/>
+    <date day="12" month="10" year="2022"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 14 April 2023.
+        This Internet-Draft will expire on 15 April 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 11, 2022
+Internet-Draft                                          October 12, 2022
 Intended status: Experimental                                           
-Expires: April 14, 2023
+Expires: April 15, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 14, 2023.
+   This Internet-Draft will expire on April 15, 2023.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires April 14, 2023</td>
+<td class="center">Expires April 15, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-10-11" class="published">October 11, 2022</time>
+<time datetime="2022-10-12" class="published">October 12, 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-04-14">April 14, 2023</time></dd>
+<dd class="expires"><time datetime="2023-04-15">April 15, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on April 14, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on April 15, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                         11 October 2022
+                                                         12 October 2022
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -256,7 +256,7 @@ a.selfRef:hover {
 } */
 
 /* Figures */
-tt, code, pre, code {
+tt, code, pre {
   background-color: #f9f9f9;
   font-family: 'Roboto Mono', monospace;
 }
@@ -828,7 +828,7 @@ section {
 }
 
 /* prevent monospace from becoming overly large */
-tt, code, pre, code {
+tt, code, pre {
   font-size: 95%;
 }
 

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 11, 2022
+Internet-Draft                                          October 12, 2022
 Intended status: Experimental                                           
-Expires: April 14, 2023
+Expires: April 15, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 14, 2023.
+   This Internet-Draft will expire on April 15, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                   Expires April 14, 2023                 [Page 1]
+Person                   Expires April 15, 2023                 [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests            October 2022
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests            October 2022
 
 
 
-Person                   Expires April 14, 2023                 [Page 2]
+Person                   Expires April 15, 2023                 [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests            October 2022
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests            October 2022
 
 
 
-Person                   Expires April 14, 2023                 [Page 3]
+Person                   Expires April 15, 2023                 [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests            October 2022
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                   Expires April 14, 2023                 [Page 4]
+Person                   Expires April 15, 2023                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="sourcecode-00" indexInclude="true" ipr="trust200902" prepTime="2022-10-11T03:44:36" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="sourcecode-00" indexInclude="true" ipr="trust200902" prepTime="2022-10-12T18:49:47" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.15.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="11" month="10" year="2022"/>
+    <date day="12" month="10" year="2022"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 14 April 2023.
+        This Internet-Draft will expire on 15 April 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 11, 2022
+Internet-Draft                                          October 12, 2022
 Intended status: Experimental                                           
-Expires: April 14, 2023
+Expires: April 15, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 14, 2023.
+   This Internet-Draft will expire on April 15, 2023.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires April 14, 2023</td>
+<td class="center">Expires April 15, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-10-11" class="published">October 11, 2022</time>
+<time datetime="2022-10-12" class="published">October 12, 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-04-14">April 14, 2023</time></dd>
+<dd class="expires"><time datetime="2023-04-15">April 15, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on April 14, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on April 15, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -215,7 +215,7 @@ a.selfRef:hover {
 } */
 
 /* Figures */
-tt, code, pre, code {
+tt, code, pre {
   background-color: #f9f9f9;
   font-family: 'Roboto Mono', monospace;
 }
@@ -787,7 +787,7 @@ section {
 }
 
 /* prevent monospace from becoming overly large */
-tt, code, pre, code {
+tt, code, pre {
   font-size: 95%;
 }
 

--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -158,7 +158,7 @@ page_css_template = """
     font-family: {fonts};
     width: 100%;
   }}
-  tt, code, pre, code {{
+  tt, code, pre {{
     font-family: {mono-fonts};
   }}
   @page {{


### PR DESCRIPTION
Ref: https://github.com/ietf-tools/xml2rfc/pull/909#discussion_r992999543