### PR TITLE
fix: Add Noto Sans Symbols 2 font to PDF template

### DIFF
--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -123,14 +123,14 @@ class PdfWriter(BaseV3Writer):
     def get_serif_fonts(self):
         fonts = set()
         scripts = self.root.get('scripts').split(',')
-        noto_serif = 'Noto Serif'
-        noto_symbols = 'NotoSansSymbols2'
+        noto_serif = "Noto Serif"
+        noto_symbols = "NotoSansSymbols2"
         for script in scripts:
             family = get_noto_serif_family_for_script(script)
-            fonts.add('%s' % family)
+            fonts.add("%s" % family)
         fonts -= set([ noto_serif, ])
         fonts = [noto_serif, noto_symbols] + list(fonts)
-        self.note(None, 'Found installed font: %s' % ', '.join(fonts))
+        self.note(None, "Found installed font: %s" % ', '.join(fonts))
         return fonts
 
     def get_mono_fonts(self):

--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -122,7 +122,7 @@ class PdfWriter(BaseV3Writer):
 
     def get_serif_fonts(self):
         fonts = set()
-        scripts = self.root.get('scripts').split(',')
+        scripts = self.root.get("scripts").split(",")
         noto_serif = "Noto Serif"
         noto_symbols = "NotoSansSymbols2"
         for script in scripts:
@@ -130,7 +130,7 @@ class PdfWriter(BaseV3Writer):
             fonts.add("%s" % family)
         fonts -= set([ noto_serif, ])
         fonts = [noto_serif, noto_symbols] + list(fonts)
-        self.note(None, "Found installed font: %s" % ', '.join(fonts))
+        self.note(None, "Found installed font: %s" % ", ".join(fonts))
         return fonts
 
     def get_mono_fonts(self):

--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -123,13 +123,14 @@ class PdfWriter(BaseV3Writer):
     def get_serif_fonts(self):
         fonts = set()
         scripts = self.root.get('scripts').split(',')
-        noto_serif = "Noto Serif"
+        noto_serif = 'Noto Serif'
+        noto_symbols = 'NotoSansSymbols2'
         for script in scripts:
             family = get_noto_serif_family_for_script(script)
-            fonts.add("%s" % family)
+            fonts.add('%s' % family)
         fonts -= set([ noto_serif, ])
-        fonts = [ noto_serif, ] + list(fonts)
-        self.note(None, "Found installed font: %s" % ', '.join(fonts))
+        fonts = [noto_serif, noto_symbols] + list(fonts)
+        self.note(None, 'Found installed font: %s' % ', '.join(fonts))
         return fonts
 
     def get_mono_fonts(self):


### PR DESCRIPTION
This Noto Sans Symbols 2 font provides a "circle" symbol for nested ul > li elements.

Fixes #925 