### PR TITLE
chore: Skip Weasyprint 57.0 in tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,7 +90,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "PyPDF2>=2.6.0" "weasyprint>=53.0,<57.0"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "PyPDF2>=2.6.0" "weasyprint>=53.0,!=57.0"
         
     - name: Generate Valid Tests
       run: |
@@ -151,7 +151,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "PyPDF2>=2.6.0" "weasyprint>=53.0,<57.0"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "PyPDF2>=2.6.0" "weasyprint>=53.0,!=57.0"
         
     - name: Generate Valid Tests
       run: |
@@ -201,7 +201,7 @@ jobs:
 #         echo "Installing pip + wheel..."
 #         python -m pip install --upgrade pip wheel
 #         echo "Installing requirements.txt + test dependencies..."
-#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "PyPDF2>=2.6.0" "weasyprint>=53.0,<57.0"
+#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "PyPDF2>=2.6.0" "weasyprint>=53.0,!=57.0"
 #     - name: Generate Valid Tests
 #       run: |
 #         make yestests || true

--- a/tox.ini
+++ b/tox.ini
@@ -33,4 +33,4 @@ deps =
     decorator
     dict2xml
     pypdf2>=2.6.0
-    weasyprint>=53.0,<57.0
+    weasyprint>=53.0,!=57.0


### PR DESCRIPTION
Weasyprint 57.0 introduced a bug that breaks xml2rfc tests. This is fixed in Weasyprint 57.1.
See https://github.com/Kozea/WeasyPrint/issues/1752