### PR TITLE
feat: Lighter styling on internal iref links

### DIFF
--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -220,7 +220,8 @@ a[href]:hover {
   background-color: #f2f2f2;
 }
 figcaption a[href],
-a[href].selfRef {
+a[href].selfRef,
+.iref + a[href].internal {
   color: #222;
 }
 /* XXX probably not this:


### PR DESCRIPTION
See https://github.com/ietf-tools/datatracker/pull/5071 for more context.

This removes the blue coloration from internal links that immediately follow an `<iref>` tag (rendered as a `span.iref`).  This reduces visual noise arising from the use of keyword linking.  See https://github.com/cabo/kramdown-rfc/wiki/Syntax2#index-entries for details on how that operates.