### PR TITLE
fix(v2v3): Preserve t element in ol and li 

### DIFF
--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -1503,8 +1503,9 @@ li > p:last-of-type:only-child {
             well suited for editing RFC-like documents.<a href="#section-1-3" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="section-1-4.1">
+          <p id="section-1-4.1.1">
                   Note: this document is typeset in Pandoc and does not render
-                  completely correct when reading it on github.<a href="#section-1-4.1" class="pilcrow">¶</a>
+                  completely correct when reading it on github.<a href="#section-1-4.1.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 </section>
@@ -1516,7 +1517,8 @@ li > p:last-of-type:only-child {
       </h2>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="section-2-1.1">
-                  Pandoc2rfc -- designed to do the right thing, until it doesn't.<a href="#section-2-1.1" class="pilcrow">¶</a>
+          <p id="section-2-1.1.1">
+                  Pandoc2rfc -- designed to do the right thing, until it doesn't.<a href="#section-2-1.1.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <p id="section-2-2">
@@ -1612,13 +1614,16 @@ non-existent  |                       | xsltproc
             edit 3 documents:<a href="#section-2-8" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-2-9">
 <li id="section-2-9.1">
-                  middle.pdc - contains the main body of text;<a href="#section-2-9.1" class="pilcrow">¶</a>
+          <p id="section-2-9.1.1">
+                  middle.pdc - contains the main body of text;<a href="#section-2-9.1.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-2-9.2">
-                  back.pdc - holds appendices and references;<a href="#section-2-9.2" class="pilcrow">¶</a>
+          <p id="section-2-9.2.1">
+                  back.pdc - holds appendices and references;<a href="#section-2-9.2.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-2-9.3">
-                  template.xml (probably a fairly static file).<a href="#section-2-9.3" class="pilcrow">¶</a>
+          <p id="section-2-9.3.1">
+                  template.xml (probably a fairly static file).<a href="#section-2-9.3.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <p id="section-2-10">
@@ -1665,23 +1670,28 @@ non-existent  |                       | xsltproc
             need to copy the following files:<a href="#section-3-1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-3-2.1">
-          <code>Makefile</code><a href="#section-3-2.1" class="pilcrow">¶</a>
+          <p id="section-3-2.1.1">
+                  <code>Makefile</code><a href="#section-3-2.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-3-2.2">
-          <code>transform.xslt</code><a href="#section-3-2.2" class="pilcrow">¶</a>
+          <p id="section-3-2.2.1">
+                  <code>transform.xslt</code><a href="#section-3-2.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-3-2.3">
           <p id="section-3-2.3.1">
                   And the above mentioned files:<a href="#section-3-2.3.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-3-2.3.2.1">
-              <code>middle.pdc</code><a href="#section-3-2.3.2.1" class="pilcrow">¶</a>
+              <p id="section-3-2.3.2.1.1">
+                        <code>middle.pdc</code><a href="#section-3-2.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-3-2.3.2.2">
-              <code>back.pdc</code><a href="#section-3-2.3.2.2" class="pilcrow">¶</a>
+              <p id="section-3-2.3.2.2.1">
+                        <code>back.pdc</code><a href="#section-3-2.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-3-2.3.2.3">
-              <code>template.xml</code><a href="#section-3-2.3.2.3" class="pilcrow">¶</a>
+              <p id="section-3-2.3.2.3.1">
+                        <code>template.xml</code><a href="#section-3-2.3.2.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>
@@ -1697,79 +1707,97 @@ non-existent  |                       | xsltproc
       </h2>
 <ul class="normal">
 <li class="normal" id="section-4-1.1">
+          <p id="section-4-1.1.1">
                   Sections with an anchor and title attributes
-   (<a href="#section" class="auto internal xref">Section 7.2</a>);<a href="#section-4-1.1" class="pilcrow">¶</a>
+   (<a href="#section" class="auto internal xref">Section 7.2</a>);<a href="#section-4-1.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.2">
           <p id="section-4-1.2.1">
                   Lists<a href="#section-4-1.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4-1.2.2.1">
-                        style=symbols (<a href="#symbol" class="auto internal xref">Section 7.3.1</a>);<a href="#section-4-1.2.2.1" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.1.1">
+                        style=symbols (<a href="#symbol" class="auto internal xref">Section 7.3.1</a>);<a href="#section-4-1.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.2">
-                        style=numbers (<a href="#number" class="auto internal xref">Section 7.3.2</a>);<a href="#section-4-1.2.2.2" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.2.1">
+                        style=numbers (<a href="#number" class="auto internal xref">Section 7.3.2</a>);<a href="#section-4-1.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.3">
-                        style=empty (<a href="#empty" class="auto internal xref">Section 7.3.3</a>);<a href="#section-4-1.2.2.3" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.3.1">
+                        style=empty (<a href="#empty" class="auto internal xref">Section 7.3.3</a>);<a href="#section-4-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.4">
-                        style=format %i, use roman lowercase numerals, (<a href="#roman" class="auto internal xref">Section 7.3.4</a>);<a href="#section-4-1.2.2.4" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.4.1">
+                        style=format %i, use roman lowercase numerals, (<a href="#roman" class="auto internal xref">Section 7.3.4</a>);<a href="#section-4-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.5">
-                        style=format (%d), use roman uppercase numerals (<a href="#roman" class="auto internal xref">Section 7.3.4</a>);<a href="#section-4-1.2.2.5" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.5.1">
+                        style=format (%d), use roman uppercase numerals (<a href="#roman" class="auto internal xref">Section 7.3.4</a>);<a href="#section-4-1.2.2.5.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.6">
-                        style=letters (lower- and uppercase, <a href="#letter" class="auto internal xref">Section 7.3.5</a>);<a href="#section-4-1.2.2.6" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.6.1">
+                        style=letters (lower- and uppercase, <a href="#letter" class="auto internal xref">Section 7.3.5</a>);<a href="#section-4-1.2.2.6.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.7">
-                        style=hanging (<a href="#hanging" class="auto internal xref">Section 7.3.6</a>);<a href="#section-4-1.2.2.7" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.7.1">
+                        style=hanging (<a href="#hanging" class="auto internal xref">Section 7.3.6</a>);<a href="#section-4-1.2.2.7.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>
         <li class="normal" id="section-4-1.3">
-                  Figure/artwork with a title (<a href="#figureartwork" class="auto internal xref">Section 7.4</a>);<a href="#section-4-1.3" class="pilcrow">¶</a>
+          <p id="section-4-1.3.1">
+                  Figure/artwork with a title (<a href="#figureartwork" class="auto internal xref">Section 7.4</a>);<a href="#section-4-1.3.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.4">
+          <p id="section-4-1.4.1">
                   Block quote this is converted to
                   <code>&lt;list style="empty"&gt;</code>
-                  paragraph (<a href="#block-quote" class="auto internal xref">Section 7.5</a>);<a href="#section-4-1.4" class="pilcrow">¶</a>
+                  paragraph (<a href="#block-quote" class="auto internal xref">Section 7.5</a>);<a href="#section-4-1.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.5">
           <p id="section-4-1.5.1">
                   References<a href="#section-4-1.5.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4-1.5.2.1">
-                        external (eref) (<a href="#external" class="auto internal xref">Section 7.6.1</a>);<a href="#section-4-1.5.2.1" class="pilcrow">¶</a>
+              <p id="section-4-1.5.2.1.1">
+                        external (eref) (<a href="#external" class="auto internal xref">Section 7.6.1</a>);<a href="#section-4-1.5.2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.5.2.2">
               <p id="section-4-1.5.2.2.1">
                         internal (xref) (<a href="#internal" class="auto internal xref">Section 7.6.2</a>), you can refer to:<a href="#section-4-1.5.2.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4-1.5.2.2.2.1">
-                              section (handled by Pandoc, see <a href="#references-1" class="auto internal xref">Section 7.6</a>));<a href="#section-4-1.5.2.2.2.1" class="pilcrow">¶</a>
+                  <p id="section-4-1.5.2.2.2.1.1">
+                              section (handled by Pandoc, see <a href="#references-1" class="auto internal xref">Section 7.6</a>));<a href="#section-4-1.5.2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
                 <li class="normal" id="section-4-1.5.2.2.2.2">
-                              figures (handled by XSLT, see <a href="#references" class="auto internal xref">Section 7.4.1</a>);<a href="#section-4-1.5.2.2.2.2" class="pilcrow">¶</a>
+                  <p id="section-4-1.5.2.2.2.2.1">
+                              figures (handled by XSLT, see <a href="#references" class="auto internal xref">Section 7.4.1</a>);<a href="#section-4-1.5.2.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
                 <li class="normal" id="section-4-1.5.2.2.2.3">
-                              tables (handled by XSLT, see <a href="#references-2" class="auto internal xref">Section 7.8.1</a>).<a href="#section-4-1.5.2.2.2.3" class="pilcrow">¶</a>
+                  <p id="section-4-1.5.2.2.2.3.1">
+                              tables (handled by XSLT, see <a href="#references-2" class="auto internal xref">Section 7.8.1</a>).<a href="#section-4-1.5.2.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
               </ul>
 </li>
           </ul>
 </li>
         <li class="normal" id="section-4-1.6">
-                  Citations, by using internal references;<a href="#section-4-1.6" class="pilcrow">¶</a>
+          <p id="section-4-1.6.1">
+                  Citations, by using internal references;<a href="#section-4-1.6.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.7">
-                  Spanx style=verb, style=emph and style=strong (<a href="#spanx-styles" class="auto internal xref">Section 7.7</a>);<a href="#section-4-1.7" class="pilcrow">¶</a>
+          <p id="section-4-1.7.1">
+                  Spanx style=verb, style=emph and style=strong (<a href="#spanx-styles" class="auto internal xref">Section 7.7</a>);<a href="#section-4-1.7.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.8">
-                  Tables with an anchor and title (<a href="#tables" class="auto internal xref">Section 7.8</a>);<a href="#section-4-1.8" class="pilcrow">¶</a>
+          <p id="section-4-1.8.1">
+                  Tables with an anchor and title (<a href="#tables" class="auto internal xref">Section 7.8</a>);<a href="#section-4-1.8.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.9">
-                  Indexes, by using footnotes (<a href="#indexes" class="auto internal xref">Section 7.9</a>).<a href="#section-4-1.9" class="pilcrow">¶</a>
+          <p id="section-4-1.9.1">
+                  Indexes, by using footnotes (<a href="#indexes" class="auto internal xref">Section 7.9</a>).<a href="#section-4-1.9.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 </section>
@@ -1781,13 +1809,16 @@ non-existent  |                       | xsltproc
       </h2>
 <ul class="normal">
 <li class="normal" id="section-5-1.1">
-                  Lists inside a table (<code>xml2rfc</code> doesn't handle this);<a href="#section-5-1.1" class="pilcrow">¶</a>
+          <p id="section-5-1.1.1">
+                  Lists inside a table (<code>xml2rfc</code> doesn't handle this);<a href="#section-5-1.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-5-1.2">
-                  Pandoc markup in the caption for figures/artwork. Pandoc markup for table captions <em>is</em> supported;<a href="#section-5-1.2" class="pilcrow">¶</a>
+          <p id="section-5-1.2.1">
+                  Pandoc markup in the caption for figures/artwork. Pandoc markup for table captions <em>is</em> supported;<a href="#section-5-1.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-5-1.3">
-                  crefs: for comments (no input syntax available), use HTML comments: <code>&lt;!-- ... --&gt;</code>;<a href="#section-5-1.3" class="pilcrow">¶</a>
+          <p id="section-5-1.3.1">
+                  crefs: for comments (no input syntax available), use HTML comments: <code>&lt;!-- ... --&gt;</code>;<a href="#section-5-1.3.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 </section>
@@ -1872,10 +1903,12 @@ A symbol list.
                   Converts to <code>&lt;list style="symbol"&gt;</code>:<a href="#section-7.3.1-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.3.1-3.1">
-                        Item one;<a href="#section-7.3.1-3.1" class="pilcrow">¶</a>
+              <p id="section-7.3.1-3.1.1">
+                        Item one;<a href="#section-7.3.1-3.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.3.1-3.2">
-                        Item two.<a href="#section-7.3.1-3.2" class="pilcrow">¶</a>
+              <p id="section-7.3.1-3.2.1">
+                        Item two.<a href="#section-7.3.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </section>
@@ -1897,10 +1930,12 @@ A numbered list.
                   Converts to <code>&lt;list style="numbers"&gt;</code>:<a href="#section-7.3.2-2" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-7.3.2-3">
 <li id="section-7.3.2-3.1">
-                        Item one;<a href="#section-7.3.2-3.1" class="pilcrow">¶</a>
+              <p id="section-7.3.2-3.1.1">
+                        Item one;<a href="#section-7.3.2-3.1.1" class="pilcrow">¶</a></p>
 </li>
             <li id="section-7.3.2-3.2">
-                        Item two.<a href="#section-7.3.2-3.2" class="pilcrow">¶</a>
+              <p id="section-7.3.2-3.2.1">
+                        Item two.<a href="#section-7.3.2-3.2.1" class="pilcrow">¶</a></p>
 </li>
           </ol>
 </section>
@@ -1924,10 +1959,12 @@ A list using the default list markers.
                   Converts to <code>&lt;list style="empty"&gt;</code>:<a href="#section-7.3.3-3" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="section-7.3.3-4.1">
-                        Item one;<a href="#section-7.3.3-4.1" class="pilcrow">¶</a>
+              <p id="section-7.3.3-4.1.1">
+                        Item one;<a href="#section-7.3.3-4.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal ulEmpty" id="section-7.3.3-4.2">
-                        Item two.<a href="#section-7.3.3-4.2" class="pilcrow">¶</a>
+              <p id="section-7.3.3-4.2.1">
+                        Item two.<a href="#section-7.3.3-4.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </section>
@@ -1950,12 +1987,14 @@ ii. Item two.
 <span class="break"></span><dl class="olPercent" id="section-7.3.4-4">
 <dt>i.</dt>
 <dd id="section-7.3.4-4.1">
-                        Item one;<a href="#section-7.3.4-4.1" class="pilcrow">¶</a>
+              <p id="section-7.3.4-4.1.1">
+                        Item one;<a href="#section-7.3.4-4.1.1" class="pilcrow">¶</a></p>
 </dd>
             <dd class="break"></dd>
 <dt>ii.</dt>
 <dd id="section-7.3.4-4.2">
-                        Item two.<a href="#section-7.3.4-4.2" class="pilcrow">¶</a>
+              <p id="section-7.3.4-4.2.1">
+                        Item two.<a href="#section-7.3.4-4.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 </dl>
@@ -1972,12 +2011,14 @@ II. Item two.
 <span class="break"></span><dl class="olPercent" id="section-7.3.4-8">
 <dt>(1)</dt>
 <dd id="section-7.3.4-8.1">
-                        Item one;<a href="#section-7.3.4-8.1" class="pilcrow">¶</a>
+              <p id="section-7.3.4-8.1.1">
+                        Item one;<a href="#section-7.3.4-8.1.1" class="pilcrow">¶</a></p>
 </dd>
             <dd class="break"></dd>
 <dt>(2)</dt>
 <dd id="section-7.3.4-8.2">
-                        Item two.<a href="#section-7.3.4-8.2" class="pilcrow">¶</a>
+              <p id="section-7.3.4-8.2.1">
+                        Item two.<a href="#section-7.3.4-8.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 </dl>
@@ -2000,10 +2041,12 @@ b.  Item two.
                   Converts to <code>&lt;list style="letters"&gt;</code>:<a href="#section-7.3.5-3" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="section-7.3.5-4">
 <li id="section-7.3.5-4.1">
-                        Item one;<a href="#section-7.3.5-4.1" class="pilcrow">¶</a>
+              <p id="section-7.3.5-4.1.1">
+                        Item one;<a href="#section-7.3.5-4.1.1" class="pilcrow">¶</a></p>
 </li>
             <li id="section-7.3.5-4.2">
-                        Item two.<a href="#section-7.3.5-4.2" class="pilcrow">¶</a>
+              <p id="section-7.3.5-4.2.1">
+                        Item two.<a href="#section-7.3.5-4.2.1" class="pilcrow">¶</a></p>
 </li>
           </ol>
 <p id="section-7.3.5-5">
@@ -2019,12 +2062,14 @@ B.  Item two.
 <span class="break"></span><dl class="olPercent" id="section-7.3.5-8">
 <dt>A.</dt>
 <dd id="section-7.3.5-8.1">
-                        Item one;<a href="#section-7.3.5-8.1" class="pilcrow">¶</a>
+              <p id="section-7.3.5-8.1.1">
+                        Item one;<a href="#section-7.3.5-8.1.1" class="pilcrow">¶</a></p>
 </dd>
             <dd class="break"></dd>
 <dt>B.</dt>
 <dd id="section-7.3.5-8.2">
-                        Item two.<a href="#section-7.3.5-8.2" class="pilcrow">¶</a>
+              <p id="section-7.3.5-8.2.1">
+                        Item two.<a href="#section-7.3.5-8.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 </dl>
@@ -2096,16 +2141,19 @@ Like this
                   Where normalized means:<a href="#section-7.4.1-1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.4.1-2.1">
+              <p id="section-7.4.1-2.1.1">
                         Take the first 10 characters of the caption (i.e. this is the text
                         <em>after</em> the string
-                        <code>@Figure:</code>);<a href="#section-7.4.1-2.1" class="pilcrow">¶</a>
+                        <code>@Figure:</code>);<a href="#section-7.4.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.4.1-2.2">
+              <p id="section-7.4.1-2.2.1">
                         Spaces and single quotes (') are translated to a minus
-                        <code>-</code>;<a href="#section-7.4.1-2.2" class="pilcrow">¶</a>
+                        <code>-</code>;<a href="#section-7.4.1-2.2.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.4.1-2.3">
-                        Uppercase letters translated to lowercase.<a href="#section-7.4.1-2.3" class="pilcrow">¶</a>
+              <p id="section-7.4.1-2.3.1">
+                        Uppercase letters translated to lowercase.<a href="#section-7.4.1-2.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 <p id="section-7.4.1-3">
@@ -2267,16 +2315,19 @@ See [](#pandoc-constructs)
                   Where normalized means:<a href="#section-7.8.1-1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.8.1-2.1">
+              <p id="section-7.8.1-2.1.1">
                         Take the first 10 characters of the caption (i.e. this is the text
                         <em>after</em> the string
-                        <code>Table:</code>);<a href="#section-7.8.1-2.1" class="pilcrow">¶</a>
+                        <code>Table:</code>);<a href="#section-7.8.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.8.1-2.2">
+              <p id="section-7.8.1-2.2.1">
                         Spaces and single quotes (') are translated to a minus
-                        <code>-</code>;<a href="#section-7.8.1-2.2" class="pilcrow">¶</a>
+                        <code>-</code>;<a href="#section-7.8.1-2.2.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.8.1-2.3">
-                        Uppercase letters translated to lowercase.<a href="#section-7.8.1-2.3" class="pilcrow">¶</a>
+              <p id="section-7.8.1-2.3.1">
+                        Uppercase letters translated to lowercase.<a href="#section-7.8.1-2.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 <p id="section-7.8.1-3">
@@ -2489,7 +2540,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
         </h3>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="appendix-A.3-1.1">
-                     This is a blockquote, how does it look?<a href="#appendix-A.3-1.1" class="pilcrow">¶</a>
+            <p id="appendix-A.3-1.1.1">
+                     This is a blockquote, how does it look?<a href="#appendix-A.3-1.1.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 </section>
@@ -2523,16 +2575,20 @@ jkasjksajassjasjsajsajkas
         </h3>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="appendix-A.6-1.1">
-                     underscores: <em>underscores</em><a href="#appendix-A.6-1.1" class="pilcrow">¶</a>
+            <p id="appendix-A.6-1.1.1">
+                     underscores: <em>underscores</em><a href="#appendix-A.6-1.1.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.6-1.2">
-                     asterisks: <em>asterisks</em><a href="#appendix-A.6-1.2" class="pilcrow">¶</a>
+            <p id="appendix-A.6-1.2.1">
+                     asterisks: <em>asterisks</em><a href="#appendix-A.6-1.2.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.6-1.3">
-                     double asterisks: <strong>double asterisks</strong><a href="#appendix-A.6-1.3" class="pilcrow">¶</a>
+            <p id="appendix-A.6-1.3.1">
+                     double asterisks: <strong>double asterisks</strong><a href="#appendix-A.6-1.3.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.6-1.4">
-                     backticks: <code>backticks</code><a href="#appendix-A.6-1.4" class="pilcrow">¶</a>
+            <p id="appendix-A.6-1.4.1">
+                     backticks: <code>backticks</code><a href="#appendix-A.6-1.4.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 </section>
@@ -2544,17 +2600,20 @@ jkasjksajassjasjsajsajkas
         </h3>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-1">
 <li id="appendix-A.7-1.1">
-                     First we do<a href="#appendix-A.7-1.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-1.1.1">
+                     First we do<a href="#appendix-A.7-1.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-1.2">
             <p id="appendix-A.7-1.2.1">
                      And then<a href="#appendix-A.7-1.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.7-1.2.2.1">
-                           item 1<a href="#appendix-A.7-1.2.2.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-1.2.2.1.1">
+                           item 1<a href="#appendix-A.7-1.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li class="normal" id="appendix-A.7-1.2.2.2">
-                           item 2<a href="#appendix-A.7-1.2.2.2" class="pilcrow">¶</a>
+                <p id="appendix-A.7-1.2.2.2.1">
+                           item 2<a href="#appendix-A.7-1.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
@@ -2563,17 +2622,20 @@ jkasjksajassjasjsajsajkas
                And the other around.<a href="#appendix-A.7-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.7-3.1">
-                     First we do<a href="#appendix-A.7-3.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-3.1.1">
+                     First we do<a href="#appendix-A.7-3.1.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal" id="appendix-A.7-3.2">
             <p id="appendix-A.7-3.2.1">
                      Then<a href="#appendix-A.7-3.2.1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-3.2.2">
 <li id="appendix-A.7-3.2.2.1">
-                           Something<a href="#appendix-A.7-3.2.2.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-3.2.2.1.1">
+                           Something<a href="#appendix-A.7-3.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li id="appendix-A.7-3.2.2.2">
-                           Another thing<a href="#appendix-A.7-3.2.2.2" class="pilcrow">¶</a>
+                <p id="appendix-A.7-3.2.2.2.1">
+                           Another thing<a href="#appendix-A.7-3.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ol>
 </li>
@@ -2600,10 +2662,12 @@ jkasjksajassjasjsajsajkas
             <p id="appendix-A.7-7.2.1">It works because of<a href="#appendix-A.7-7.2.1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.2.2">
 <li id="appendix-A.7-7.2.2.1">
-                        One<a href="#appendix-A.7-7.2.2.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-7.2.2.1.1">
+                        One<a href="#appendix-A.7-7.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li id="appendix-A.7-7.2.2.2">
-                        Two<a href="#appendix-A.7-7.2.2.2" class="pilcrow">¶</a>
+                <p id="appendix-A.7-7.2.2.2.1">
+                        Two<a href="#appendix-A.7-7.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ol>
 </dd>
@@ -2617,17 +2681,20 @@ jkasjksajassjasjsajsajkas
             <p id="appendix-A.7-7.6.1">It works because of<a href="#appendix-A.7-7.6.1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.6.2">
 <li id="appendix-A.7-7.6.2.1">
-                        One1<a href="#appendix-A.7-7.6.2.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-7.6.2.1.1">
+                        One1<a href="#appendix-A.7-7.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li id="appendix-A.7-7.6.2.2">
                 <p id="appendix-A.7-7.6.2.2.1">
                         Two1<a href="#appendix-A.7-7.6.2.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.7-7.6.2.2.2.1">
-                              Itemize list<a href="#appendix-A.7-7.6.2.2.2.1" class="pilcrow">¶</a>
+                    <p id="appendix-A.7-7.6.2.2.2.1.1">
+                              Itemize list<a href="#appendix-A.7-7.6.2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
                   <li class="normal" id="appendix-A.7-7.6.2.2.2.2">
-                              Another item<a href="#appendix-A.7-7.6.2.2.2.2" class="pilcrow">¶</a>
+                    <p id="appendix-A.7-7.6.2.2.2.2.1">
+                              Another item<a href="#appendix-A.7-7.6.2.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
                 </ul>
 </li>
@@ -2657,7 +2724,8 @@ jkasjksajassjasjsajsajkas
 </dl>
 </li>
           <li id="appendix-A.7-9.2">
-                     Go'bye<a href="#appendix-A.7-9.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-9.2.1">
+                     Go'bye<a href="#appendix-A.7-9.2.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.7-10">
@@ -2669,7 +2737,8 @@ jkasjksajassjasjsajsajkas
 <p id="appendix-A.7-11.1.2"> ... to be explained properly.<a href="#appendix-A.7-11.1.2" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-11.2">
-                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#appendix-A.7-11.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-11.2.1">
+                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#appendix-A.7-11.2.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-11.3">
             <p id="appendix-A.7-11.3.1">
@@ -2681,7 +2750,8 @@ Artwork
 </div>
 </li>
           <li id="appendix-A.7-11.4">
-                     Final item.<a href="#appendix-A.7-11.4" class="pilcrow">¶</a>
+            <p id="appendix-A.7-11.4.1">
+                     Final item.<a href="#appendix-A.7-11.4.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.7-12">
@@ -2695,10 +2765,12 @@ Artwork
                Ordered lists.<a href="#appendix-A.7-14" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-15">
 <li id="appendix-A.7-15.1">
-                     First item<a href="#appendix-A.7-15.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-15.1.1">
+                     First item<a href="#appendix-A.7-15.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-15.2">
-                     Second item<a href="#appendix-A.7-15.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-15.2.1">
+                     Second item<a href="#appendix-A.7-15.2.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.7-16">
@@ -2706,12 +2778,14 @@ Artwork
 <span class="break"></span><dl class="olPercent" id="appendix-A.7-17">
 <dt>i.</dt>
 <dd id="appendix-A.7-17.1">
-                     Item 1<a href="#appendix-A.7-17.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-17.1.1">
+                     Item 1<a href="#appendix-A.7-17.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>ii.</dt>
 <dd id="appendix-A.7-17.2">
-                     Item 2<a href="#appendix-A.7-17.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-17.2.1">
+                     Item 2<a href="#appendix-A.7-17.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -2720,17 +2794,20 @@ Artwork
 <span class="break"></span><dl class="olPercent" id="appendix-A.7-19">
 <dt>(1)</dt>
 <dd id="appendix-A.7-19.1">
-                     Item1<a href="#appendix-A.7-19.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-19.1.1">
+                     Item1<a href="#appendix-A.7-19.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>(2)</dt>
 <dd id="appendix-A.7-19.2">
-                     Item2<a href="#appendix-A.7-19.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-19.2.1">
+                     Item2<a href="#appendix-A.7-19.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>(3)</dt>
 <dd id="appendix-A.7-19.3">
-                     Item 3<a href="#appendix-A.7-19.3" class="pilcrow">¶</a>
+            <p id="appendix-A.7-19.3.1">
+                     Item 3<a href="#appendix-A.7-19.3.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -2740,16 +2817,19 @@ Artwork
                Some surrounding text, to make it look better.<a href="#appendix-A.7-21" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="appendix-A.7-22.1">
+            <p id="appendix-A.7-22.1.1">
                      First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
-      First item. Use lot of text to get a real paragraphs sense.<a href="#appendix-A.7-22.1" class="pilcrow">¶</a>
+      First item. Use lot of text to get a real paragraphs sense.<a href="#appendix-A.7-22.1.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.7-22.2">
-                     Second item. So this is the second para in your list. Enjoy;<a href="#appendix-A.7-22.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-22.2.1">
+                     Second item. So this is the second para in your list. Enjoy;<a href="#appendix-A.7-22.2.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.7-22.3">
-                     Another item.<a href="#appendix-A.7-22.3" class="pilcrow">¶</a>
+            <p id="appendix-A.7-22.3.1">
+                     Another item.<a href="#appendix-A.7-22.3.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <p id="appendix-A.7-23">
@@ -2758,10 +2838,12 @@ Artwork
                Lowercase letters list.<a href="#appendix-A.7-24" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="appendix-A.7-25">
 <li id="appendix-A.7-25.1">
-                     First item<a href="#appendix-A.7-25.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-25.1.1">
+                     First item<a href="#appendix-A.7-25.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-25.2">
-                     Second item<a href="#appendix-A.7-25.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-25.2.1">
+                     Second item<a href="#appendix-A.7-25.2.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.7-26">
@@ -2769,12 +2851,14 @@ Artwork
 <span class="break"></span><dl class="olPercent" id="appendix-A.7-27">
 <dt>A.</dt>
 <dd id="appendix-A.7-27.1">
-                     First item<a href="#appendix-A.7-27.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-27.1.1">
+                     First item<a href="#appendix-A.7-27.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>B.</dt>
 <dd id="appendix-A.7-27.2">
-                     Second item<a href="#appendix-A.7-27.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-27.2.1">
+                     Second item<a href="#appendix-A.7-27.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -2807,10 +2891,12 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
                List with a sublist with a paragraph above the sublist<a href="#appendix-A.7-31" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-32">
 <li id="appendix-A.7-32.1">
-                     First Item<a href="#appendix-A.7-32.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-32.1.1">
+                     First Item<a href="#appendix-A.7-32.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-32.2">
-                     Second item<a href="#appendix-A.7-32.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-32.2.1">
+                     Second item<a href="#appendix-A.7-32.2.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-32.3">
             <p id="appendix-A.7-32.3.1">
@@ -2818,10 +2904,12 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
 <p id="appendix-A.7-32.3.2"> A paragraph that comes first<a href="#appendix-A.7-32.3.2" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="appendix-A.7-32.3.3">
 <li id="appendix-A.7-32.3.3.1">
-                           But what do you know<a href="#appendix-A.7-32.3.3.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-32.3.3.1.1">
+                           But what do you know<a href="#appendix-A.7-32.3.3.1.1" class="pilcrow">¶</a></p>
 </li>
               <li id="appendix-A.7-32.3.3.2">
-                           This is another list<a href="#appendix-A.7-32.3.3.2" class="pilcrow">¶</a>
+                <p id="appendix-A.7-32.3.3.2.1">
+                           This is another list<a href="#appendix-A.7-32.3.3.2.1" class="pilcrow">¶</a></p>
 </li>
             </ol>
 </li>
@@ -2982,7 +3070,8 @@ See [](#tab-here-s-the)
                This is another example:<a href="#appendix-A.9-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.9-2">
 <li id="appendix-A.9-2.1">
-                     Another bla bla..<a href="#appendix-A.9-2.1" class="pilcrow">¶</a>
+            <p id="appendix-A.9-2.1.1">
+                     Another bla bla..<a href="#appendix-A.9-2.1.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.9-3">

--- a/tests/valid/draft-miek-test.prepped.xml
+++ b/tests/valid/draft-miek-test.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" consensus="false" docName="draft-gieben-writing-rfcs-pandoc-02" indexInclude="true" ipr="trust200902" prepTime="2022-02-28T04:13:02" scripts="Common,Latin" sortRefs="true" submissionType="IETF" symRefs="true" tocDepth="3" tocInclude="true" xml:lang="en">
-  <!-- xml2rfc v2v3 conversion 3.12.3 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" ipr="trust200902" category="info" docName="draft-gieben-writing-rfcs-pandoc-02" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" symRefs="true" sortRefs="true" consensus="false" prepTime="2023-08-29T11:29:23" indexInclude="true" scripts="Common,Latin" tocDepth="3">
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   <!--generate a table of contents -->
    <!--use anchors instead of numbers for references -->
    <!--alphabetize the references -->
@@ -291,17 +291,21 @@
       </t>
       <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-1-4">
         <li pn="section-1-4.1">
+          <t indent="0" pn="section-1-4.1.1">
                   Note: this document is typeset in Pandoc and does not render
                   completely correct when reading it on github.  
-               </li>
+          </t>
+        </li>
       </ul>
     </section>
     <section anchor="pandoc-to-rfc" toc="include" numbered="true" removeInRFC="false" pn="section-2">
       <name slugifiedName="name-pandoc-to-rfc">Pandoc to RFC</name>
       <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-2-1">
         <li pn="section-2-1.1">
+          <t indent="0" pn="section-2-1.1.1">
                   Pandoc2rfc -- designed to do the right thing, until it doesn't.  
-               </li>
+          </t>
+        </li>
       </ul>
       <t indent="0" pn="section-2-2">
             When writing <xref target="RFC4641" format="default" sectionFormat="of" derivedContent="RFC4641"/>
@@ -390,14 +394,20 @@ non-existent  |                       | xsltproc
             edit 3 documents: 
       </t>
       <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-2-9"><li pn="section-2-9.1" derivedCounter="1.">
+          <t indent="0" pn="section-2-9.1.1">
                   middle.pdc - contains the main body of text; 
-               </li>
+          </t>
+        </li>
         <li pn="section-2-9.2" derivedCounter="2.">
+          <t indent="0" pn="section-2-9.2.1">
                   back.pdc - holds appendices and references; 
-               </li>
+          </t>
+        </li>
         <li pn="section-2-9.3" derivedCounter="3.">
+          <t indent="0" pn="section-2-9.3.1">
                   template.xml (probably a fairly static file).  
-               </li>
+          </t>
+        </li>
       </ol>
       <t indent="0" pn="section-2-10">
             The draft
@@ -437,23 +447,33 @@ non-existent  |                       | xsltproc
       </t>
       <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-3-2">
         <li pn="section-3-2.1">
-          <tt>Makefile</tt>
+          <t indent="0" pn="section-3-2.1.1">
+                  <tt>Makefile</tt>
+          </t>
         </li>
         <li pn="section-3-2.2">
-          <tt>transform.xslt</tt>
+          <t indent="0" pn="section-3-2.2.1">
+                  <tt>transform.xslt</tt>
+          </t>
         </li>
         <li pn="section-3-2.3">
           <t indent="0" pn="section-3-2.3.1">
                   And the above mentioned files: </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-3-2.3.2">
             <li pn="section-3-2.3.2.1">
-              <tt>middle.pdc</tt>
+              <t indent="0" pn="section-3-2.3.2.1.1">
+                        <tt>middle.pdc</tt>
+              </t>
             </li>
             <li pn="section-3-2.3.2.2">
-              <tt>back.pdc</tt>
+              <t indent="0" pn="section-3-2.3.2.2.1">
+                        <tt>back.pdc</tt>
+              </t>
             </li>
             <li pn="section-3-2.3.2.3">
-              <tt>template.xml</tt>
+              <t indent="0" pn="section-3-2.3.2.3.1">
+                        <tt>template.xml</tt>
+              </t>
             </li>
           </ul>
         </li>
@@ -466,94 +486,136 @@ non-existent  |                       | xsltproc
       <name slugifiedName="name-supported-features">Supported Features</name>
       <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4-1">
         <li pn="section-4-1.1">
+          <t indent="0" pn="section-4-1.1.1">
                   Sections with an anchor and title attributes
 		  (<xref target="section" format="default" sectionFormat="of" derivedContent="Section 7.2"/>); 
-               </li>
+          </t>
+        </li>
         <li pn="section-4-1.2">
           <t indent="0" pn="section-4-1.2.1">
                   Lists </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4-1.2.2">
             <li pn="section-4-1.2.2.1">
+              <t indent="0" pn="section-4-1.2.2.1.1">
                         style=symbols (<xref target="symbol" format="default" sectionFormat="of" derivedContent="Section 7.3.1"/>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-4-1.2.2.2">
+              <t indent="0" pn="section-4-1.2.2.2.1">
                         style=numbers (<xref target="number" format="default" sectionFormat="of" derivedContent="Section 7.3.2"/>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-4-1.2.2.3">
+              <t indent="0" pn="section-4-1.2.2.3.1">
                         style=empty (<xref target="empty" format="default" sectionFormat="of" derivedContent="Section 7.3.3"/>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-4-1.2.2.4">
+              <t indent="0" pn="section-4-1.2.2.4.1">
                         style=format %i, use roman lowercase numerals, (<xref target="roman" format="default" sectionFormat="of" derivedContent="Section 7.3.4"/>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-4-1.2.2.5">
+              <t indent="0" pn="section-4-1.2.2.5.1">
                         style=format (%d), use roman uppercase numerals (<xref target="roman" format="default" sectionFormat="of" derivedContent="Section 7.3.4"/>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-4-1.2.2.6">
+              <t indent="0" pn="section-4-1.2.2.6.1">
                         style=letters (lower- and uppercase, <xref target="letter" format="default" sectionFormat="of" derivedContent="Section 7.3.5"/>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-4-1.2.2.7">
+              <t indent="0" pn="section-4-1.2.2.7.1">
                         style=hanging (<xref target="hanging" format="default" sectionFormat="of" derivedContent="Section 7.3.6"/>); 
-                     </li>
+              </t>
+            </li>
           </ul>
         </li>
         <li pn="section-4-1.3">
+          <t indent="0" pn="section-4-1.3.1">
                   Figure/artwork with a title (<xref target="figureartwork" format="default" sectionFormat="of" derivedContent="Section 7.4"/>); 
-               </li>
+          </t>
+        </li>
         <li pn="section-4-1.4">
+          <t indent="0" pn="section-4-1.4.1">
                   Block quote this is converted to
                   <tt>&lt;list style="empty"&gt;</tt>
                   paragraph (<xref target="block-quote" format="default" sectionFormat="of" derivedContent="Section 7.5"/>); 
-               </li>
+          </t>
+        </li>
         <li pn="section-4-1.5">
           <t indent="0" pn="section-4-1.5.1">
                   References </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4-1.5.2">
             <li pn="section-4-1.5.2.1">
+              <t indent="0" pn="section-4-1.5.2.1.1">
                         external (eref) (<xref target="external" format="default" sectionFormat="of" derivedContent="Section 7.6.1"/>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-4-1.5.2.2">
               <t indent="0" pn="section-4-1.5.2.2.1">
                         internal (xref) (<xref target="internal" format="default" sectionFormat="of" derivedContent="Section 7.6.2"/>), you can refer to: </t>
               <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4-1.5.2.2.2">
                 <li pn="section-4-1.5.2.2.2.1">
+                  <t indent="0" pn="section-4-1.5.2.2.2.1.1">
                               section (handled by Pandoc, see <xref target="references-1" format="default" sectionFormat="of" derivedContent="Section 7.6"/>)); 
-                           </li>
+                  </t>
+                </li>
                 <li pn="section-4-1.5.2.2.2.2">
+                  <t indent="0" pn="section-4-1.5.2.2.2.2.1">
                               figures (handled by XSLT, see <xref target="references" format="default" sectionFormat="of" derivedContent="Section 7.4.1"/>); 
-                           </li>
+                  </t>
+                </li>
                 <li pn="section-4-1.5.2.2.2.3">
+                  <t indent="0" pn="section-4-1.5.2.2.2.3.1">
                               tables (handled by XSLT, see <xref target="references-2" format="default" sectionFormat="of" derivedContent="Section 7.8.1"/>).  
-                           </li>
+                  </t>
+                </li>
               </ul>
             </li>
           </ul>
         </li>
         <li pn="section-4-1.6">
+          <t indent="0" pn="section-4-1.6.1">
                   Citations, by using internal references; 
-               </li>
+          </t>
+        </li>
         <li pn="section-4-1.7">
+          <t indent="0" pn="section-4-1.7.1">
                   Spanx style=verb, style=emph and style=strong (<xref target="spanx-styles" format="default" sectionFormat="of" derivedContent="Section 7.7"/>); 
-               </li>
+          </t>
+        </li>
         <li pn="section-4-1.8">
+          <t indent="0" pn="section-4-1.8.1">
                   Tables with an anchor and title (<xref target="tables" format="default" sectionFormat="of" derivedContent="Section 7.8"/>); 
-               </li>
+          </t>
+        </li>
         <li pn="section-4-1.9">
+          <t indent="0" pn="section-4-1.9.1">
                   Indexes, by using footnotes (<xref target="indexes" format="default" sectionFormat="of" derivedContent="Section 7.9"/>).  
-               </li>
+          </t>
+        </li>
       </ul>
     </section>
     <section anchor="unsupported-features" toc="include" numbered="true" removeInRFC="false" pn="section-5">
       <name slugifiedName="name-unsupported-features">Unsupported Features</name>
       <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-5-1">
         <li pn="section-5-1.1">
+          <t indent="0" pn="section-5-1.1.1">
                   Lists inside a table (<tt>xml2rfc</tt> doesn't handle this); 
-               </li>
+          </t>
+        </li>
         <li pn="section-5-1.2">
+          <t indent="0" pn="section-5-1.2.1">
                   Pandoc markup in the caption for figures/artwork. Pandoc markup for table captions <em>is</em> supported; 
-               </li>
+          </t>
+        </li>
         <li pn="section-5-1.3">
+          <t indent="0" pn="section-5-1.3.1">
                   crefs: for comments (no input syntax available), use HTML comments: <tt>&lt;!-- ... --&gt;</tt>; 
-               </li>
+          </t>
+        </li>
       </ul>
     </section>
     <section anchor="acknowledgements" toc="include" numbered="true" removeInRFC="false" pn="section-6">
@@ -621,11 +683,15 @@ A symbol list.
           </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-7.3.1-3">
             <li pn="section-7.3.1-3.1">
+              <t indent="0" pn="section-7.3.1-3.1.1">
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.3.1-3.2">
+              <t indent="0" pn="section-7.3.1-3.2.1">
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ul>
         </section>
         <section anchor="number" toc="include" numbered="true" removeInRFC="false" pn="section-7.3.2">
@@ -640,11 +706,15 @@ A numbered list.
                   Converts to <tt>&lt;list style="numbers"&gt;</tt>: 
           </t>
           <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-7.3.2-3"><li pn="section-7.3.2-3.1" derivedCounter="1.">
+              <t indent="0" pn="section-7.3.2-3.1.1">
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.3.2-3.2" derivedCounter="2.">
+              <t indent="0" pn="section-7.3.2-3.2.1">
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
         </section>
         <section anchor="empty" toc="include" numbered="true" removeInRFC="false" pn="section-7.3.3">
@@ -663,11 +733,15 @@ A list using the default list markers.
           </t>
           <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-7.3.3-4">
             <li pn="section-7.3.3-4.1">
+              <t indent="0" pn="section-7.3.3-4.1.1">
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.3.3-4.2">
+              <t indent="0" pn="section-7.3.3-4.2.1">
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ul>
         </section>
         <section anchor="roman" toc="include" numbered="true" removeInRFC="false" pn="section-7.3.4">
@@ -683,11 +757,15 @@ ii. Item two.
                   Converts to <tt>&lt;list style="format %i."&gt;</tt>: 
           </t>
           <ol spacing="normal" type="%i." indent="adaptive" start="1" pn="section-7.3.4-4"><li pn="section-7.3.4-4.1" derivedCounter="i.">
+              <t indent="0" pn="section-7.3.4-4.1.1">
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.3.4-4.2" derivedCounter="ii.">
+              <t indent="0" pn="section-7.3.4-4.2.1">
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
           <t indent="0" pn="section-7.3.4-5">
                   If you use uppercase Roman numerals, they convert to a different style: 
@@ -700,11 +778,15 @@ II. Item two.
                   Yields <tt>&lt;list style="format (%d) "&gt;</tt>: 
           </t>
           <ol spacing="normal" type="(%d)" indent="adaptive" start="1" pn="section-7.3.4-8"><li pn="section-7.3.4-8.1" derivedCounter="(1)">
+              <t indent="0" pn="section-7.3.4-8.1.1">
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.3.4-8.2" derivedCounter="(2)">
+              <t indent="0" pn="section-7.3.4-8.2.1">
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
         </section>
         <section anchor="letter" toc="include" numbered="true" removeInRFC="false" pn="section-7.3.5">
@@ -720,11 +802,15 @@ b.  Item two.
                   Converts to <tt>&lt;list style="letters"&gt;</tt>: 
           </t>
           <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-7.3.5-4"><li pn="section-7.3.5-4.1" derivedCounter="a.">
+              <t indent="0" pn="section-7.3.5-4.1.1">
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.3.5-4.2" derivedCounter="b.">
+              <t indent="0" pn="section-7.3.5-4.2.1">
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
           <t indent="0" pn="section-7.3.5-5">
                   Uppercasing the letters works too (note two spaces after the letter.  
@@ -737,11 +823,15 @@ B.  Item two.
                   Becomes: 
           </t>
           <ol spacing="normal" type="%C." indent="adaptive" start="1" pn="section-7.3.5-8"><li pn="section-7.3.5-8.1" derivedCounter="A.">
+              <t indent="0" pn="section-7.3.5-8.1.1">
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.3.5-8.2" derivedCounter="B.">
+              <t indent="0" pn="section-7.3.5-8.2.1">
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
         </section>
         <section anchor="hanging" toc="include" numbered="true" removeInRFC="false" pn="section-7.3.6">
@@ -801,17 +891,23 @@ Like this
           </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-7.4.1-2">
             <li pn="section-7.4.1-2.1">
+              <t indent="0" pn="section-7.4.1-2.1.1">
                         Take the first 10 characters of the caption (i.e. this is the text
                         <em>after</em> the string
                         <tt>@Figure:</tt>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.4.1-2.2">
+              <t indent="0" pn="section-7.4.1-2.2.1">
                         Spaces and single quotes (') are translated to a minus
                         <tt>-</tt>; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.4.1-2.3">
+              <t indent="0" pn="section-7.4.1-2.3.1">
                         Uppercase letters translated to lowercase.  
-                     </li>
+              </t>
+            </li>
           </ul>
           <t indent="0" pn="section-7.4.1-3">
                   So the first artwork with a caption will get
@@ -946,17 +1042,23 @@ See [](#pandoc-constructs)
           </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-7.8.1-2">
             <li pn="section-7.8.1-2.1">
+              <t indent="0" pn="section-7.8.1-2.1.1">
                         Take the first 10 characters of the caption (i.e. this is the text
                         <em>after</em> the string
                         <tt>Table:</tt>); 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.8.1-2.2">
+              <t indent="0" pn="section-7.8.1-2.2.1">
                         Spaces and single quotes (') are translated to a minus
                         <tt>-</tt>; 
-                     </li>
+              </t>
+            </li>
             <li pn="section-7.8.1-2.3">
+              <t indent="0" pn="section-7.8.1-2.3.1">
                         Uppercase letters translated to lowercase.  
-                     </li>
+              </t>
+            </li>
           </ul>
           <t indent="0" pn="section-7.8.1-3">
                   So the first table with a caption will get
@@ -1114,10 +1216,12 @@ draft-gieben-writing-rfcs-pandoc-00.txt -> draft.txt
               </t>
               <ul empty="true" spacing="normal" bare="false" indent="3">
                 <li>
+                  <t indent="0">
                            The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
                            "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
                            document are to be interpreted as described in RFC 2119.  
-                        </li>
+                  </t>
+                </li>
               </ul>
               <t indent="0">
                      Note that the force of these words is modified by the requirement level of
@@ -1185,8 +1289,10 @@ draft-gieben-writing-rfcs-pandoc-00.txt -> draft.txt
         <name slugifiedName="name-blockquote">Blockquote</name>
         <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-appendix.a.3-1">
           <li pn="section-appendix.a.3-1.1">
+            <t indent="0" pn="section-appendix.a.3-1.1.1">
                      This is a blockquote, how does it look? 
-                  </li>
+            </t>
+          </li>
         </ul>
       </section>
       <section anchor="verbatim-code-blocks" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.4">
@@ -1206,34 +1312,48 @@ jkasjksajassjasjsajsajkas
         <name slugifiedName="name-spanx-tests">Spanx Tests</name>
         <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-appendix.a.6-1">
           <li pn="section-appendix.a.6-1.1">
+            <t indent="0" pn="section-appendix.a.6-1.1.1">
                      underscores: <em>underscores</em>
+            </t>
           </li>
           <li pn="section-appendix.a.6-1.2">
+            <t indent="0" pn="section-appendix.a.6-1.2.1">
                      asterisks: <em>asterisks</em>
+            </t>
           </li>
           <li pn="section-appendix.a.6-1.3">
+            <t indent="0" pn="section-appendix.a.6-1.3.1">
                      double asterisks: <strong>double asterisks</strong>
+            </t>
           </li>
           <li pn="section-appendix.a.6-1.4">
+            <t indent="0" pn="section-appendix.a.6-1.4.1">
                      backticks: <tt>backticks</tt>
+            </t>
           </li>
         </ul>
       </section>
       <section anchor="list-tests" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.7">
         <name slugifiedName="name-list-tests">List Tests</name>
         <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-1"><li pn="section-appendix.a.7-1.1" derivedCounter="1.">
+            <t indent="0" pn="section-appendix.a.7-1.1.1">
                      First we do 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-1.2" derivedCounter="2.">
             <t indent="0" pn="section-appendix.a.7-1.2.1">
                      And then </t>
             <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-appendix.a.7-1.2.2">
               <li pn="section-appendix.a.7-1.2.2.1">
+                <t indent="0" pn="section-appendix.a.7-1.2.2.1.1">
                            item 1 
-                        </li>
+                </t>
+              </li>
               <li pn="section-appendix.a.7-1.2.2.2">
+                <t indent="0" pn="section-appendix.a.7-1.2.2.2.1">
                            item 2 
-                        </li>
+                </t>
+              </li>
             </ul>
           </li>
         </ol>
@@ -1242,17 +1362,23 @@ jkasjksajassjasjsajsajkas
         </t>
         <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-appendix.a.7-3">
           <li pn="section-appendix.a.7-3.1">
+            <t indent="0" pn="section-appendix.a.7-3.1.1">
                      First we do 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-3.2">
             <t indent="0" pn="section-appendix.a.7-3.2.1">
                      Then </t>
             <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-3.2.2"><li pn="section-appendix.a.7-3.2.2.1" derivedCounter="1.">
+                <t indent="0" pn="section-appendix.a.7-3.2.2.1.1">
                            Something 
-                        </li>
+                </t>
+              </li>
               <li pn="section-appendix.a.7-3.2.2.2" derivedCounter="2.">
+                <t indent="0" pn="section-appendix.a.7-3.2.2.2.1">
                            Another thing 
-                        </li>
+                </t>
+              </li>
             </ol>
           </li>
         </ul>
@@ -1278,11 +1404,15 @@ jkasjksajassjasjsajsajkas
           <dd pn="section-appendix.a.7-7.2">
             <t indent="0" pn="section-appendix.a.7-7.2.1">It works because of </t>
             <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-7.2.2"><li pn="section-appendix.a.7-7.2.2.1" derivedCounter="1.">
+                <t indent="0" pn="section-appendix.a.7-7.2.2.1.1">
                         One 
-                     </li>
+                </t>
+              </li>
               <li pn="section-appendix.a.7-7.2.2.2" derivedCounter="2.">
+                <t indent="0" pn="section-appendix.a.7-7.2.2.2.1">
                         Two 
-                     </li>
+                </t>
+              </li>
             </ol>
           </dd>
           <dt pn="section-appendix.a.7-7.3">Another item to explain:</dt>
@@ -1292,18 +1422,24 @@ jkasjksajassjasjsajsajkas
           <dd pn="section-appendix.a.7-7.6">
             <t indent="0" pn="section-appendix.a.7-7.6.1">It works because of </t>
             <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-7.6.2"><li pn="section-appendix.a.7-7.6.2.1" derivedCounter="1.">
+                <t indent="0" pn="section-appendix.a.7-7.6.2.1.1">
                         One1 
-                     </li>
+                </t>
+              </li>
               <li pn="section-appendix.a.7-7.6.2.2" derivedCounter="2.">
                 <t indent="0" pn="section-appendix.a.7-7.6.2.2.1">
                         Two1 </t>
                 <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-appendix.a.7-7.6.2.2.2">
                   <li pn="section-appendix.a.7-7.6.2.2.2.1">
+                    <t indent="0" pn="section-appendix.a.7-7.6.2.2.2.1.1">
                               Itemize list 
-                           </li>
+                    </t>
+                  </li>
                   <li pn="section-appendix.a.7-7.6.2.2.2.2">
+                    <t indent="0" pn="section-appendix.a.7-7.6.2.2.2.2.1">
                               Another item 
-                           </li>
+                    </t>
+                  </li>
                 </ul>
               </li>
             </ol>
@@ -1328,8 +1464,10 @@ jkasjksajassjasjsajsajkas
             </dl>
           </li>
           <li pn="section-appendix.a.7-9.2" derivedCounter="2.">
+            <t indent="0" pn="section-appendix.a.7-9.2.1">
                      Go'bye 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t indent="0" pn="section-appendix.a.7-10">
                Multiple paragraphs in a list.  
@@ -1342,8 +1480,10 @@ jkasjksajassjasjsajsajkas
             </t>
           </li>
           <li pn="section-appendix.a.7-11.2" derivedCounter="2.">
+            <t indent="0" pn="section-appendix.a.7-11.2.1">
                      This is the next bullet. New paragraphs should be indented with 4 four spaces.  
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-11.3" derivedCounter="3.">
             <t indent="0" pn="section-appendix.a.7-11.3.1">
                      Another item with some artwork, indented by 8 spaces.
@@ -1353,8 +1493,10 @@ Artwork
                         ]]></artwork>
           </li>
           <li pn="section-appendix.a.7-11.4" derivedCounter="4.">
+            <t indent="0" pn="section-appendix.a.7-11.4.1">
                      Final item.  
-                  </li>
+            </t>
+          </li>
         </ol>
         <t indent="0" pn="section-appendix.a.7-12">
                xml2rfc does not allow this, so the second paragraph is faked with a 
@@ -1366,34 +1508,48 @@ Artwork
                Ordered lists.  
         </t>
         <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-15"><li pn="section-appendix.a.7-15.1" derivedCounter="1.">
+            <t indent="0" pn="section-appendix.a.7-15.1.1">
                      First item 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-15.2" derivedCounter="2.">
+            <t indent="0" pn="section-appendix.a.7-15.2.1">
                      Second item 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t indent="0" pn="section-appendix.a.7-16">
                A lowercase roman list: 
         </t>
         <ol spacing="normal" type="%i." indent="adaptive" start="1" pn="section-appendix.a.7-17"><li pn="section-appendix.a.7-17.1" derivedCounter="i.">
+            <t indent="0" pn="section-appendix.a.7-17.1.1">
                      Item 1 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-17.2" derivedCounter="ii.">
+            <t indent="0" pn="section-appendix.a.7-17.2.1">
                      Item 2 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t indent="0" pn="section-appendix.a.7-18">
                An uppercase roman list.  
         </t>
         <ol spacing="normal" type="(%d)" indent="adaptive" start="1" pn="section-appendix.a.7-19"><li pn="section-appendix.a.7-19.1" derivedCounter="(1)">
+            <t indent="0" pn="section-appendix.a.7-19.1.1">
                      Item1 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-19.2" derivedCounter="(2)">
+            <t indent="0" pn="section-appendix.a.7-19.2.1">
                      Item2 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-19.3" derivedCounter="(3)">
+            <t indent="0" pn="section-appendix.a.7-19.3.1">
                      Item 3 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t indent="0" pn="section-appendix.a.7-20">
                And default list markers.<iref item="list" subitem="default markers" primary="false" pn="iref-list-default-markers-1"/>
@@ -1403,17 +1559,23 @@ Artwork
         </t>
         <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-appendix.a.7-22">
           <li pn="section-appendix.a.7-22.1">
+            <t indent="0" pn="section-appendix.a.7-22.1.1">
                      First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.  
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-22.2">
+            <t indent="0" pn="section-appendix.a.7-22.2.1">
                      Second item. So this is the second para in your list. Enjoy; 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-22.3">
+            <t indent="0" pn="section-appendix.a.7-22.3.1">
                      Another item.  
-                  </li>
+            </t>
+          </li>
         </ul>
         <t indent="0" pn="section-appendix.a.7-23">
                Text at the end.  
@@ -1422,21 +1584,29 @@ Artwork
                Lowercase letters list.  
         </t>
         <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-appendix.a.7-25"><li pn="section-appendix.a.7-25.1" derivedCounter="a.">
+            <t indent="0" pn="section-appendix.a.7-25.1.1">
                      First item 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-25.2" derivedCounter="b.">
+            <t indent="0" pn="section-appendix.a.7-25.2.1">
                      Second item 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t indent="0" pn="section-appendix.a.7-26">
                Uppercase letters list.  
         </t>
         <ol spacing="normal" type="%C." indent="adaptive" start="1" pn="section-appendix.a.7-27"><li pn="section-appendix.a.7-27.1" derivedCounter="A.">
+            <t indent="0" pn="section-appendix.a.7-27.1.1">
                      First item 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-27.2" derivedCounter="B.">
+            <t indent="0" pn="section-appendix.a.7-27.2.1">
                      Second item 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t indent="0" pn="section-appendix.a.7-28">
                <iref item="list" subitem="Uppercase Letters" primary="false" pn="iref-list-uppercase-letters-2"/>
@@ -1467,21 +1637,29 @@ a.miek.nl.  IN  A   192.0.2.1    ; <- this is glue
                List with a sublist with a paragraph above the sublist 
         </t>
         <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-32"><li pn="section-appendix.a.7-32.1" derivedCounter="1.">
+            <t indent="0" pn="section-appendix.a.7-32.1.1">
                      First Item 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-32.2" derivedCounter="2.">
+            <t indent="0" pn="section-appendix.a.7-32.2.1">
                      Second item 
-                  </li>
+            </t>
+          </li>
           <li pn="section-appendix.a.7-32.3" derivedCounter="3.">
             <t indent="0" pn="section-appendix.a.7-32.3.1">
                      Third item </t>
             <t indent="0" pn="section-appendix.a.7-32.3.2"> A paragraph that comes first </t>
             <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-appendix.a.7-32.3.3"><li pn="section-appendix.a.7-32.3.3.1" derivedCounter="a.">
+                <t indent="0" pn="section-appendix.a.7-32.3.3.1.1">
                            But what do you know 
-                        </li>
+                </t>
+              </li>
               <li pn="section-appendix.a.7-32.3.3.2" derivedCounter="b.">
+                <t indent="0" pn="section-appendix.a.7-32.3.3.2.1">
                            This is another list 
-                        </li>
+                </t>
+              </li>
             </ol>
           </li>
         </ol>
@@ -1621,8 +1799,10 @@ See [](#tab-here-s-the)
                This is another example: 
         </t>
         <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.9-2"><li pn="section-appendix.a.9-2.1" derivedCounter="1.">
+            <t indent="0" pn="section-appendix.a.9-2.1.1">
                      Another bla bla..  
-                  </li>
+            </t>
+          </li>
         </ol>
         <t indent="0" pn="section-appendix.a.9-3">
                as (1) shows...  

--- a/tests/valid/draft-miek-test.v2v3.xml
+++ b/tests/valid/draft-miek-test.v2v3.xml
@@ -6,7 +6,7 @@
   <!ENTITY wj     "&#8288;">
 ]>
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" ipr="trust200902" category="info" docName="draft-gieben-writing-rfcs-pandoc-02" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" symRefs="true" sortRefs="true" version="3">
-  <!-- xml2rfc v2v3 conversion 3.12.10 -->
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   <!--generate a table of contents -->
    <!--use anchors instead of numbers for references -->
    <!--alphabetize the references -->
@@ -72,17 +72,21 @@
       </t>
       <ul empty="true" spacing="normal">
         <li>
+          <t>
                   Note: this document is typeset in Pandoc and does not render
                   completely correct when reading it on github.  
-               </li>
+          </t>
+        </li>
       </ul>
     </section>
     <section anchor="pandoc-to-rfc" toc="default" numbered="true">
       <name>Pandoc to RFC</name>
       <ul empty="true" spacing="normal">
         <li>
+          <t>
                   Pandoc2rfc -- designed to do the right thing, until it doesn't.  
-               </li>
+          </t>
+        </li>
       </ul>
       <t>
             When writing <xref target="RFC4641" format="default"/>
@@ -171,14 +175,20 @@ non-existent  |                       | xsltproc
             edit 3 documents: 
       </t>
       <ol spacing="normal" type="1"><li>
+          <t>
                   middle.pdc - contains the main body of text; 
-               </li>
+          </t>
+        </li>
         <li>
+          <t>
                   back.pdc - holds appendices and references; 
-               </li>
+          </t>
+        </li>
         <li>
+          <t>
                   template.xml (probably a fairly static file).  
-               </li>
+          </t>
+        </li>
       </ol>
       <t>
             The draft
@@ -218,23 +228,33 @@ non-existent  |                       | xsltproc
       </t>
       <ul spacing="normal">
         <li>
-          <tt>Makefile</tt>
+          <t>
+                  <tt>Makefile</tt>
+          </t>
         </li>
         <li>
-          <tt>transform.xslt</tt>
+          <t>
+                  <tt>transform.xslt</tt>
+          </t>
         </li>
         <li>
           <t>
                   And the above mentioned files: </t>
           <ul spacing="normal">
             <li>
-              <tt>middle.pdc</tt>
+              <t>
+                        <tt>middle.pdc</tt>
+              </t>
             </li>
             <li>
-              <tt>back.pdc</tt>
+              <t>
+                        <tt>back.pdc</tt>
+              </t>
             </li>
             <li>
-              <tt>template.xml</tt>
+              <t>
+                        <tt>template.xml</tt>
+              </t>
             </li>
           </ul>
         </li>
@@ -247,94 +267,136 @@ non-existent  |                       | xsltproc
       <name>Supported Features</name>
       <ul spacing="normal">
         <li>
+          <t>
                   Sections with an anchor and title attributes
 		  (<xref target="section" format="default"/>); 
-               </li>
+          </t>
+        </li>
         <li>
           <t>
                   Lists </t>
           <ul spacing="normal">
             <li>
+              <t>
                         style=symbols (<xref target="symbol" format="default"/>); 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         style=numbers (<xref target="number" format="default"/>); 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         style=empty (<xref target="empty" format="default"/>); 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         style=format %i, use roman lowercase numerals, (<xref target="roman" format="default"/>); 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         style=format (%d), use roman uppercase numerals (<xref target="roman" format="default"/>); 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         style=letters (lower- and uppercase, <xref target="letter" format="default"/>); 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         style=hanging (<xref target="hanging" format="default"/>); 
-                     </li>
+              </t>
+            </li>
           </ul>
         </li>
         <li>
+          <t>
                   Figure/artwork with a title (<xref target="figureartwork" format="default"/>); 
-               </li>
+          </t>
+        </li>
         <li>
+          <t>
                   Block quote this is converted to
                   <tt>&lt;list style="empty"&gt;</tt>
                   paragraph (<xref target="block-quote" format="default"/>); 
-               </li>
+          </t>
+        </li>
         <li>
           <t>
                   References </t>
           <ul spacing="normal">
             <li>
+              <t>
                         external (eref) (<xref target="external" format="default"/>); 
-                     </li>
+              </t>
+            </li>
             <li>
               <t>
                         internal (xref) (<xref target="internal" format="default"/>), you can refer to: </t>
               <ul spacing="normal">
                 <li>
+                  <t>
                               section (handled by Pandoc, see <xref target="references-1" format="default"/>)); 
-                           </li>
+                  </t>
+                </li>
                 <li>
+                  <t>
                               figures (handled by XSLT, see <xref target="references" format="default"/>); 
-                           </li>
+                  </t>
+                </li>
                 <li>
+                  <t>
                               tables (handled by XSLT, see <xref target="references-2" format="default"/>).  
-                           </li>
+                  </t>
+                </li>
               </ul>
             </li>
           </ul>
         </li>
         <li>
+          <t>
                   Citations, by using internal references; 
-               </li>
+          </t>
+        </li>
         <li>
+          <t>
                   Spanx style=verb, style=emph and style=strong (<xref target="spanx-styles" format="default"/>); 
-               </li>
+          </t>
+        </li>
         <li>
+          <t>
                   Tables with an anchor and title (<xref target="tables" format="default"/>); 
-               </li>
+          </t>
+        </li>
         <li>
+          <t>
                   Indexes, by using footnotes (<xref target="indexes" format="default"/>).  
-               </li>
+          </t>
+        </li>
       </ul>
     </section>
     <section anchor="unsupported-features" toc="default" numbered="true">
       <name>Unsupported Features</name>
       <ul spacing="normal">
         <li>
+          <t>
                   Lists inside a table (<tt>xml2rfc</tt> doesn't handle this); 
-               </li>
+          </t>
+        </li>
         <li>
+          <t>
                   Pandoc markup in the caption for figures/artwork. Pandoc markup for table captions <em>is</em> supported; 
-               </li>
+          </t>
+        </li>
         <li>
+          <t>
                   crefs: for comments (no input syntax available), use HTML comments: <tt>&lt;!-- ... --&gt;</tt>; 
-               </li>
+          </t>
+        </li>
       </ul>
     </section>
     <section anchor="acknowledgements" toc="default" numbered="true">
@@ -402,11 +464,15 @@ A symbol list.
           </t>
           <ul spacing="normal">
             <li>
+              <t>
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ul>
         </section>
         <section anchor="number" toc="default" numbered="true">
@@ -421,11 +487,15 @@ A numbered list.
                   Converts to <tt>&lt;list style="numbers"&gt;</tt>: 
           </t>
           <ol spacing="normal" type="1"><li>
+              <t>
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
         </section>
         <section anchor="empty" toc="default" numbered="true">
@@ -444,11 +514,15 @@ A list using the default list markers.
           </t>
           <ul empty="true" spacing="normal">
             <li>
+              <t>
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ul>
         </section>
         <section anchor="roman" toc="default" numbered="true">
@@ -464,11 +538,15 @@ ii. Item two.
                   Converts to <tt>&lt;list style="format %i."&gt;</tt>: 
           </t>
           <ol spacing="normal" type="%i."><li>
+              <t>
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
           <t>
                   If you use uppercase Roman numerals, they convert to a different style: 
@@ -481,11 +559,15 @@ II. Item two.
                   Yields <tt>&lt;list style="format (%d) "&gt;</tt>: 
           </t>
           <ol spacing="normal" type="(%d)"><li>
+              <t>
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
         </section>
         <section anchor="letter" toc="default" numbered="true">
@@ -501,11 +583,15 @@ b.  Item two.
                   Converts to <tt>&lt;list style="letters"&gt;</tt>: 
           </t>
           <ol spacing="normal" type="a"><li>
+              <t>
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
           <t>
                   Uppercasing the letters works too (note two spaces after the letter.  
@@ -518,11 +604,15 @@ B.  Item two.
                   Becomes: 
           </t>
           <ol spacing="normal" type="%C."><li>
+              <t>
                         Item one; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Item two.  
-                     </li>
+              </t>
+            </li>
           </ol>
         </section>
         <section anchor="hanging" toc="default" numbered="true">
@@ -582,17 +672,23 @@ Like this
           </t>
           <ul spacing="normal">
             <li>
+              <t>
                         Take the first 10 characters of the caption (i.e. this is the text
                         <em>after</em> the string
                         <tt>@Figure:</tt>); 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Spaces and single quotes (') are translated to a minus
                         <tt>-</tt>; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Uppercase letters translated to lowercase.  
-                     </li>
+              </t>
+            </li>
           </ul>
           <t>
                   So the first artwork with a caption will get
@@ -727,17 +823,23 @@ See [](#pandoc-constructs)
           </t>
           <ul spacing="normal">
             <li>
+              <t>
                         Take the first 10 characters of the caption (i.e. this is the text
                         <em>after</em> the string
                         <tt>Table:</tt>); 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Spaces and single quotes (') are translated to a minus
                         <tt>-</tt>; 
-                     </li>
+              </t>
+            </li>
             <li>
+              <t>
                         Uppercase letters translated to lowercase.  
-                     </li>
+              </t>
+            </li>
           </ul>
           <t>
                   So the first table with a caption will get
@@ -898,8 +1000,10 @@ draft-gieben-writing-rfcs-pandoc-00.txt -> draft.txt
         <name>Blockquote</name>
         <ul empty="true" spacing="normal">
           <li>
+            <t>
                      This is a blockquote, how does it look? 
-                  </li>
+            </t>
+          </li>
         </ul>
       </section>
       <section anchor="verbatim-code-blocks" toc="default" numbered="true">
@@ -919,34 +1023,48 @@ jkasjksajassjasjsajsajkas
         <name>Spanx Tests</name>
         <ul empty="true" spacing="normal">
           <li>
+            <t>
                      underscores: <em>underscores</em>
+            </t>
           </li>
           <li>
+            <t>
                      asterisks: <em>asterisks</em>
+            </t>
           </li>
           <li>
+            <t>
                      double asterisks: <strong>double asterisks</strong>
+            </t>
           </li>
           <li>
+            <t>
                      backticks: <tt>backticks</tt>
+            </t>
           </li>
         </ul>
       </section>
       <section anchor="list-tests" toc="default" numbered="true">
         <name>List Tests</name>
         <ol spacing="normal" type="1"><li>
+            <t>
                      First we do 
-                  </li>
+            </t>
+          </li>
           <li>
             <t>
                      And then </t>
             <ul spacing="normal">
               <li>
+                <t>
                            item 1 
-                        </li>
+                </t>
+              </li>
               <li>
+                <t>
                            item 2 
-                        </li>
+                </t>
+              </li>
             </ul>
           </li>
         </ol>
@@ -955,17 +1073,23 @@ jkasjksajassjasjsajsajkas
         </t>
         <ul spacing="normal">
           <li>
+            <t>
                      First we do 
-                  </li>
+            </t>
+          </li>
           <li>
             <t>
                      Then </t>
             <ol spacing="normal" type="1"><li>
+                <t>
                            Something 
-                        </li>
+                </t>
+              </li>
               <li>
+                <t>
                            Another thing 
-                        </li>
+                </t>
+              </li>
             </ol>
           </li>
         </ul>
@@ -991,11 +1115,15 @@ jkasjksajassjasjsajsajkas
           <dd>
             <t>It works because of </t>
             <ol spacing="normal" type="1"><li>
+                <t>
                         One 
-                     </li>
+                </t>
+              </li>
               <li>
+                <t>
                         Two 
-                     </li>
+                </t>
+              </li>
             </ol>
           </dd>
           <dt>Another item to explain:</dt>
@@ -1005,18 +1133,24 @@ jkasjksajassjasjsajsajkas
           <dd>
             <t>It works because of </t>
             <ol spacing="normal" type="1"><li>
+                <t>
                         One1 
-                     </li>
+                </t>
+              </li>
               <li>
                 <t>
                         Two1 </t>
                 <ul spacing="normal">
                   <li>
+                    <t>
                               Itemize list 
-                           </li>
+                    </t>
+                  </li>
                   <li>
+                    <t>
                               Another item 
-                           </li>
+                    </t>
+                  </li>
                 </ul>
               </li>
             </ol>
@@ -1041,8 +1175,10 @@ jkasjksajassjasjsajsajkas
             </dl>
           </li>
           <li>
+            <t>
                      Go'bye 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t>
                Multiple paragraphs in a list.  
@@ -1055,8 +1191,10 @@ jkasjksajassjasjsajsajkas
             </t>
           </li>
           <li>
+            <t>
                      This is the next bullet. New paragraphs should be indented with 4 four spaces.  
-                  </li>
+            </t>
+          </li>
           <li>
             <t>
                      Another item with some artwork, indented by 8 spaces.
@@ -1066,8 +1204,10 @@ Artwork
                         ]]></artwork>
           </li>
           <li>
+            <t>
                      Final item.  
-                  </li>
+            </t>
+          </li>
         </ol>
         <t>
                xml2rfc does not allow this, so the second paragraph is faked with a 
@@ -1079,34 +1219,48 @@ Artwork
                Ordered lists.  
         </t>
         <ol spacing="normal" type="1"><li>
+            <t>
                      First item 
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Second item 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t>
                A lowercase roman list: 
         </t>
         <ol spacing="normal" type="%i."><li>
+            <t>
                      Item 1 
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Item 2 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t>
                An uppercase roman list.  
         </t>
         <ol spacing="normal" type="(%d)"><li>
+            <t>
                      Item1 
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Item2 
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Item 3 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t>
                And default list markers.<iref item="list" subitem="default markers" primary="false"/>
@@ -1116,17 +1270,23 @@ Artwork
         </t>
         <ul empty="true" spacing="normal">
           <li>
+            <t>
                      First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.  
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Second item. So this is the second para in your list. Enjoy; 
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Another item.  
-                  </li>
+            </t>
+          </li>
         </ul>
         <t>
                Text at the end.  
@@ -1135,21 +1295,29 @@ Artwork
                Lowercase letters list.  
         </t>
         <ol spacing="normal" type="a"><li>
+            <t>
                      First item 
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Second item 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t>
                Uppercase letters list.  
         </t>
         <ol spacing="normal" type="%C."><li>
+            <t>
                      First item 
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Second item 
-                  </li>
+            </t>
+          </li>
         </ol>
         <t>
                <iref item="list" subitem="Uppercase Letters" primary="false"/>
@@ -1180,21 +1348,29 @@ a.miek.nl.  IN  A   192.0.2.1    ; <- this is glue
                List with a sublist with a paragraph above the sublist 
         </t>
         <ol spacing="normal" type="1"><li>
+            <t>
                      First Item 
-                  </li>
+            </t>
+          </li>
           <li>
+            <t>
                      Second item 
-                  </li>
+            </t>
+          </li>
           <li>
             <t>
                      Third item </t>
             <t> A paragraph that comes first </t>
             <ol spacing="normal" type="a"><li>
+                <t>
                            But what do you know 
-                        </li>
+                </t>
+              </li>
               <li>
+                <t>
                            This is another list 
-                        </li>
+                </t>
+              </li>
             </ol>
           </li>
         </ol>
@@ -1334,8 +1510,10 @@ See [](#tab-here-s-the)
                This is another example: 
         </t>
         <ol spacing="normal" type="1"><li>
+            <t>
                      Another bla bla..  
-                  </li>
+            </t>
+          </li>
         </ol>
         <t>
                as (1) shows...  

--- a/tests/valid/draft-miek-test.v3.html
+++ b/tests/valid/draft-miek-test.v3.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.14.2" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -323,8 +323,9 @@
             well suited for editing RFC-like documents.<a href="#section-1-3" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="section-1-4.1">
+          <p id="section-1-4.1.1">
                   Note: this document is typeset in Pandoc and does not render
-                  completely correct when reading it on github.<a href="#section-1-4.1" class="pilcrow">¶</a>
+                  completely correct when reading it on github.<a href="#section-1-4.1.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 </section>
@@ -336,7 +337,8 @@
       </h2>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="section-2-1.1">
-                  Pandoc2rfc -- designed to do the right thing, until it doesn't.<a href="#section-2-1.1" class="pilcrow">¶</a>
+          <p id="section-2-1.1.1">
+                  Pandoc2rfc -- designed to do the right thing, until it doesn't.<a href="#section-2-1.1.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <p id="section-2-2">
@@ -432,13 +434,16 @@ non-existent  |                       | xsltproc
             edit 3 documents:<a href="#section-2-8" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-2-9">
 <li id="section-2-9.1">
-                  middle.pdc - contains the main body of text;<a href="#section-2-9.1" class="pilcrow">¶</a>
+          <p id="section-2-9.1.1">
+                  middle.pdc - contains the main body of text;<a href="#section-2-9.1.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-2-9.2">
-                  back.pdc - holds appendices and references;<a href="#section-2-9.2" class="pilcrow">¶</a>
+          <p id="section-2-9.2.1">
+                  back.pdc - holds appendices and references;<a href="#section-2-9.2.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-2-9.3">
-                  template.xml (probably a fairly static file).<a href="#section-2-9.3" class="pilcrow">¶</a>
+          <p id="section-2-9.3.1">
+                  template.xml (probably a fairly static file).<a href="#section-2-9.3.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <p id="section-2-10">
@@ -485,23 +490,28 @@ non-existent  |                       | xsltproc
             need to copy the following files:<a href="#section-3-1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-3-2.1">
-          <code>Makefile</code><a href="#section-3-2.1" class="pilcrow">¶</a>
+          <p id="section-3-2.1.1">
+                  <code>Makefile</code><a href="#section-3-2.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-3-2.2">
-          <code>transform.xslt</code><a href="#section-3-2.2" class="pilcrow">¶</a>
+          <p id="section-3-2.2.1">
+                  <code>transform.xslt</code><a href="#section-3-2.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-3-2.3">
           <p id="section-3-2.3.1">
                   And the above mentioned files:<a href="#section-3-2.3.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-3-2.3.2.1">
-              <code>middle.pdc</code><a href="#section-3-2.3.2.1" class="pilcrow">¶</a>
+              <p id="section-3-2.3.2.1.1">
+                        <code>middle.pdc</code><a href="#section-3-2.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-3-2.3.2.2">
-              <code>back.pdc</code><a href="#section-3-2.3.2.2" class="pilcrow">¶</a>
+              <p id="section-3-2.3.2.2.1">
+                        <code>back.pdc</code><a href="#section-3-2.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-3-2.3.2.3">
-              <code>template.xml</code><a href="#section-3-2.3.2.3" class="pilcrow">¶</a>
+              <p id="section-3-2.3.2.3.1">
+                        <code>template.xml</code><a href="#section-3-2.3.2.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>
@@ -517,79 +527,97 @@ non-existent  |                       | xsltproc
       </h2>
 <ul class="normal">
 <li class="normal" id="section-4-1.1">
+          <p id="section-4-1.1.1">
                   Sections with an anchor and title attributes
-   (<a href="#section" class="auto internal xref">Section 7.2</a>);<a href="#section-4-1.1" class="pilcrow">¶</a>
+   (<a href="#section" class="auto internal xref">Section 7.2</a>);<a href="#section-4-1.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.2">
           <p id="section-4-1.2.1">
                   Lists<a href="#section-4-1.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4-1.2.2.1">
-                        style=symbols (<a href="#symbol" class="auto internal xref">Section 7.3.1</a>);<a href="#section-4-1.2.2.1" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.1.1">
+                        style=symbols (<a href="#symbol" class="auto internal xref">Section 7.3.1</a>);<a href="#section-4-1.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.2">
-                        style=numbers (<a href="#number" class="auto internal xref">Section 7.3.2</a>);<a href="#section-4-1.2.2.2" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.2.1">
+                        style=numbers (<a href="#number" class="auto internal xref">Section 7.3.2</a>);<a href="#section-4-1.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.3">
-                        style=empty (<a href="#empty" class="auto internal xref">Section 7.3.3</a>);<a href="#section-4-1.2.2.3" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.3.1">
+                        style=empty (<a href="#empty" class="auto internal xref">Section 7.3.3</a>);<a href="#section-4-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.4">
-                        style=format %i, use roman lowercase numerals, (<a href="#roman" class="auto internal xref">Section 7.3.4</a>);<a href="#section-4-1.2.2.4" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.4.1">
+                        style=format %i, use roman lowercase numerals, (<a href="#roman" class="auto internal xref">Section 7.3.4</a>);<a href="#section-4-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.5">
-                        style=format (%d), use roman uppercase numerals (<a href="#roman" class="auto internal xref">Section 7.3.4</a>);<a href="#section-4-1.2.2.5" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.5.1">
+                        style=format (%d), use roman uppercase numerals (<a href="#roman" class="auto internal xref">Section 7.3.4</a>);<a href="#section-4-1.2.2.5.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.6">
-                        style=letters (lower- and uppercase, <a href="#letter" class="auto internal xref">Section 7.3.5</a>);<a href="#section-4-1.2.2.6" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.6.1">
+                        style=letters (lower- and uppercase, <a href="#letter" class="auto internal xref">Section 7.3.5</a>);<a href="#section-4-1.2.2.6.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.2.2.7">
-                        style=hanging (<a href="#hanging" class="auto internal xref">Section 7.3.6</a>);<a href="#section-4-1.2.2.7" class="pilcrow">¶</a>
+              <p id="section-4-1.2.2.7.1">
+                        style=hanging (<a href="#hanging" class="auto internal xref">Section 7.3.6</a>);<a href="#section-4-1.2.2.7.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>
         <li class="normal" id="section-4-1.3">
-                  Figure/artwork with a title (<a href="#figureartwork" class="auto internal xref">Section 7.4</a>);<a href="#section-4-1.3" class="pilcrow">¶</a>
+          <p id="section-4-1.3.1">
+                  Figure/artwork with a title (<a href="#figureartwork" class="auto internal xref">Section 7.4</a>);<a href="#section-4-1.3.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.4">
+          <p id="section-4-1.4.1">
                   Block quote this is converted to
                   <code>&lt;list style="empty"&gt;</code>
-                  paragraph (<a href="#block-quote" class="auto internal xref">Section 7.5</a>);<a href="#section-4-1.4" class="pilcrow">¶</a>
+                  paragraph (<a href="#block-quote" class="auto internal xref">Section 7.5</a>);<a href="#section-4-1.4.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.5">
           <p id="section-4-1.5.1">
                   References<a href="#section-4-1.5.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4-1.5.2.1">
-                        external (eref) (<a href="#external" class="auto internal xref">Section 7.6.1</a>);<a href="#section-4-1.5.2.1" class="pilcrow">¶</a>
+              <p id="section-4-1.5.2.1.1">
+                        external (eref) (<a href="#external" class="auto internal xref">Section 7.6.1</a>);<a href="#section-4-1.5.2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-4-1.5.2.2">
               <p id="section-4-1.5.2.2.1">
                         internal (xref) (<a href="#internal" class="auto internal xref">Section 7.6.2</a>), you can refer to:<a href="#section-4-1.5.2.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4-1.5.2.2.2.1">
-                              section (handled by Pandoc, see <a href="#references-1" class="auto internal xref">Section 7.6</a>));<a href="#section-4-1.5.2.2.2.1" class="pilcrow">¶</a>
+                  <p id="section-4-1.5.2.2.2.1.1">
+                              section (handled by Pandoc, see <a href="#references-1" class="auto internal xref">Section 7.6</a>));<a href="#section-4-1.5.2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
                 <li class="normal" id="section-4-1.5.2.2.2.2">
-                              figures (handled by XSLT, see <a href="#references" class="auto internal xref">Section 7.4.1</a>);<a href="#section-4-1.5.2.2.2.2" class="pilcrow">¶</a>
+                  <p id="section-4-1.5.2.2.2.2.1">
+                              figures (handled by XSLT, see <a href="#references" class="auto internal xref">Section 7.4.1</a>);<a href="#section-4-1.5.2.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
                 <li class="normal" id="section-4-1.5.2.2.2.3">
-                              tables (handled by XSLT, see <a href="#references-2" class="auto internal xref">Section 7.8.1</a>).<a href="#section-4-1.5.2.2.2.3" class="pilcrow">¶</a>
+                  <p id="section-4-1.5.2.2.2.3.1">
+                              tables (handled by XSLT, see <a href="#references-2" class="auto internal xref">Section 7.8.1</a>).<a href="#section-4-1.5.2.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
               </ul>
 </li>
           </ul>
 </li>
         <li class="normal" id="section-4-1.6">
-                  Citations, by using internal references;<a href="#section-4-1.6" class="pilcrow">¶</a>
+          <p id="section-4-1.6.1">
+                  Citations, by using internal references;<a href="#section-4-1.6.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.7">
-                  Spanx style=verb, style=emph and style=strong (<a href="#spanx-styles" class="auto internal xref">Section 7.7</a>);<a href="#section-4-1.7" class="pilcrow">¶</a>
+          <p id="section-4-1.7.1">
+                  Spanx style=verb, style=emph and style=strong (<a href="#spanx-styles" class="auto internal xref">Section 7.7</a>);<a href="#section-4-1.7.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.8">
-                  Tables with an anchor and title (<a href="#tables" class="auto internal xref">Section 7.8</a>);<a href="#section-4-1.8" class="pilcrow">¶</a>
+          <p id="section-4-1.8.1">
+                  Tables with an anchor and title (<a href="#tables" class="auto internal xref">Section 7.8</a>);<a href="#section-4-1.8.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-4-1.9">
-                  Indexes, by using footnotes (<a href="#indexes" class="auto internal xref">Section 7.9</a>).<a href="#section-4-1.9" class="pilcrow">¶</a>
+          <p id="section-4-1.9.1">
+                  Indexes, by using footnotes (<a href="#indexes" class="auto internal xref">Section 7.9</a>).<a href="#section-4-1.9.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 </section>
@@ -601,13 +629,16 @@ non-existent  |                       | xsltproc
       </h2>
 <ul class="normal">
 <li class="normal" id="section-5-1.1">
-                  Lists inside a table (<code>xml2rfc</code> doesn't handle this);<a href="#section-5-1.1" class="pilcrow">¶</a>
+          <p id="section-5-1.1.1">
+                  Lists inside a table (<code>xml2rfc</code> doesn't handle this);<a href="#section-5-1.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-5-1.2">
-                  Pandoc markup in the caption for figures/artwork. Pandoc markup for table captions <em>is</em> supported;<a href="#section-5-1.2" class="pilcrow">¶</a>
+          <p id="section-5-1.2.1">
+                  Pandoc markup in the caption for figures/artwork. Pandoc markup for table captions <em>is</em> supported;<a href="#section-5-1.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="section-5-1.3">
-                  crefs: for comments (no input syntax available), use HTML comments: <code>&lt;!-- ... --&gt;</code>;<a href="#section-5-1.3" class="pilcrow">¶</a>
+          <p id="section-5-1.3.1">
+                  crefs: for comments (no input syntax available), use HTML comments: <code>&lt;!-- ... --&gt;</code>;<a href="#section-5-1.3.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 </section>
@@ -692,10 +723,12 @@ A symbol list.
                   Converts to <code>&lt;list style="symbol"&gt;</code>:<a href="#section-7.3.1-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.3.1-3.1">
-                        Item one;<a href="#section-7.3.1-3.1" class="pilcrow">¶</a>
+              <p id="section-7.3.1-3.1.1">
+                        Item one;<a href="#section-7.3.1-3.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.3.1-3.2">
-                        Item two.<a href="#section-7.3.1-3.2" class="pilcrow">¶</a>
+              <p id="section-7.3.1-3.2.1">
+                        Item two.<a href="#section-7.3.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </section>
@@ -717,10 +750,12 @@ A numbered list.
                   Converts to <code>&lt;list style="numbers"&gt;</code>:<a href="#section-7.3.2-2" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-7.3.2-3">
 <li id="section-7.3.2-3.1">
-                        Item one;<a href="#section-7.3.2-3.1" class="pilcrow">¶</a>
+              <p id="section-7.3.2-3.1.1">
+                        Item one;<a href="#section-7.3.2-3.1.1" class="pilcrow">¶</a></p>
 </li>
             <li id="section-7.3.2-3.2">
-                        Item two.<a href="#section-7.3.2-3.2" class="pilcrow">¶</a>
+              <p id="section-7.3.2-3.2.1">
+                        Item two.<a href="#section-7.3.2-3.2.1" class="pilcrow">¶</a></p>
 </li>
           </ol>
 </section>
@@ -744,10 +779,12 @@ A list using the default list markers.
                   Converts to <code>&lt;list style="empty"&gt;</code>:<a href="#section-7.3.3-3" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="section-7.3.3-4.1">
-                        Item one;<a href="#section-7.3.3-4.1" class="pilcrow">¶</a>
+              <p id="section-7.3.3-4.1.1">
+                        Item one;<a href="#section-7.3.3-4.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal ulEmpty" id="section-7.3.3-4.2">
-                        Item two.<a href="#section-7.3.3-4.2" class="pilcrow">¶</a>
+              <p id="section-7.3.3-4.2.1">
+                        Item two.<a href="#section-7.3.3-4.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </section>
@@ -770,12 +807,14 @@ ii. Item two.
 <span class="break"></span><dl class="olPercent" id="section-7.3.4-4">
 <dt>i.</dt>
 <dd id="section-7.3.4-4.1">
-                        Item one;<a href="#section-7.3.4-4.1" class="pilcrow">¶</a>
+              <p id="section-7.3.4-4.1.1">
+                        Item one;<a href="#section-7.3.4-4.1.1" class="pilcrow">¶</a></p>
 </dd>
             <dd class="break"></dd>
 <dt>ii.</dt>
 <dd id="section-7.3.4-4.2">
-                        Item two.<a href="#section-7.3.4-4.2" class="pilcrow">¶</a>
+              <p id="section-7.3.4-4.2.1">
+                        Item two.<a href="#section-7.3.4-4.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 </dl>
@@ -792,12 +831,14 @@ II. Item two.
 <span class="break"></span><dl class="olPercent" id="section-7.3.4-8">
 <dt>(1)</dt>
 <dd id="section-7.3.4-8.1">
-                        Item one;<a href="#section-7.3.4-8.1" class="pilcrow">¶</a>
+              <p id="section-7.3.4-8.1.1">
+                        Item one;<a href="#section-7.3.4-8.1.1" class="pilcrow">¶</a></p>
 </dd>
             <dd class="break"></dd>
 <dt>(2)</dt>
 <dd id="section-7.3.4-8.2">
-                        Item two.<a href="#section-7.3.4-8.2" class="pilcrow">¶</a>
+              <p id="section-7.3.4-8.2.1">
+                        Item two.<a href="#section-7.3.4-8.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 </dl>
@@ -820,10 +861,12 @@ b.  Item two.
                   Converts to <code>&lt;list style="letters"&gt;</code>:<a href="#section-7.3.5-3" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="section-7.3.5-4">
 <li id="section-7.3.5-4.1">
-                        Item one;<a href="#section-7.3.5-4.1" class="pilcrow">¶</a>
+              <p id="section-7.3.5-4.1.1">
+                        Item one;<a href="#section-7.3.5-4.1.1" class="pilcrow">¶</a></p>
 </li>
             <li id="section-7.3.5-4.2">
-                        Item two.<a href="#section-7.3.5-4.2" class="pilcrow">¶</a>
+              <p id="section-7.3.5-4.2.1">
+                        Item two.<a href="#section-7.3.5-4.2.1" class="pilcrow">¶</a></p>
 </li>
           </ol>
 <p id="section-7.3.5-5">
@@ -839,12 +882,14 @@ B.  Item two.
 <span class="break"></span><dl class="olPercent" id="section-7.3.5-8">
 <dt>A.</dt>
 <dd id="section-7.3.5-8.1">
-                        Item one;<a href="#section-7.3.5-8.1" class="pilcrow">¶</a>
+              <p id="section-7.3.5-8.1.1">
+                        Item one;<a href="#section-7.3.5-8.1.1" class="pilcrow">¶</a></p>
 </dd>
             <dd class="break"></dd>
 <dt>B.</dt>
 <dd id="section-7.3.5-8.2">
-                        Item two.<a href="#section-7.3.5-8.2" class="pilcrow">¶</a>
+              <p id="section-7.3.5-8.2.1">
+                        Item two.<a href="#section-7.3.5-8.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 </dl>
@@ -916,16 +961,19 @@ Like this
                   Where normalized means:<a href="#section-7.4.1-1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.4.1-2.1">
+              <p id="section-7.4.1-2.1.1">
                         Take the first 10 characters of the caption (i.e. this is the text
                         <em>after</em> the string
-                        <code>@Figure:</code>);<a href="#section-7.4.1-2.1" class="pilcrow">¶</a>
+                        <code>@Figure:</code>);<a href="#section-7.4.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.4.1-2.2">
+              <p id="section-7.4.1-2.2.1">
                         Spaces and single quotes (') are translated to a minus
-                        <code>-</code>;<a href="#section-7.4.1-2.2" class="pilcrow">¶</a>
+                        <code>-</code>;<a href="#section-7.4.1-2.2.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.4.1-2.3">
-                        Uppercase letters translated to lowercase.<a href="#section-7.4.1-2.3" class="pilcrow">¶</a>
+              <p id="section-7.4.1-2.3.1">
+                        Uppercase letters translated to lowercase.<a href="#section-7.4.1-2.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 <p id="section-7.4.1-3">
@@ -1087,16 +1135,19 @@ See [](#pandoc-constructs)
                   Where normalized means:<a href="#section-7.8.1-1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-7.8.1-2.1">
+              <p id="section-7.8.1-2.1.1">
                         Take the first 10 characters of the caption (i.e. this is the text
                         <em>after</em> the string
-                        <code>Table:</code>);<a href="#section-7.8.1-2.1" class="pilcrow">¶</a>
+                        <code>Table:</code>);<a href="#section-7.8.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.8.1-2.2">
+              <p id="section-7.8.1-2.2.1">
                         Spaces and single quotes (') are translated to a minus
-                        <code>-</code>;<a href="#section-7.8.1-2.2" class="pilcrow">¶</a>
+                        <code>-</code>;<a href="#section-7.8.1-2.2.1" class="pilcrow">¶</a></p>
 </li>
             <li class="normal" id="section-7.8.1-2.3">
-                        Uppercase letters translated to lowercase.<a href="#section-7.8.1-2.3" class="pilcrow">¶</a>
+              <p id="section-7.8.1-2.3.1">
+                        Uppercase letters translated to lowercase.<a href="#section-7.8.1-2.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 <p id="section-7.8.1-3">
@@ -1309,7 +1360,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
         </h3>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="appendix-A.3-1.1">
-                     This is a blockquote, how does it look?<a href="#appendix-A.3-1.1" class="pilcrow">¶</a>
+            <p id="appendix-A.3-1.1.1">
+                     This is a blockquote, how does it look?<a href="#appendix-A.3-1.1.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 </section>
@@ -1343,16 +1395,20 @@ jkasjksajassjasjsajsajkas
         </h3>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="appendix-A.6-1.1">
-                     underscores: <em>underscores</em><a href="#appendix-A.6-1.1" class="pilcrow">¶</a>
+            <p id="appendix-A.6-1.1.1">
+                     underscores: <em>underscores</em><a href="#appendix-A.6-1.1.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.6-1.2">
-                     asterisks: <em>asterisks</em><a href="#appendix-A.6-1.2" class="pilcrow">¶</a>
+            <p id="appendix-A.6-1.2.1">
+                     asterisks: <em>asterisks</em><a href="#appendix-A.6-1.2.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.6-1.3">
-                     double asterisks: <strong>double asterisks</strong><a href="#appendix-A.6-1.3" class="pilcrow">¶</a>
+            <p id="appendix-A.6-1.3.1">
+                     double asterisks: <strong>double asterisks</strong><a href="#appendix-A.6-1.3.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.6-1.4">
-                     backticks: <code>backticks</code><a href="#appendix-A.6-1.4" class="pilcrow">¶</a>
+            <p id="appendix-A.6-1.4.1">
+                     backticks: <code>backticks</code><a href="#appendix-A.6-1.4.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 </section>
@@ -1364,17 +1420,20 @@ jkasjksajassjasjsajsajkas
         </h3>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-1">
 <li id="appendix-A.7-1.1">
-                     First we do<a href="#appendix-A.7-1.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-1.1.1">
+                     First we do<a href="#appendix-A.7-1.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-1.2">
             <p id="appendix-A.7-1.2.1">
                      And then<a href="#appendix-A.7-1.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.7-1.2.2.1">
-                           item 1<a href="#appendix-A.7-1.2.2.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-1.2.2.1.1">
+                           item 1<a href="#appendix-A.7-1.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li class="normal" id="appendix-A.7-1.2.2.2">
-                           item 2<a href="#appendix-A.7-1.2.2.2" class="pilcrow">¶</a>
+                <p id="appendix-A.7-1.2.2.2.1">
+                           item 2<a href="#appendix-A.7-1.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
@@ -1383,17 +1442,20 @@ jkasjksajassjasjsajsajkas
                And the other around.<a href="#appendix-A.7-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.7-3.1">
-                     First we do<a href="#appendix-A.7-3.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-3.1.1">
+                     First we do<a href="#appendix-A.7-3.1.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal" id="appendix-A.7-3.2">
             <p id="appendix-A.7-3.2.1">
                      Then<a href="#appendix-A.7-3.2.1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-3.2.2">
 <li id="appendix-A.7-3.2.2.1">
-                           Something<a href="#appendix-A.7-3.2.2.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-3.2.2.1.1">
+                           Something<a href="#appendix-A.7-3.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li id="appendix-A.7-3.2.2.2">
-                           Another thing<a href="#appendix-A.7-3.2.2.2" class="pilcrow">¶</a>
+                <p id="appendix-A.7-3.2.2.2.1">
+                           Another thing<a href="#appendix-A.7-3.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ol>
 </li>
@@ -1420,10 +1482,12 @@ jkasjksajassjasjsajsajkas
             <p id="appendix-A.7-7.2.1">It works because of<a href="#appendix-A.7-7.2.1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.2.2">
 <li id="appendix-A.7-7.2.2.1">
-                        One<a href="#appendix-A.7-7.2.2.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-7.2.2.1.1">
+                        One<a href="#appendix-A.7-7.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li id="appendix-A.7-7.2.2.2">
-                        Two<a href="#appendix-A.7-7.2.2.2" class="pilcrow">¶</a>
+                <p id="appendix-A.7-7.2.2.2.1">
+                        Two<a href="#appendix-A.7-7.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ol>
 </dd>
@@ -1437,17 +1501,20 @@ jkasjksajassjasjsajsajkas
             <p id="appendix-A.7-7.6.1">It works because of<a href="#appendix-A.7-7.6.1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.6.2">
 <li id="appendix-A.7-7.6.2.1">
-                        One1<a href="#appendix-A.7-7.6.2.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-7.6.2.1.1">
+                        One1<a href="#appendix-A.7-7.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
               <li id="appendix-A.7-7.6.2.2">
                 <p id="appendix-A.7-7.6.2.2.1">
                         Two1<a href="#appendix-A.7-7.6.2.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.7-7.6.2.2.2.1">
-                              Itemize list<a href="#appendix-A.7-7.6.2.2.2.1" class="pilcrow">¶</a>
+                    <p id="appendix-A.7-7.6.2.2.2.1.1">
+                              Itemize list<a href="#appendix-A.7-7.6.2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
                   <li class="normal" id="appendix-A.7-7.6.2.2.2.2">
-                              Another item<a href="#appendix-A.7-7.6.2.2.2.2" class="pilcrow">¶</a>
+                    <p id="appendix-A.7-7.6.2.2.2.2.1">
+                              Another item<a href="#appendix-A.7-7.6.2.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
                 </ul>
 </li>
@@ -1477,7 +1544,8 @@ jkasjksajassjasjsajsajkas
 </dl>
 </li>
           <li id="appendix-A.7-9.2">
-                     Go'bye<a href="#appendix-A.7-9.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-9.2.1">
+                     Go'bye<a href="#appendix-A.7-9.2.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.7-10">
@@ -1489,7 +1557,8 @@ jkasjksajassjasjsajsajkas
 <p id="appendix-A.7-11.1.2"> ... to be explained properly.<a href="#appendix-A.7-11.1.2" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-11.2">
-                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#appendix-A.7-11.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-11.2.1">
+                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#appendix-A.7-11.2.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-11.3">
             <p id="appendix-A.7-11.3.1">
@@ -1501,7 +1570,8 @@ Artwork
 </div>
 </li>
           <li id="appendix-A.7-11.4">
-                     Final item.<a href="#appendix-A.7-11.4" class="pilcrow">¶</a>
+            <p id="appendix-A.7-11.4.1">
+                     Final item.<a href="#appendix-A.7-11.4.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.7-12">
@@ -1515,10 +1585,12 @@ Artwork
                Ordered lists.<a href="#appendix-A.7-14" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-15">
 <li id="appendix-A.7-15.1">
-                     First item<a href="#appendix-A.7-15.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-15.1.1">
+                     First item<a href="#appendix-A.7-15.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-15.2">
-                     Second item<a href="#appendix-A.7-15.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-15.2.1">
+                     Second item<a href="#appendix-A.7-15.2.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.7-16">
@@ -1526,12 +1598,14 @@ Artwork
 <span class="break"></span><dl class="olPercent" id="appendix-A.7-17">
 <dt>i.</dt>
 <dd id="appendix-A.7-17.1">
-                     Item 1<a href="#appendix-A.7-17.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-17.1.1">
+                     Item 1<a href="#appendix-A.7-17.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>ii.</dt>
 <dd id="appendix-A.7-17.2">
-                     Item 2<a href="#appendix-A.7-17.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-17.2.1">
+                     Item 2<a href="#appendix-A.7-17.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -1540,17 +1614,20 @@ Artwork
 <span class="break"></span><dl class="olPercent" id="appendix-A.7-19">
 <dt>(1)</dt>
 <dd id="appendix-A.7-19.1">
-                     Item1<a href="#appendix-A.7-19.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-19.1.1">
+                     Item1<a href="#appendix-A.7-19.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>(2)</dt>
 <dd id="appendix-A.7-19.2">
-                     Item2<a href="#appendix-A.7-19.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-19.2.1">
+                     Item2<a href="#appendix-A.7-19.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>(3)</dt>
 <dd id="appendix-A.7-19.3">
-                     Item 3<a href="#appendix-A.7-19.3" class="pilcrow">¶</a>
+            <p id="appendix-A.7-19.3.1">
+                     Item 3<a href="#appendix-A.7-19.3.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -1560,16 +1637,19 @@ Artwork
                Some surrounding text, to make it look better.<a href="#appendix-A.7-21" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="appendix-A.7-22.1">
+            <p id="appendix-A.7-22.1.1">
                      First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
-      First item. Use lot of text to get a real paragraphs sense.<a href="#appendix-A.7-22.1" class="pilcrow">¶</a>
+      First item. Use lot of text to get a real paragraphs sense.<a href="#appendix-A.7-22.1.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.7-22.2">
-                     Second item. So this is the second para in your list. Enjoy;<a href="#appendix-A.7-22.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-22.2.1">
+                     Second item. So this is the second para in your list. Enjoy;<a href="#appendix-A.7-22.2.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal ulEmpty" id="appendix-A.7-22.3">
-                     Another item.<a href="#appendix-A.7-22.3" class="pilcrow">¶</a>
+            <p id="appendix-A.7-22.3.1">
+                     Another item.<a href="#appendix-A.7-22.3.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <p id="appendix-A.7-23">
@@ -1578,10 +1658,12 @@ Artwork
                Lowercase letters list.<a href="#appendix-A.7-24" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="appendix-A.7-25">
 <li id="appendix-A.7-25.1">
-                     First item<a href="#appendix-A.7-25.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-25.1.1">
+                     First item<a href="#appendix-A.7-25.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-25.2">
-                     Second item<a href="#appendix-A.7-25.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-25.2.1">
+                     Second item<a href="#appendix-A.7-25.2.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.7-26">
@@ -1589,12 +1671,14 @@ Artwork
 <span class="break"></span><dl class="olPercent" id="appendix-A.7-27">
 <dt>A.</dt>
 <dd id="appendix-A.7-27.1">
-                     First item<a href="#appendix-A.7-27.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-27.1.1">
+                     First item<a href="#appendix-A.7-27.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>B.</dt>
 <dd id="appendix-A.7-27.2">
-                     Second item<a href="#appendix-A.7-27.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-27.2.1">
+                     Second item<a href="#appendix-A.7-27.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -1627,10 +1711,12 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
                List with a sublist with a paragraph above the sublist<a href="#appendix-A.7-31" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-32">
 <li id="appendix-A.7-32.1">
-                     First Item<a href="#appendix-A.7-32.1" class="pilcrow">¶</a>
+            <p id="appendix-A.7-32.1.1">
+                     First Item<a href="#appendix-A.7-32.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-32.2">
-                     Second item<a href="#appendix-A.7-32.2" class="pilcrow">¶</a>
+            <p id="appendix-A.7-32.2.1">
+                     Second item<a href="#appendix-A.7-32.2.1" class="pilcrow">¶</a></p>
 </li>
           <li id="appendix-A.7-32.3">
             <p id="appendix-A.7-32.3.1">
@@ -1638,10 +1724,12 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
 <p id="appendix-A.7-32.3.2"> A paragraph that comes first<a href="#appendix-A.7-32.3.2" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="appendix-A.7-32.3.3">
 <li id="appendix-A.7-32.3.3.1">
-                           But what do you know<a href="#appendix-A.7-32.3.3.1" class="pilcrow">¶</a>
+                <p id="appendix-A.7-32.3.3.1.1">
+                           But what do you know<a href="#appendix-A.7-32.3.3.1.1" class="pilcrow">¶</a></p>
 </li>
               <li id="appendix-A.7-32.3.3.2">
-                           This is another list<a href="#appendix-A.7-32.3.3.2" class="pilcrow">¶</a>
+                <p id="appendix-A.7-32.3.3.2.1">
+                           This is another list<a href="#appendix-A.7-32.3.3.2.1" class="pilcrow">¶</a></p>
 </li>
             </ol>
 </li>
@@ -1802,7 +1890,8 @@ See [](#tab-here-s-the)
                This is another example:<a href="#appendix-A.9-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.9-2">
 <li id="appendix-A.9-2.1">
-                     Another bla bla..<a href="#appendix-A.9-2.1" class="pilcrow">¶</a>
+            <p id="appendix-A.9-2.1.1">
+                     Another bla bla..<a href="#appendix-A.9-2.1.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
 <p id="appendix-A.9-3">

--- a/tests/valid/draft-template-old.prepped.xml
+++ b/tests/valid/draft-template-old.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" consensus="false" prepTime="2023-07-26T21:42:41" indexInclude="true" scripts="Common,Latin">
-  <!-- xml2rfc v2v3 conversion 3.17.4 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" consensus="false" prepTime="2023-08-29T11:29:38" indexInclude="true" scripts="Common,Latin">
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
   
   
@@ -214,8 +214,12 @@
       <t indent="0" pn="section-2-1">List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
       'format'.</t>
       <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-2-2">
-        <li pn="section-2-2.1">First bullet</li>
-        <li pn="section-2-2.2">Second bullet</li>
+        <li pn="section-2-2.1">
+          <t indent="0" pn="section-2-2.1.1">First bullet</t>
+        </li>
+        <li pn="section-2-2.2">
+          <t indent="0" pn="section-2-2.2.1">Second bullet</t>
+        </li>
       </ul>
       <t indent="0" pn="section-2-3"> You can write text here as well.</t>
     </section>
@@ -305,7 +309,9 @@
 
       <t indent="0" pn="section-5-3">Simulating more than one paragraph in a list item using
       &lt;vspace&gt;: </t>
-      <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5-4"><li pn="section-5-4.1" derivedCounter="a.">First, a short item.</li>
+      <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5-4"><li pn="section-5-4.1" derivedCounter="a.">
+          <t indent="0" pn="section-5-4.1.1">First, a short item.</t>
+        </li>
         <li pn="section-5-4.2" derivedCounter="b.">
           <t indent="0" pn="section-5-4.2.1">Second, a longer list item.</t>
           <t indent="0" pn="section-5-4.2.2"> And
@@ -314,8 +320,10 @@
       </ol>
       <t indent="0" pn="section-5-5">Simple indented paragraph using the "empty" style: </t>
       <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-5-6">
-        <li pn="section-5-6.1">The quick, brown fox jumped over the lazy dog and lived to fool
-          many another hunter in the great wood in the west.</li>
+        <li pn="section-5-6.1">
+          <t indent="0" pn="section-5-6.1.1">The quick, brown fox jumped over the lazy dog and lived to fool
+          many another hunter in the great wood in the west.</t>
+        </li>
       </ul>
       <section numbered="true" toc="include" removeInRFC="false" pn="section-5.1">
         <name slugifiedName="name-numbering-lists-across-list">Numbering Lists across Lists and Sections</name>
@@ -323,26 +331,46 @@
         &lt;list&gt; elements, maybe in separate sections using the "format"
         style and a "counter" variable.</t>
         <t indent="0" pn="section-5.1-2">First list: </t>
-        <ol group="reqs" spacing="normal" type="R%d" start="1" indent="adaptive" pn="section-5.1-3"><li pn="section-5.1-3.1" derivedCounter="R1">#1</li>
-          <li pn="section-5.1-3.2" derivedCounter="R2">#2</li>
-          <li pn="section-5.1-3.3" derivedCounter="R3">#3</li>
+        <ol group="reqs" spacing="normal" type="R%d" start="1" indent="adaptive" pn="section-5.1-3"><li pn="section-5.1-3.1" derivedCounter="R1">
+            <t indent="0" pn="section-5.1-3.1.1">#1</t>
+          </li>
+          <li pn="section-5.1-3.2" derivedCounter="R2">
+            <t indent="0" pn="section-5.1-3.2.1">#2</t>
+          </li>
+          <li pn="section-5.1-3.3" derivedCounter="R3">
+            <t indent="0" pn="section-5.1-3.3.1">#3</t>
+          </li>
         </ol>
         <t indent="0" pn="section-5.1-4"> Specify the indent explicitly so that all the items line up
         nicely.</t>
         <t indent="0" pn="section-5.1-5">Second list: </t>
-        <ol group="reqs" spacing="normal" type="R%d" start="4" indent="adaptive" pn="section-5.1-6"><li pn="section-5.1-6.1" derivedCounter="R4">#4</li>
-          <li pn="section-5.1-6.2" derivedCounter="R5">#5</li>
-          <li pn="section-5.1-6.3" derivedCounter="R6">#6</li>
+        <ol group="reqs" spacing="normal" type="R%d" start="4" indent="adaptive" pn="section-5.1-6"><li pn="section-5.1-6.1" derivedCounter="R4">
+            <t indent="0" pn="section-5.1-6.1.1">#4</t>
+          </li>
+          <li pn="section-5.1-6.2" derivedCounter="R5">
+            <t indent="0" pn="section-5.1-6.2.1">#5</t>
+          </li>
+          <li pn="section-5.1-6.3" derivedCounter="R6">
+            <t indent="0" pn="section-5.1-6.3.1">#6</t>
+          </li>
         </ol>
       </section>
       <section numbered="true" toc="include" removeInRFC="false" pn="section-5.2">
         <name slugifiedName="name-where-the-list-numbering-co">Where the List Numbering Continues</name>
         <t indent="0" pn="section-5.2-1">List continues here.</t>
         <t indent="0" pn="section-5.2-2">Third list: </t>
-        <ol group="reqs" spacing="normal" type="R%d" start="7" indent="adaptive" pn="section-5.2-3"><li pn="section-5.2-3.1" derivedCounter="R7">#7</li>
-          <li pn="section-5.2-3.2" derivedCounter="R8">#8</li>
-          <li pn="section-5.2-3.3" derivedCounter="R9">#9</li>
-          <li pn="section-5.2-3.4" derivedCounter="R10">#10</li>
+        <ol group="reqs" spacing="normal" type="R%d" start="7" indent="adaptive" pn="section-5.2-3"><li pn="section-5.2-3.1" derivedCounter="R7">
+            <t indent="0" pn="section-5.2-3.1.1">#7</t>
+          </li>
+          <li pn="section-5.2-3.2" derivedCounter="R8">
+            <t indent="0" pn="section-5.2-3.2.1">#8</t>
+          </li>
+          <li pn="section-5.2-3.3" derivedCounter="R9">
+            <t indent="0" pn="section-5.2-3.3.1">#9</t>
+          </li>
+          <li pn="section-5.2-3.4" derivedCounter="R10">
+            <t indent="0" pn="section-5.2-3.4.1">#10</t>
+          </li>
         </ol>
         <t indent="0" pn="section-5.2-4"> The end of the list.</t>
       </section>
@@ -351,7 +379,9 @@
         <t indent="0" pn="section-5.3-1">Simulating more than one paragraph in a list item using
 	  &lt;vspace&gt;: 
         </t>
-        <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5.3-2"><li pn="section-5.3-2.1" derivedCounter="a.">First, a short item.</li>
+        <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5.3-2"><li pn="section-5.3-2.1" derivedCounter="a.">
+            <t indent="0" pn="section-5.3-2.1.1">First, a short item.</t>
+          </li>
           <li pn="section-5.3-2.2" derivedCounter="b.">
             <t indent="0" pn="section-5.3-2.2.1">Second, a longer list item.</t>
             <t indent="0" pn="section-5.3-2.2.2"> And
@@ -360,13 +390,21 @@
           <li pn="section-5.3-2.3" derivedCounter="c.">
             <t indent="0" pn="section-5.3-2.3.1">and a sublist, also with letters
             </t>
-            <ol spacing="normal" type="A" indent="adaptive" start="1" pn="section-5.3-2.3.2"><li pn="section-5.3-2.3.2.1" derivedCounter="A.">first subitem</li>
-              <li pn="section-5.3-2.3.2.2" derivedCounter="B.">second subitem</li>
+            <ol spacing="normal" type="A" indent="adaptive" start="1" pn="section-5.3-2.3.2"><li pn="section-5.3-2.3.2.1" derivedCounter="A.">
+                <t indent="0" pn="section-5.3-2.3.2.1.1">first subitem</t>
+              </li>
+              <li pn="section-5.3-2.3.2.2" derivedCounter="B.">
+                <t indent="0" pn="section-5.3-2.3.2.2.1">second subitem</t>
+              </li>
               <li pn="section-5.3-2.3.2.3" derivedCounter="C.">
                 <t indent="0" pn="section-5.3-2.3.2.3.1">and a sub-sublist, also with letters
                 </t>
-                <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5.3-2.3.2.3.2"><li pn="section-5.3-2.3.2.3.2.1" derivedCounter="a.">first sub-subitem</li>
-                  <li pn="section-5.3-2.3.2.3.2.2" derivedCounter="b.">second sub-subitem</li>
+                <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5.3-2.3.2.3.2"><li pn="section-5.3-2.3.2.3.2.1" derivedCounter="a.">
+                    <t indent="0" pn="section-5.3-2.3.2.3.2.1.1">first sub-subitem</t>
+                  </li>
+                  <li pn="section-5.3-2.3.2.3.2.2" derivedCounter="b.">
+                    <t indent="0" pn="section-5.3-2.3.2.3.2.2.1">second sub-subitem</t>
+                  </li>
                 </ol>
               </li>
             </ol>
@@ -377,80 +415,214 @@
         <name slugifiedName="name-list-formats">List Formats</name>
         <t indent="0" pn="section-5.4-1">many formats
         </t>
-        <ol spacing="normal" type="%c" indent="adaptive" start="1" pn="section-5.4-2"><li pn="section-5.4-2.1" derivedCounter="a">first %c-item</li>
-          <li pn="section-5.4-2.2" derivedCounter="b">more %c-items</li>
+        <ol spacing="normal" type="%c" indent="adaptive" start="1" pn="section-5.4-2"><li pn="section-5.4-2.1" derivedCounter="a">
+            <t indent="0" pn="section-5.4-2.1.1">first %c-item</t>
+          </li>
+          <li pn="section-5.4-2.2" derivedCounter="b">
+            <t indent="0" pn="section-5.4-2.2.1">more %c-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%C" indent="adaptive" start="1" pn="section-5.4-3"><li pn="section-5.4-3.1" derivedCounter="A">first %C-item</li>
-          <li pn="section-5.4-3.2" derivedCounter="B">more %C-items</li>
+        <ol spacing="normal" type="%C" indent="adaptive" start="1" pn="section-5.4-3"><li pn="section-5.4-3.1" derivedCounter="A">
+            <t indent="0" pn="section-5.4-3.1.1">first %C-item</t>
+          </li>
+          <li pn="section-5.4-3.2" derivedCounter="B">
+            <t indent="0" pn="section-5.4-3.2.1">more %C-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%d" indent="adaptive" start="1" pn="section-5.4-4"><li pn="section-5.4-4.1" derivedCounter="1">first %d-item.</li>
-          <li pn="section-5.4-4.2" derivedCounter="2">more %d-items.</li>
+        <ol spacing="normal" type="%d" indent="adaptive" start="1" pn="section-5.4-4"><li pn="section-5.4-4.1" derivedCounter="1">
+            <t indent="0" pn="section-5.4-4.1.1">first %d-item.</t>
+          </li>
+          <li pn="section-5.4-4.2" derivedCounter="2">
+            <t indent="0" pn="section-5.4-4.2.1">more %d-items.</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%i" indent="adaptive" start="1" pn="section-5.4-5"><li pn="section-5.4-5.1" derivedCounter="i">first %i-item</li>
-          <li pn="section-5.4-5.2" derivedCounter="ii">more %i-items</li>
-          <li pn="section-5.4-5.3" derivedCounter="iii">more %i-items</li>
-          <li pn="section-5.4-5.4" derivedCounter="iv">more %i-items</li>
-          <li pn="section-5.4-5.5" derivedCounter="v">more %i-items</li>
-          <li pn="section-5.4-5.6" derivedCounter="vi">more %i-items</li>
-          <li pn="section-5.4-5.7" derivedCounter="vii">more %i-items</li>
-          <li pn="section-5.4-5.8" derivedCounter="viii">more %i-items</li>
-          <li pn="section-5.4-5.9" derivedCounter="ix">more %i-items</li>
+        <ol spacing="normal" type="%i" indent="adaptive" start="1" pn="section-5.4-5"><li pn="section-5.4-5.1" derivedCounter="i">
+            <t indent="0" pn="section-5.4-5.1.1">first %i-item</t>
+          </li>
+          <li pn="section-5.4-5.2" derivedCounter="ii">
+            <t indent="0" pn="section-5.4-5.2.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.3" derivedCounter="iii">
+            <t indent="0" pn="section-5.4-5.3.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.4" derivedCounter="iv">
+            <t indent="0" pn="section-5.4-5.4.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.5" derivedCounter="v">
+            <t indent="0" pn="section-5.4-5.5.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.6" derivedCounter="vi">
+            <t indent="0" pn="section-5.4-5.6.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.7" derivedCounter="vii">
+            <t indent="0" pn="section-5.4-5.7.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.8" derivedCounter="viii">
+            <t indent="0" pn="section-5.4-5.8.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.9" derivedCounter="ix">
+            <t indent="0" pn="section-5.4-5.9.1">more %i-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%I" indent="adaptive" start="1" pn="section-5.4-6"><li pn="section-5.4-6.1" derivedCounter="I">first %I-item</li>
-          <li pn="section-5.4-6.2" derivedCounter="II">more %I-items</li>
-          <li pn="section-5.4-6.3" derivedCounter="III">more %I-items</li>
-          <li pn="section-5.4-6.4" derivedCounter="IV">more %I-items</li>
-          <li pn="section-5.4-6.5" derivedCounter="V">more %I-items</li>
-          <li pn="section-5.4-6.6" derivedCounter="VI">more %I-items</li>
-          <li pn="section-5.4-6.7" derivedCounter="VII">more %I-items</li>
-          <li pn="section-5.4-6.8" derivedCounter="VIII">more %I-items</li>
-          <li pn="section-5.4-6.9" derivedCounter="IX">more %I-items</li>
+        <ol spacing="normal" type="%I" indent="adaptive" start="1" pn="section-5.4-6"><li pn="section-5.4-6.1" derivedCounter="I">
+            <t indent="0" pn="section-5.4-6.1.1">first %I-item</t>
+          </li>
+          <li pn="section-5.4-6.2" derivedCounter="II">
+            <t indent="0" pn="section-5.4-6.2.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.3" derivedCounter="III">
+            <t indent="0" pn="section-5.4-6.3.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.4" derivedCounter="IV">
+            <t indent="0" pn="section-5.4-6.4.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.5" derivedCounter="V">
+            <t indent="0" pn="section-5.4-6.5.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.6" derivedCounter="VI">
+            <t indent="0" pn="section-5.4-6.6.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.7" derivedCounter="VII">
+            <t indent="0" pn="section-5.4-6.7.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.8" derivedCounter="VIII">
+            <t indent="0" pn="section-5.4-6.8.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.9" derivedCounter="IX">
+            <t indent="0" pn="section-5.4-6.9.1">more %I-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%o" indent="adaptive" start="1" pn="section-5.4-7"><li pn="section-5.4-7.1" derivedCounter="1">first %o-item</li>
-          <li pn="section-5.4-7.2" derivedCounter="2">more %o-items</li>
-          <li pn="section-5.4-7.3" derivedCounter="3">more %o-items</li>
-          <li pn="section-5.4-7.4" derivedCounter="4">more %o-items</li>
-          <li pn="section-5.4-7.5" derivedCounter="5">more %o-items</li>
-          <li pn="section-5.4-7.6" derivedCounter="6">more %o-items</li>
-          <li pn="section-5.4-7.7" derivedCounter="7">more %o-items</li>
-          <li pn="section-5.4-7.8" derivedCounter="10">more %o-items</li>
-          <li pn="section-5.4-7.9" derivedCounter="11">more %o-items</li>
+        <ol spacing="normal" type="%o" indent="adaptive" start="1" pn="section-5.4-7"><li pn="section-5.4-7.1" derivedCounter="1">
+            <t indent="0" pn="section-5.4-7.1.1">first %o-item</t>
+          </li>
+          <li pn="section-5.4-7.2" derivedCounter="2">
+            <t indent="0" pn="section-5.4-7.2.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.3" derivedCounter="3">
+            <t indent="0" pn="section-5.4-7.3.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.4" derivedCounter="4">
+            <t indent="0" pn="section-5.4-7.4.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.5" derivedCounter="5">
+            <t indent="0" pn="section-5.4-7.5.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.6" derivedCounter="6">
+            <t indent="0" pn="section-5.4-7.6.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.7" derivedCounter="7">
+            <t indent="0" pn="section-5.4-7.7.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.8" derivedCounter="10">
+            <t indent="0" pn="section-5.4-7.8.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.9" derivedCounter="11">
+            <t indent="0" pn="section-5.4-7.9.1">more %o-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%x" indent="adaptive" start="1" pn="section-5.4-8"><li pn="section-5.4-8.1" derivedCounter="1">first %x-item</li>
-          <li pn="section-5.4-8.2" derivedCounter="2">more %x-items</li>
-          <li pn="section-5.4-8.3" derivedCounter="3">more %x-items</li>
-          <li pn="section-5.4-8.4" derivedCounter="4">more %x-items</li>
-          <li pn="section-5.4-8.5" derivedCounter="5">more %x-items</li>
-          <li pn="section-5.4-8.6" derivedCounter="6">more %x-items</li>
-          <li pn="section-5.4-8.7" derivedCounter="7">more %x-items</li>
-          <li pn="section-5.4-8.8" derivedCounter="8">more %x-items</li>
-          <li pn="section-5.4-8.9" derivedCounter="9">more %x-items</li>
-          <li pn="section-5.4-8.10" derivedCounter="a">more %x-items</li>
-          <li pn="section-5.4-8.11" derivedCounter="b">more %x-items</li>
-          <li pn="section-5.4-8.12" derivedCounter="c">more %x-items</li>
-          <li pn="section-5.4-8.13" derivedCounter="d">more %x-items</li>
-          <li pn="section-5.4-8.14" derivedCounter="e">more %x-items</li>
-          <li pn="section-5.4-8.15" derivedCounter="f">more %x-items</li>
-          <li pn="section-5.4-8.16" derivedCounter="10">more %x-items</li>
-          <li pn="section-5.4-8.17" derivedCounter="11">more %x-items</li>
+        <ol spacing="normal" type="%x" indent="adaptive" start="1" pn="section-5.4-8"><li pn="section-5.4-8.1" derivedCounter="1">
+            <t indent="0" pn="section-5.4-8.1.1">first %x-item</t>
+          </li>
+          <li pn="section-5.4-8.2" derivedCounter="2">
+            <t indent="0" pn="section-5.4-8.2.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.3" derivedCounter="3">
+            <t indent="0" pn="section-5.4-8.3.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.4" derivedCounter="4">
+            <t indent="0" pn="section-5.4-8.4.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.5" derivedCounter="5">
+            <t indent="0" pn="section-5.4-8.5.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.6" derivedCounter="6">
+            <t indent="0" pn="section-5.4-8.6.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.7" derivedCounter="7">
+            <t indent="0" pn="section-5.4-8.7.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.8" derivedCounter="8">
+            <t indent="0" pn="section-5.4-8.8.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.9" derivedCounter="9">
+            <t indent="0" pn="section-5.4-8.9.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.10" derivedCounter="a">
+            <t indent="0" pn="section-5.4-8.10.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.11" derivedCounter="b">
+            <t indent="0" pn="section-5.4-8.11.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.12" derivedCounter="c">
+            <t indent="0" pn="section-5.4-8.12.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.13" derivedCounter="d">
+            <t indent="0" pn="section-5.4-8.13.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.14" derivedCounter="e">
+            <t indent="0" pn="section-5.4-8.14.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.15" derivedCounter="f">
+            <t indent="0" pn="section-5.4-8.15.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.16" derivedCounter="10">
+            <t indent="0" pn="section-5.4-8.16.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.17" derivedCounter="11">
+            <t indent="0" pn="section-5.4-8.17.1">more %x-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%X" indent="adaptive" start="1" pn="section-5.4-9"><li pn="section-5.4-9.1" derivedCounter="1">first %X-item</li>
-          <li pn="section-5.4-9.2" derivedCounter="2">more %X-items</li>
-          <li pn="section-5.4-9.3" derivedCounter="3">more %X-items</li>
-          <li pn="section-5.4-9.4" derivedCounter="4">more %X-items</li>
-          <li pn="section-5.4-9.5" derivedCounter="5">more %X-items</li>
-          <li pn="section-5.4-9.6" derivedCounter="6">more %X-items</li>
-          <li pn="section-5.4-9.7" derivedCounter="7">more %X-items</li>
-          <li pn="section-5.4-9.8" derivedCounter="8">more %X-items</li>
-          <li pn="section-5.4-9.9" derivedCounter="9">more %X-items</li>
-          <li pn="section-5.4-9.10" derivedCounter="A">more %X-items</li>
-          <li pn="section-5.4-9.11" derivedCounter="B">more %X-items</li>
-          <li pn="section-5.4-9.12" derivedCounter="C">more %X-items</li>
-          <li pn="section-5.4-9.13" derivedCounter="D">more %X-items</li>
-          <li pn="section-5.4-9.14" derivedCounter="E">more %X-items</li>
-          <li pn="section-5.4-9.15" derivedCounter="F">more %X-items</li>
-          <li pn="section-5.4-9.16" derivedCounter="10">more %X-items</li>
-          <li pn="section-5.4-9.17" derivedCounter="11">more %X-items</li>
+        <ol spacing="normal" type="%X" indent="adaptive" start="1" pn="section-5.4-9"><li pn="section-5.4-9.1" derivedCounter="1">
+            <t indent="0" pn="section-5.4-9.1.1">first %X-item</t>
+          </li>
+          <li pn="section-5.4-9.2" derivedCounter="2">
+            <t indent="0" pn="section-5.4-9.2.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.3" derivedCounter="3">
+            <t indent="0" pn="section-5.4-9.3.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.4" derivedCounter="4">
+            <t indent="0" pn="section-5.4-9.4.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.5" derivedCounter="5">
+            <t indent="0" pn="section-5.4-9.5.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.6" derivedCounter="6">
+            <t indent="0" pn="section-5.4-9.6.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.7" derivedCounter="7">
+            <t indent="0" pn="section-5.4-9.7.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.8" derivedCounter="8">
+            <t indent="0" pn="section-5.4-9.8.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.9" derivedCounter="9">
+            <t indent="0" pn="section-5.4-9.9.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.10" derivedCounter="A">
+            <t indent="0" pn="section-5.4-9.10.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.11" derivedCounter="B">
+            <t indent="0" pn="section-5.4-9.11.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.12" derivedCounter="C">
+            <t indent="0" pn="section-5.4-9.12.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.13" derivedCounter="D">
+            <t indent="0" pn="section-5.4-9.13.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.14" derivedCounter="E">
+            <t indent="0" pn="section-5.4-9.14.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.15" derivedCounter="F">
+            <t indent="0" pn="section-5.4-9.15.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.16" derivedCounter="10">
+            <t indent="0" pn="section-5.4-9.16.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.17" derivedCounter="11">
+            <t indent="0" pn="section-5.4-9.17.1">more %X-items</t>
+          </li>
         </ol>
       </section>
     </section>

--- a/tests/valid/draft-template-old.v2v3.xml
+++ b/tests/valid/draft-template-old.v2v3.xml
@@ -33,7 +33,7 @@
 <?rfc multiple-initials="yes" ?>
 <!-- end of list of popular I-D processing instructions -->
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
-  <!-- xml2rfc v2v3 conversion 3.17.4 -->
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   <?v3xml2rfc silence=".*[Pp]ostal address" ?>
   <?v3xml2rfc silence="The document date .*? is more than 3 days away from today's date" ?>
   <?v3xml2rfc silence="Found SVG with width or height specified" ?>
@@ -129,8 +129,12 @@
       <t>List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
       'format'.</t>
       <ul spacing="normal">
-        <li>First bullet</li>
-        <li>Second bullet</li>
+        <li>
+          <t>First bullet</t>
+        </li>
+        <li>
+          <t>Second bullet</t>
+        </li>
       </ul>
       <t> You can write text here as well.</t>
     </section>
@@ -215,7 +219,9 @@
 
       <t>Simulating more than one paragraph in a list item using
       &lt;vspace&gt;: </t>
-      <ol spacing="normal" type="a"><li>First, a short item.</li>
+      <ol spacing="normal" type="a"><li>
+          <t>First, a short item.</t>
+        </li>
         <li>
           <t>Second, a longer list item.</t>
           <t> And
@@ -224,8 +230,10 @@
       </ol>
       <t>Simple indented paragraph using the "empty" style: </t>
       <ul empty="true" spacing="normal">
-        <li>The quick, brown fox jumped over the lazy dog and lived to fool
-          many another hunter in the great wood in the west.</li>
+        <li>
+          <t>The quick, brown fox jumped over the lazy dog and lived to fool
+          many another hunter in the great wood in the west.</t>
+        </li>
       </ul>
       <section numbered="true" toc="default">
         <name>Numbering Lists across Lists and Sections</name>
@@ -233,26 +241,46 @@
         &lt;list&gt; elements, maybe in separate sections using the "format"
         style and a "counter" variable.</t>
         <t>First list: </t>
-        <ol group="reqs" spacing="normal" type="R%d"><li>#1</li>
-          <li>#2</li>
-          <li>#3</li>
+        <ol group="reqs" spacing="normal" type="R%d"><li>
+            <t>#1</t>
+          </li>
+          <li>
+            <t>#2</t>
+          </li>
+          <li>
+            <t>#3</t>
+          </li>
         </ol>
         <t> Specify the indent explicitly so that all the items line up
         nicely.</t>
         <t>Second list: </t>
-        <ol group="reqs" spacing="normal" type="R%d"><li>#4</li>
-          <li>#5</li>
-          <li>#6</li>
+        <ol group="reqs" spacing="normal" type="R%d"><li>
+            <t>#4</t>
+          </li>
+          <li>
+            <t>#5</t>
+          </li>
+          <li>
+            <t>#6</t>
+          </li>
         </ol>
       </section>
       <section numbered="true" toc="default">
         <name>Where the List Numbering Continues</name>
         <t>List continues here.</t>
         <t>Third list: </t>
-        <ol group="reqs" spacing="normal" type="R%d"><li>#7</li>
-          <li>#8</li>
-          <li>#9</li>
-          <li>#10</li>
+        <ol group="reqs" spacing="normal" type="R%d"><li>
+            <t>#7</t>
+          </li>
+          <li>
+            <t>#8</t>
+          </li>
+          <li>
+            <t>#9</t>
+          </li>
+          <li>
+            <t>#10</t>
+          </li>
         </ol>
         <t> The end of the list.</t>
       </section>
@@ -261,7 +289,9 @@
         <t>Simulating more than one paragraph in a list item using
 	  &lt;vspace&gt;: 
         </t>
-        <ol spacing="normal" type="a"><li>First, a short item.</li>
+        <ol spacing="normal" type="a"><li>
+            <t>First, a short item.</t>
+          </li>
           <li>
             <t>Second, a longer list item.</t>
             <t> And
@@ -270,13 +300,21 @@
           <li>
             <t>and a sublist, also with letters
             </t>
-            <ol spacing="normal" type="A"><li>first subitem</li>
-              <li>second subitem</li>
+            <ol spacing="normal" type="A"><li>
+                <t>first subitem</t>
+              </li>
+              <li>
+                <t>second subitem</t>
+              </li>
               <li>
                 <t>and a sub-sublist, also with letters
                 </t>
-                <ol spacing="normal" type="a"><li>first sub-subitem</li>
-                  <li>second sub-subitem</li>
+                <ol spacing="normal" type="a"><li>
+                    <t>first sub-subitem</t>
+                  </li>
+                  <li>
+                    <t>second sub-subitem</t>
+                  </li>
                 </ol>
               </li>
             </ol>
@@ -287,80 +325,214 @@
         <name>List Formats</name>
         <t>many formats
         </t>
-        <ol spacing="normal" type="%c"><li>first %c-item</li>
-          <li>more %c-items</li>
+        <ol spacing="normal" type="%c"><li>
+            <t>first %c-item</t>
+          </li>
+          <li>
+            <t>more %c-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%C"><li>first %C-item</li>
-          <li>more %C-items</li>
+        <ol spacing="normal" type="%C"><li>
+            <t>first %C-item</t>
+          </li>
+          <li>
+            <t>more %C-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%d"><li>first %d-item.</li>
-          <li>more %d-items.</li>
+        <ol spacing="normal" type="%d"><li>
+            <t>first %d-item.</t>
+          </li>
+          <li>
+            <t>more %d-items.</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%i"><li>first %i-item</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
+        <ol spacing="normal" type="%i"><li>
+            <t>first %i-item</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%I"><li>first %I-item</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
+        <ol spacing="normal" type="%I"><li>
+            <t>first %I-item</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%o"><li>first %o-item</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
+        <ol spacing="normal" type="%o"><li>
+            <t>first %o-item</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%x"><li>first %x-item</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
+        <ol spacing="normal" type="%x"><li>
+            <t>first %x-item</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%X"><li>first %X-item</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
+        <ol spacing="normal" type="%X"><li>
+            <t>first %X-item</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
         </ol>
       </section>
     </section>

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -1392,9 +1392,11 @@ li > p:last-of-type:only-child {
 <p id="section-2-1">List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
       'format'.<a href="#section-2-1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-2-2.1">First bullet<a href="#section-2-2.1" class="pilcrow">¶</a>
+<li class="normal" id="section-2-2.1">
+          <p id="section-2-2.1.1">First bullet<a href="#section-2-2.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="section-2-2.2">Second bullet<a href="#section-2-2.2" class="pilcrow">¶</a>
+        <li class="normal" id="section-2-2.2">
+          <p id="section-2-2.2.1">Second bullet<a href="#section-2-2.2.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <p id="section-2-3"> You can write text here as well.<a href="#section-2-3" class="pilcrow">¶</a></p>
@@ -1503,7 +1505,8 @@ li > p:last-of-type:only-child {
 <p id="section-5-3">Simulating more than one paragraph in a list item using
       &lt;vspace&gt;:<a href="#section-5-3" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="section-5-4">
-<li id="section-5-4.1">First, a short item.<a href="#section-5-4.1" class="pilcrow">¶</a>
+<li id="section-5-4.1">
+          <p id="section-5-4.1.1">First, a short item.<a href="#section-5-4.1.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-5-4.2">
           <p id="section-5-4.2.1">Second, a longer list item.<a href="#section-5-4.2.1" class="pilcrow">¶</a></p>
@@ -1513,8 +1516,9 @@ li > p:last-of-type:only-child {
       </ol>
 <p id="section-5-5">Simple indented paragraph using the "empty" style:<a href="#section-5-5" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
-<li class="normal ulEmpty" id="section-5-6.1">The quick, brown fox jumped over the lazy dog and lived to fool
-          many another hunter in the great wood in the west.<a href="#section-5-6.1" class="pilcrow">¶</a>
+<li class="normal ulEmpty" id="section-5-6.1">
+          <p id="section-5-6.1.1">The quick, brown fox jumped over the lazy dog and lived to fool
+          many another hunter in the great wood in the west.<a href="#section-5-6.1.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <section id="section-5.1">
@@ -1527,15 +1531,18 @@ li > p:last-of-type:only-child {
 <p id="section-5.1-2">First list:<a href="#section-5.1-2" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.1-3">
 <dt>R1</dt>
-<dd id="section-5.1-3.1">#1<a href="#section-5.1-3.1" class="pilcrow">¶</a>
+<dd id="section-5.1-3.1">
+            <p id="section-5.1-3.1.1">#1<a href="#section-5.1-3.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R2</dt>
-<dd id="section-5.1-3.2">#2<a href="#section-5.1-3.2" class="pilcrow">¶</a>
+<dd id="section-5.1-3.2">
+            <p id="section-5.1-3.2.1">#2<a href="#section-5.1-3.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R3</dt>
-<dd id="section-5.1-3.3">#3<a href="#section-5.1-3.3" class="pilcrow">¶</a>
+<dd id="section-5.1-3.3">
+            <p id="section-5.1-3.3.1">#3<a href="#section-5.1-3.3.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -1544,15 +1551,18 @@ li > p:last-of-type:only-child {
 <p id="section-5.1-5">Second list:<a href="#section-5.1-5" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.1-6">
 <dt>R4</dt>
-<dd id="section-5.1-6.1">#4<a href="#section-5.1-6.1" class="pilcrow">¶</a>
+<dd id="section-5.1-6.1">
+            <p id="section-5.1-6.1.1">#4<a href="#section-5.1-6.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R5</dt>
-<dd id="section-5.1-6.2">#5<a href="#section-5.1-6.2" class="pilcrow">¶</a>
+<dd id="section-5.1-6.2">
+            <p id="section-5.1-6.2.1">#5<a href="#section-5.1-6.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R6</dt>
-<dd id="section-5.1-6.3">#6<a href="#section-5.1-6.3" class="pilcrow">¶</a>
+<dd id="section-5.1-6.3">
+            <p id="section-5.1-6.3.1">#6<a href="#section-5.1-6.3.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -1565,19 +1575,23 @@ li > p:last-of-type:only-child {
 <p id="section-5.2-2">Third list:<a href="#section-5.2-2" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.2-3">
 <dt>R7</dt>
-<dd id="section-5.2-3.1">#7<a href="#section-5.2-3.1" class="pilcrow">¶</a>
+<dd id="section-5.2-3.1">
+            <p id="section-5.2-3.1.1">#7<a href="#section-5.2-3.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R8</dt>
-<dd id="section-5.2-3.2">#8<a href="#section-5.2-3.2" class="pilcrow">¶</a>
+<dd id="section-5.2-3.2">
+            <p id="section-5.2-3.2.1">#8<a href="#section-5.2-3.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R9</dt>
-<dd id="section-5.2-3.3">#9<a href="#section-5.2-3.3" class="pilcrow">¶</a>
+<dd id="section-5.2-3.3">
+            <p id="section-5.2-3.3.1">#9<a href="#section-5.2-3.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R10</dt>
-<dd id="section-5.2-3.4">#10<a href="#section-5.2-3.4" class="pilcrow">¶</a>
+<dd id="section-5.2-3.4">
+            <p id="section-5.2-3.4.1">#10<a href="#section-5.2-3.4.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -1590,7 +1604,8 @@ li > p:last-of-type:only-child {
 <p id="section-5.3-1">Simulating more than one paragraph in a list item using
    &lt;vspace&gt;:<a href="#section-5.3-1" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="section-5.3-2">
-<li id="section-5.3-2.1">First, a short item.<a href="#section-5.3-2.1" class="pilcrow">¶</a>
+<li id="section-5.3-2.1">
+            <p id="section-5.3-2.1.1">First, a short item.<a href="#section-5.3-2.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-5.3-2.2">
             <p id="section-5.3-2.2.1">Second, a longer list item.<a href="#section-5.3-2.2.1" class="pilcrow">¶</a></p>
@@ -1600,16 +1615,20 @@ li > p:last-of-type:only-child {
           <li id="section-5.3-2.3">
             <p id="section-5.3-2.3.1">and a sublist, also with letters<a href="#section-5.3-2.3.1" class="pilcrow">¶</a></p>
 <ol start="1" type="A" class="normal type-A" id="section-5.3-2.3.2">
-<li id="section-5.3-2.3.2.1">first subitem<a href="#section-5.3-2.3.2.1" class="pilcrow">¶</a>
+<li id="section-5.3-2.3.2.1">
+                <p id="section-5.3-2.3.2.1.1">first subitem<a href="#section-5.3-2.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li id="section-5.3-2.3.2.2">second subitem<a href="#section-5.3-2.3.2.2" class="pilcrow">¶</a>
+              <li id="section-5.3-2.3.2.2">
+                <p id="section-5.3-2.3.2.2.1">second subitem<a href="#section-5.3-2.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
               <li id="section-5.3-2.3.2.3">
                 <p id="section-5.3-2.3.2.3.1">and a sub-sublist, also with letters<a href="#section-5.3-2.3.2.3.1" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="section-5.3-2.3.2.3.2">
-<li id="section-5.3-2.3.2.3.2.1">first sub-subitem<a href="#section-5.3-2.3.2.3.2.1" class="pilcrow">¶</a>
+<li id="section-5.3-2.3.2.3.2.1">
+                    <p id="section-5.3-2.3.2.3.2.1.1">first sub-subitem<a href="#section-5.3-2.3.2.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
-                  <li id="section-5.3-2.3.2.3.2.2">second sub-subitem<a href="#section-5.3-2.3.2.3.2.2" class="pilcrow">¶</a>
+                  <li id="section-5.3-2.3.2.3.2.2">
+                    <p id="section-5.3-2.3.2.3.2.2.1">second sub-subitem<a href="#section-5.3-2.3.2.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
                 </ol>
 </li>
@@ -1624,285 +1643,352 @@ li > p:last-of-type:only-child {
 <p id="section-5.4-1">many formats<a href="#section-5.4-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.4-2">
 <dt>a</dt>
-<dd id="section-5.4-2.1">first %c-item<a href="#section-5.4-2.1" class="pilcrow">¶</a>
+<dd id="section-5.4-2.1">
+            <p id="section-5.4-2.1.1">first %c-item<a href="#section-5.4-2.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>b</dt>
-<dd id="section-5.4-2.2">more %c-items<a href="#section-5.4-2.2" class="pilcrow">¶</a>
+<dd id="section-5.4-2.2">
+            <p id="section-5.4-2.2.1">more %c-items<a href="#section-5.4-2.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-3">
 <dt>A</dt>
-<dd id="section-5.4-3.1">first %C-item<a href="#section-5.4-3.1" class="pilcrow">¶</a>
+<dd id="section-5.4-3.1">
+            <p id="section-5.4-3.1.1">first %C-item<a href="#section-5.4-3.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>B</dt>
-<dd id="section-5.4-3.2">more %C-items<a href="#section-5.4-3.2" class="pilcrow">¶</a>
+<dd id="section-5.4-3.2">
+            <p id="section-5.4-3.2.1">more %C-items<a href="#section-5.4-3.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-4">
 <dt>1</dt>
-<dd id="section-5.4-4.1">first %d-item.<a href="#section-5.4-4.1" class="pilcrow">¶</a>
+<dd id="section-5.4-4.1">
+            <p id="section-5.4-4.1.1">first %d-item.<a href="#section-5.4-4.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>2</dt>
-<dd id="section-5.4-4.2">more %d-items.<a href="#section-5.4-4.2" class="pilcrow">¶</a>
+<dd id="section-5.4-4.2">
+            <p id="section-5.4-4.2.1">more %d-items.<a href="#section-5.4-4.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-5">
 <dt>i</dt>
-<dd id="section-5.4-5.1">first %i-item<a href="#section-5.4-5.1" class="pilcrow">¶</a>
+<dd id="section-5.4-5.1">
+            <p id="section-5.4-5.1.1">first %i-item<a href="#section-5.4-5.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>ii</dt>
-<dd id="section-5.4-5.2">more %i-items<a href="#section-5.4-5.2" class="pilcrow">¶</a>
+<dd id="section-5.4-5.2">
+            <p id="section-5.4-5.2.1">more %i-items<a href="#section-5.4-5.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>iii</dt>
-<dd id="section-5.4-5.3">more %i-items<a href="#section-5.4-5.3" class="pilcrow">¶</a>
+<dd id="section-5.4-5.3">
+            <p id="section-5.4-5.3.1">more %i-items<a href="#section-5.4-5.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>iv</dt>
-<dd id="section-5.4-5.4">more %i-items<a href="#section-5.4-5.4" class="pilcrow">¶</a>
+<dd id="section-5.4-5.4">
+            <p id="section-5.4-5.4.1">more %i-items<a href="#section-5.4-5.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>v</dt>
-<dd id="section-5.4-5.5">more %i-items<a href="#section-5.4-5.5" class="pilcrow">¶</a>
+<dd id="section-5.4-5.5">
+            <p id="section-5.4-5.5.1">more %i-items<a href="#section-5.4-5.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>vi</dt>
-<dd id="section-5.4-5.6">more %i-items<a href="#section-5.4-5.6" class="pilcrow">¶</a>
+<dd id="section-5.4-5.6">
+            <p id="section-5.4-5.6.1">more %i-items<a href="#section-5.4-5.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>vii</dt>
-<dd id="section-5.4-5.7">more %i-items<a href="#section-5.4-5.7" class="pilcrow">¶</a>
+<dd id="section-5.4-5.7">
+            <p id="section-5.4-5.7.1">more %i-items<a href="#section-5.4-5.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>viii</dt>
-<dd id="section-5.4-5.8">more %i-items<a href="#section-5.4-5.8" class="pilcrow">¶</a>
+<dd id="section-5.4-5.8">
+            <p id="section-5.4-5.8.1">more %i-items<a href="#section-5.4-5.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>ix</dt>
-<dd id="section-5.4-5.9">more %i-items<a href="#section-5.4-5.9" class="pilcrow">¶</a>
+<dd id="section-5.4-5.9">
+            <p id="section-5.4-5.9.1">more %i-items<a href="#section-5.4-5.9.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-6">
 <dt>I</dt>
-<dd id="section-5.4-6.1">first %I-item<a href="#section-5.4-6.1" class="pilcrow">¶</a>
+<dd id="section-5.4-6.1">
+            <p id="section-5.4-6.1.1">first %I-item<a href="#section-5.4-6.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>II</dt>
-<dd id="section-5.4-6.2">more %I-items<a href="#section-5.4-6.2" class="pilcrow">¶</a>
+<dd id="section-5.4-6.2">
+            <p id="section-5.4-6.2.1">more %I-items<a href="#section-5.4-6.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>III</dt>
-<dd id="section-5.4-6.3">more %I-items<a href="#section-5.4-6.3" class="pilcrow">¶</a>
+<dd id="section-5.4-6.3">
+            <p id="section-5.4-6.3.1">more %I-items<a href="#section-5.4-6.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>IV</dt>
-<dd id="section-5.4-6.4">more %I-items<a href="#section-5.4-6.4" class="pilcrow">¶</a>
+<dd id="section-5.4-6.4">
+            <p id="section-5.4-6.4.1">more %I-items<a href="#section-5.4-6.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>V</dt>
-<dd id="section-5.4-6.5">more %I-items<a href="#section-5.4-6.5" class="pilcrow">¶</a>
+<dd id="section-5.4-6.5">
+            <p id="section-5.4-6.5.1">more %I-items<a href="#section-5.4-6.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>VI</dt>
-<dd id="section-5.4-6.6">more %I-items<a href="#section-5.4-6.6" class="pilcrow">¶</a>
+<dd id="section-5.4-6.6">
+            <p id="section-5.4-6.6.1">more %I-items<a href="#section-5.4-6.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>VII</dt>
-<dd id="section-5.4-6.7">more %I-items<a href="#section-5.4-6.7" class="pilcrow">¶</a>
+<dd id="section-5.4-6.7">
+            <p id="section-5.4-6.7.1">more %I-items<a href="#section-5.4-6.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>VIII</dt>
-<dd id="section-5.4-6.8">more %I-items<a href="#section-5.4-6.8" class="pilcrow">¶</a>
+<dd id="section-5.4-6.8">
+            <p id="section-5.4-6.8.1">more %I-items<a href="#section-5.4-6.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>IX</dt>
-<dd id="section-5.4-6.9">more %I-items<a href="#section-5.4-6.9" class="pilcrow">¶</a>
+<dd id="section-5.4-6.9">
+            <p id="section-5.4-6.9.1">more %I-items<a href="#section-5.4-6.9.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-7">
 <dt>1</dt>
-<dd id="section-5.4-7.1">first %o-item<a href="#section-5.4-7.1" class="pilcrow">¶</a>
+<dd id="section-5.4-7.1">
+            <p id="section-5.4-7.1.1">first %o-item<a href="#section-5.4-7.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>2</dt>
-<dd id="section-5.4-7.2">more %o-items<a href="#section-5.4-7.2" class="pilcrow">¶</a>
+<dd id="section-5.4-7.2">
+            <p id="section-5.4-7.2.1">more %o-items<a href="#section-5.4-7.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>3</dt>
-<dd id="section-5.4-7.3">more %o-items<a href="#section-5.4-7.3" class="pilcrow">¶</a>
+<dd id="section-5.4-7.3">
+            <p id="section-5.4-7.3.1">more %o-items<a href="#section-5.4-7.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>4</dt>
-<dd id="section-5.4-7.4">more %o-items<a href="#section-5.4-7.4" class="pilcrow">¶</a>
+<dd id="section-5.4-7.4">
+            <p id="section-5.4-7.4.1">more %o-items<a href="#section-5.4-7.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>5</dt>
-<dd id="section-5.4-7.5">more %o-items<a href="#section-5.4-7.5" class="pilcrow">¶</a>
+<dd id="section-5.4-7.5">
+            <p id="section-5.4-7.5.1">more %o-items<a href="#section-5.4-7.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>6</dt>
-<dd id="section-5.4-7.6">more %o-items<a href="#section-5.4-7.6" class="pilcrow">¶</a>
+<dd id="section-5.4-7.6">
+            <p id="section-5.4-7.6.1">more %o-items<a href="#section-5.4-7.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>7</dt>
-<dd id="section-5.4-7.7">more %o-items<a href="#section-5.4-7.7" class="pilcrow">¶</a>
+<dd id="section-5.4-7.7">
+            <p id="section-5.4-7.7.1">more %o-items<a href="#section-5.4-7.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>10</dt>
-<dd id="section-5.4-7.8">more %o-items<a href="#section-5.4-7.8" class="pilcrow">¶</a>
+<dd id="section-5.4-7.8">
+            <p id="section-5.4-7.8.1">more %o-items<a href="#section-5.4-7.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>11</dt>
-<dd id="section-5.4-7.9">more %o-items<a href="#section-5.4-7.9" class="pilcrow">¶</a>
+<dd id="section-5.4-7.9">
+            <p id="section-5.4-7.9.1">more %o-items<a href="#section-5.4-7.9.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-8">
 <dt>1</dt>
-<dd id="section-5.4-8.1">first %x-item<a href="#section-5.4-8.1" class="pilcrow">¶</a>
+<dd id="section-5.4-8.1">
+            <p id="section-5.4-8.1.1">first %x-item<a href="#section-5.4-8.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>2</dt>
-<dd id="section-5.4-8.2">more %x-items<a href="#section-5.4-8.2" class="pilcrow">¶</a>
+<dd id="section-5.4-8.2">
+            <p id="section-5.4-8.2.1">more %x-items<a href="#section-5.4-8.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>3</dt>
-<dd id="section-5.4-8.3">more %x-items<a href="#section-5.4-8.3" class="pilcrow">¶</a>
+<dd id="section-5.4-8.3">
+            <p id="section-5.4-8.3.1">more %x-items<a href="#section-5.4-8.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>4</dt>
-<dd id="section-5.4-8.4">more %x-items<a href="#section-5.4-8.4" class="pilcrow">¶</a>
+<dd id="section-5.4-8.4">
+            <p id="section-5.4-8.4.1">more %x-items<a href="#section-5.4-8.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>5</dt>
-<dd id="section-5.4-8.5">more %x-items<a href="#section-5.4-8.5" class="pilcrow">¶</a>
+<dd id="section-5.4-8.5">
+            <p id="section-5.4-8.5.1">more %x-items<a href="#section-5.4-8.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>6</dt>
-<dd id="section-5.4-8.6">more %x-items<a href="#section-5.4-8.6" class="pilcrow">¶</a>
+<dd id="section-5.4-8.6">
+            <p id="section-5.4-8.6.1">more %x-items<a href="#section-5.4-8.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>7</dt>
-<dd id="section-5.4-8.7">more %x-items<a href="#section-5.4-8.7" class="pilcrow">¶</a>
+<dd id="section-5.4-8.7">
+            <p id="section-5.4-8.7.1">more %x-items<a href="#section-5.4-8.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>8</dt>
-<dd id="section-5.4-8.8">more %x-items<a href="#section-5.4-8.8" class="pilcrow">¶</a>
+<dd id="section-5.4-8.8">
+            <p id="section-5.4-8.8.1">more %x-items<a href="#section-5.4-8.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>9</dt>
-<dd id="section-5.4-8.9">more %x-items<a href="#section-5.4-8.9" class="pilcrow">¶</a>
+<dd id="section-5.4-8.9">
+            <p id="section-5.4-8.9.1">more %x-items<a href="#section-5.4-8.9.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>a</dt>
-<dd id="section-5.4-8.10">more %x-items<a href="#section-5.4-8.10" class="pilcrow">¶</a>
+<dd id="section-5.4-8.10">
+            <p id="section-5.4-8.10.1">more %x-items<a href="#section-5.4-8.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>b</dt>
-<dd id="section-5.4-8.11">more %x-items<a href="#section-5.4-8.11" class="pilcrow">¶</a>
+<dd id="section-5.4-8.11">
+            <p id="section-5.4-8.11.1">more %x-items<a href="#section-5.4-8.11.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>c</dt>
-<dd id="section-5.4-8.12">more %x-items<a href="#section-5.4-8.12" class="pilcrow">¶</a>
+<dd id="section-5.4-8.12">
+            <p id="section-5.4-8.12.1">more %x-items<a href="#section-5.4-8.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>d</dt>
-<dd id="section-5.4-8.13">more %x-items<a href="#section-5.4-8.13" class="pilcrow">¶</a>
+<dd id="section-5.4-8.13">
+            <p id="section-5.4-8.13.1">more %x-items<a href="#section-5.4-8.13.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>e</dt>
-<dd id="section-5.4-8.14">more %x-items<a href="#section-5.4-8.14" class="pilcrow">¶</a>
+<dd id="section-5.4-8.14">
+            <p id="section-5.4-8.14.1">more %x-items<a href="#section-5.4-8.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>f</dt>
-<dd id="section-5.4-8.15">more %x-items<a href="#section-5.4-8.15" class="pilcrow">¶</a>
+<dd id="section-5.4-8.15">
+            <p id="section-5.4-8.15.1">more %x-items<a href="#section-5.4-8.15.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>10</dt>
-<dd id="section-5.4-8.16">more %x-items<a href="#section-5.4-8.16" class="pilcrow">¶</a>
+<dd id="section-5.4-8.16">
+            <p id="section-5.4-8.16.1">more %x-items<a href="#section-5.4-8.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>11</dt>
-<dd id="section-5.4-8.17">more %x-items<a href="#section-5.4-8.17" class="pilcrow">¶</a>
+<dd id="section-5.4-8.17">
+            <p id="section-5.4-8.17.1">more %x-items<a href="#section-5.4-8.17.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-9">
 <dt>1</dt>
-<dd id="section-5.4-9.1">first %X-item<a href="#section-5.4-9.1" class="pilcrow">¶</a>
+<dd id="section-5.4-9.1">
+            <p id="section-5.4-9.1.1">first %X-item<a href="#section-5.4-9.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>2</dt>
-<dd id="section-5.4-9.2">more %X-items<a href="#section-5.4-9.2" class="pilcrow">¶</a>
+<dd id="section-5.4-9.2">
+            <p id="section-5.4-9.2.1">more %X-items<a href="#section-5.4-9.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>3</dt>
-<dd id="section-5.4-9.3">more %X-items<a href="#section-5.4-9.3" class="pilcrow">¶</a>
+<dd id="section-5.4-9.3">
+            <p id="section-5.4-9.3.1">more %X-items<a href="#section-5.4-9.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>4</dt>
-<dd id="section-5.4-9.4">more %X-items<a href="#section-5.4-9.4" class="pilcrow">¶</a>
+<dd id="section-5.4-9.4">
+            <p id="section-5.4-9.4.1">more %X-items<a href="#section-5.4-9.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>5</dt>
-<dd id="section-5.4-9.5">more %X-items<a href="#section-5.4-9.5" class="pilcrow">¶</a>
+<dd id="section-5.4-9.5">
+            <p id="section-5.4-9.5.1">more %X-items<a href="#section-5.4-9.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>6</dt>
-<dd id="section-5.4-9.6">more %X-items<a href="#section-5.4-9.6" class="pilcrow">¶</a>
+<dd id="section-5.4-9.6">
+            <p id="section-5.4-9.6.1">more %X-items<a href="#section-5.4-9.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>7</dt>
-<dd id="section-5.4-9.7">more %X-items<a href="#section-5.4-9.7" class="pilcrow">¶</a>
+<dd id="section-5.4-9.7">
+            <p id="section-5.4-9.7.1">more %X-items<a href="#section-5.4-9.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>8</dt>
-<dd id="section-5.4-9.8">more %X-items<a href="#section-5.4-9.8" class="pilcrow">¶</a>
+<dd id="section-5.4-9.8">
+            <p id="section-5.4-9.8.1">more %X-items<a href="#section-5.4-9.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>9</dt>
-<dd id="section-5.4-9.9">more %X-items<a href="#section-5.4-9.9" class="pilcrow">¶</a>
+<dd id="section-5.4-9.9">
+            <p id="section-5.4-9.9.1">more %X-items<a href="#section-5.4-9.9.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>A</dt>
-<dd id="section-5.4-9.10">more %X-items<a href="#section-5.4-9.10" class="pilcrow">¶</a>
+<dd id="section-5.4-9.10">
+            <p id="section-5.4-9.10.1">more %X-items<a href="#section-5.4-9.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>B</dt>
-<dd id="section-5.4-9.11">more %X-items<a href="#section-5.4-9.11" class="pilcrow">¶</a>
+<dd id="section-5.4-9.11">
+            <p id="section-5.4-9.11.1">more %X-items<a href="#section-5.4-9.11.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>C</dt>
-<dd id="section-5.4-9.12">more %X-items<a href="#section-5.4-9.12" class="pilcrow">¶</a>
+<dd id="section-5.4-9.12">
+            <p id="section-5.4-9.12.1">more %X-items<a href="#section-5.4-9.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>D</dt>
-<dd id="section-5.4-9.13">more %X-items<a href="#section-5.4-9.13" class="pilcrow">¶</a>
+<dd id="section-5.4-9.13">
+            <p id="section-5.4-9.13.1">more %X-items<a href="#section-5.4-9.13.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>E</dt>
-<dd id="section-5.4-9.14">more %X-items<a href="#section-5.4-9.14" class="pilcrow">¶</a>
+<dd id="section-5.4-9.14">
+            <p id="section-5.4-9.14.1">more %X-items<a href="#section-5.4-9.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>F</dt>
-<dd id="section-5.4-9.15">more %X-items<a href="#section-5.4-9.15" class="pilcrow">¶</a>
+<dd id="section-5.4-9.15">
+            <p id="section-5.4-9.15.1">more %X-items<a href="#section-5.4-9.15.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>10</dt>
-<dd id="section-5.4-9.16">more %X-items<a href="#section-5.4-9.16" class="pilcrow">¶</a>
+<dd id="section-5.4-9.16">
+            <p id="section-5.4-9.16.1">more %X-items<a href="#section-5.4-9.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>11</dt>
-<dd id="section-5.4-9.17">more %X-items<a href="#section-5.4-9.17" class="pilcrow">¶</a>
+<dd id="section-5.4-9.17">
+            <p id="section-5.4-9.17.1">more %X-items<a href="#section-5.4-9.17.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>

--- a/tests/valid/draft-template.prepped.xml
+++ b/tests/valid/draft-template.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" consensus="false" prepTime="2023-07-26T21:42:04" indexInclude="true" scripts="Common,Latin" submissionType="IETF">
-  <!-- xml2rfc v2v3 conversion 3.17.4 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" consensus="false" prepTime="2023-08-29T11:29:09" indexInclude="true" scripts="Common,Latin" submissionType="IETF">
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
   
   
@@ -214,8 +214,12 @@
       <t indent="0" pn="section-2-1">List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
       'format'.</t>
       <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-2-2">
-        <li pn="section-2-2.1">First bullet</li>
-        <li pn="section-2-2.2">Second bullet</li>
+        <li pn="section-2-2.1">
+          <t indent="0" pn="section-2-2.1.1">First bullet</t>
+        </li>
+        <li pn="section-2-2.2">
+          <t indent="0" pn="section-2-2.2.1">Second bullet</t>
+        </li>
       </ul>
       <t indent="0" pn="section-2-3"> You can write text here as well.</t>
     </section>
@@ -305,7 +309,9 @@
 
       <t indent="0" pn="section-5-3">Simulating more than one paragraph in a list item using
       &lt;vspace&gt;: </t>
-      <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5-4"><li pn="section-5-4.1" derivedCounter="a.">First, a short item.</li>
+      <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5-4"><li pn="section-5-4.1" derivedCounter="a.">
+          <t indent="0" pn="section-5-4.1.1">First, a short item.</t>
+        </li>
         <li pn="section-5-4.2" derivedCounter="b.">
           <t indent="0" pn="section-5-4.2.1">Second, a longer list item.</t>
           <t indent="0" pn="section-5-4.2.2"> And
@@ -314,8 +320,10 @@
       </ol>
       <t indent="0" pn="section-5-5">Simple indented paragraph using the "empty" style: </t>
       <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-5-6">
-        <li pn="section-5-6.1">The quick, brown fox jumped over the lazy dog and lived to fool
-          many another hunter in the great wood in the west.</li>
+        <li pn="section-5-6.1">
+          <t indent="0" pn="section-5-6.1.1">The quick, brown fox jumped over the lazy dog and lived to fool
+          many another hunter in the great wood in the west.</t>
+        </li>
       </ul>
       <section numbered="true" removeInRFC="false" toc="include" pn="section-5.1">
         <name slugifiedName="name-numbering-lists-across-list">Numbering Lists across Lists and Sections</name>
@@ -323,26 +331,46 @@
         &lt;list&gt; elements, maybe in separate sections using the "format"
         style and a "counter" variable.</t>
         <t indent="0" pn="section-5.1-2">First list: </t>
-        <ol group="reqs" spacing="normal" type="R%d" start="1" indent="adaptive" pn="section-5.1-3"><li pn="section-5.1-3.1" derivedCounter="R1">#1</li>
-          <li pn="section-5.1-3.2" derivedCounter="R2">#2</li>
-          <li pn="section-5.1-3.3" derivedCounter="R3">#3</li>
+        <ol group="reqs" spacing="normal" type="R%d" start="1" indent="adaptive" pn="section-5.1-3"><li pn="section-5.1-3.1" derivedCounter="R1">
+            <t indent="0" pn="section-5.1-3.1.1">#1</t>
+          </li>
+          <li pn="section-5.1-3.2" derivedCounter="R2">
+            <t indent="0" pn="section-5.1-3.2.1">#2</t>
+          </li>
+          <li pn="section-5.1-3.3" derivedCounter="R3">
+            <t indent="0" pn="section-5.1-3.3.1">#3</t>
+          </li>
         </ol>
         <t indent="0" pn="section-5.1-4"> Specify the indent explicitly so that all the items line up
         nicely.</t>
         <t indent="0" pn="section-5.1-5">Second list: </t>
-        <ol group="reqs" spacing="normal" type="R%d" start="4" indent="adaptive" pn="section-5.1-6"><li pn="section-5.1-6.1" derivedCounter="R4">#4</li>
-          <li pn="section-5.1-6.2" derivedCounter="R5">#5</li>
-          <li pn="section-5.1-6.3" derivedCounter="R6">#6</li>
+        <ol group="reqs" spacing="normal" type="R%d" start="4" indent="adaptive" pn="section-5.1-6"><li pn="section-5.1-6.1" derivedCounter="R4">
+            <t indent="0" pn="section-5.1-6.1.1">#4</t>
+          </li>
+          <li pn="section-5.1-6.2" derivedCounter="R5">
+            <t indent="0" pn="section-5.1-6.2.1">#5</t>
+          </li>
+          <li pn="section-5.1-6.3" derivedCounter="R6">
+            <t indent="0" pn="section-5.1-6.3.1">#6</t>
+          </li>
         </ol>
       </section>
       <section numbered="true" removeInRFC="false" toc="include" pn="section-5.2">
         <name slugifiedName="name-where-the-list-numbering-co">Where the List Numbering Continues</name>
         <t indent="0" pn="section-5.2-1">List continues here.</t>
         <t indent="0" pn="section-5.2-2">Third list: </t>
-        <ol group="reqs" spacing="normal" type="R%d" start="7" indent="adaptive" pn="section-5.2-3"><li pn="section-5.2-3.1" derivedCounter="R7">#7</li>
-          <li pn="section-5.2-3.2" derivedCounter="R8">#8</li>
-          <li pn="section-5.2-3.3" derivedCounter="R9">#9</li>
-          <li pn="section-5.2-3.4" derivedCounter="R10">#10</li>
+        <ol group="reqs" spacing="normal" type="R%d" start="7" indent="adaptive" pn="section-5.2-3"><li pn="section-5.2-3.1" derivedCounter="R7">
+            <t indent="0" pn="section-5.2-3.1.1">#7</t>
+          </li>
+          <li pn="section-5.2-3.2" derivedCounter="R8">
+            <t indent="0" pn="section-5.2-3.2.1">#8</t>
+          </li>
+          <li pn="section-5.2-3.3" derivedCounter="R9">
+            <t indent="0" pn="section-5.2-3.3.1">#9</t>
+          </li>
+          <li pn="section-5.2-3.4" derivedCounter="R10">
+            <t indent="0" pn="section-5.2-3.4.1">#10</t>
+          </li>
         </ol>
         <t indent="0" pn="section-5.2-4"> The end of the list.</t>
       </section>
@@ -351,7 +379,9 @@
         <t indent="0" pn="section-5.3-1">Simulating more than one paragraph in a list item using
 	  &lt;vspace&gt;: 
         </t>
-        <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5.3-2"><li pn="section-5.3-2.1" derivedCounter="a.">First, a short item.</li>
+        <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5.3-2"><li pn="section-5.3-2.1" derivedCounter="a.">
+            <t indent="0" pn="section-5.3-2.1.1">First, a short item.</t>
+          </li>
           <li pn="section-5.3-2.2" derivedCounter="b.">
             <t indent="0" pn="section-5.3-2.2.1">Second, a longer list item.</t>
             <t indent="0" pn="section-5.3-2.2.2"> And
@@ -360,13 +390,21 @@
           <li pn="section-5.3-2.3" derivedCounter="c.">
             <t indent="0" pn="section-5.3-2.3.1">and a sublist, also with letters
             </t>
-            <ol spacing="normal" type="A" indent="adaptive" start="1" pn="section-5.3-2.3.2"><li pn="section-5.3-2.3.2.1" derivedCounter="A.">first subitem</li>
-              <li pn="section-5.3-2.3.2.2" derivedCounter="B.">second subitem</li>
+            <ol spacing="normal" type="A" indent="adaptive" start="1" pn="section-5.3-2.3.2"><li pn="section-5.3-2.3.2.1" derivedCounter="A.">
+                <t indent="0" pn="section-5.3-2.3.2.1.1">first subitem</t>
+              </li>
+              <li pn="section-5.3-2.3.2.2" derivedCounter="B.">
+                <t indent="0" pn="section-5.3-2.3.2.2.1">second subitem</t>
+              </li>
               <li pn="section-5.3-2.3.2.3" derivedCounter="C.">
                 <t indent="0" pn="section-5.3-2.3.2.3.1">and a sub-sublist, also with letters
                 </t>
-                <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5.3-2.3.2.3.2"><li pn="section-5.3-2.3.2.3.2.1" derivedCounter="a.">first sub-subitem</li>
-                  <li pn="section-5.3-2.3.2.3.2.2" derivedCounter="b.">second sub-subitem</li>
+                <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-5.3-2.3.2.3.2"><li pn="section-5.3-2.3.2.3.2.1" derivedCounter="a.">
+                    <t indent="0" pn="section-5.3-2.3.2.3.2.1.1">first sub-subitem</t>
+                  </li>
+                  <li pn="section-5.3-2.3.2.3.2.2" derivedCounter="b.">
+                    <t indent="0" pn="section-5.3-2.3.2.3.2.2.1">second sub-subitem</t>
+                  </li>
                 </ol>
               </li>
             </ol>
@@ -377,80 +415,214 @@
         <name slugifiedName="name-list-formats">List Formats</name>
         <t indent="0" pn="section-5.4-1">many formats
         </t>
-        <ol spacing="normal" type="%c" indent="adaptive" start="1" pn="section-5.4-2"><li pn="section-5.4-2.1" derivedCounter="a">first %c-item</li>
-          <li pn="section-5.4-2.2" derivedCounter="b">more %c-items</li>
+        <ol spacing="normal" type="%c" indent="adaptive" start="1" pn="section-5.4-2"><li pn="section-5.4-2.1" derivedCounter="a">
+            <t indent="0" pn="section-5.4-2.1.1">first %c-item</t>
+          </li>
+          <li pn="section-5.4-2.2" derivedCounter="b">
+            <t indent="0" pn="section-5.4-2.2.1">more %c-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%C" indent="adaptive" start="1" pn="section-5.4-3"><li pn="section-5.4-3.1" derivedCounter="A">first %C-item</li>
-          <li pn="section-5.4-3.2" derivedCounter="B">more %C-items</li>
+        <ol spacing="normal" type="%C" indent="adaptive" start="1" pn="section-5.4-3"><li pn="section-5.4-3.1" derivedCounter="A">
+            <t indent="0" pn="section-5.4-3.1.1">first %C-item</t>
+          </li>
+          <li pn="section-5.4-3.2" derivedCounter="B">
+            <t indent="0" pn="section-5.4-3.2.1">more %C-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%d" indent="adaptive" start="1" pn="section-5.4-4"><li pn="section-5.4-4.1" derivedCounter="1">first %d-item.</li>
-          <li pn="section-5.4-4.2" derivedCounter="2">more %d-items.</li>
+        <ol spacing="normal" type="%d" indent="adaptive" start="1" pn="section-5.4-4"><li pn="section-5.4-4.1" derivedCounter="1">
+            <t indent="0" pn="section-5.4-4.1.1">first %d-item.</t>
+          </li>
+          <li pn="section-5.4-4.2" derivedCounter="2">
+            <t indent="0" pn="section-5.4-4.2.1">more %d-items.</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%i" indent="adaptive" start="1" pn="section-5.4-5"><li pn="section-5.4-5.1" derivedCounter="i">first %i-item</li>
-          <li pn="section-5.4-5.2" derivedCounter="ii">more %i-items</li>
-          <li pn="section-5.4-5.3" derivedCounter="iii">more %i-items</li>
-          <li pn="section-5.4-5.4" derivedCounter="iv">more %i-items</li>
-          <li pn="section-5.4-5.5" derivedCounter="v">more %i-items</li>
-          <li pn="section-5.4-5.6" derivedCounter="vi">more %i-items</li>
-          <li pn="section-5.4-5.7" derivedCounter="vii">more %i-items</li>
-          <li pn="section-5.4-5.8" derivedCounter="viii">more %i-items</li>
-          <li pn="section-5.4-5.9" derivedCounter="ix">more %i-items</li>
+        <ol spacing="normal" type="%i" indent="adaptive" start="1" pn="section-5.4-5"><li pn="section-5.4-5.1" derivedCounter="i">
+            <t indent="0" pn="section-5.4-5.1.1">first %i-item</t>
+          </li>
+          <li pn="section-5.4-5.2" derivedCounter="ii">
+            <t indent="0" pn="section-5.4-5.2.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.3" derivedCounter="iii">
+            <t indent="0" pn="section-5.4-5.3.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.4" derivedCounter="iv">
+            <t indent="0" pn="section-5.4-5.4.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.5" derivedCounter="v">
+            <t indent="0" pn="section-5.4-5.5.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.6" derivedCounter="vi">
+            <t indent="0" pn="section-5.4-5.6.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.7" derivedCounter="vii">
+            <t indent="0" pn="section-5.4-5.7.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.8" derivedCounter="viii">
+            <t indent="0" pn="section-5.4-5.8.1">more %i-items</t>
+          </li>
+          <li pn="section-5.4-5.9" derivedCounter="ix">
+            <t indent="0" pn="section-5.4-5.9.1">more %i-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%I" indent="adaptive" start="1" pn="section-5.4-6"><li pn="section-5.4-6.1" derivedCounter="I">first %I-item</li>
-          <li pn="section-5.4-6.2" derivedCounter="II">more %I-items</li>
-          <li pn="section-5.4-6.3" derivedCounter="III">more %I-items</li>
-          <li pn="section-5.4-6.4" derivedCounter="IV">more %I-items</li>
-          <li pn="section-5.4-6.5" derivedCounter="V">more %I-items</li>
-          <li pn="section-5.4-6.6" derivedCounter="VI">more %I-items</li>
-          <li pn="section-5.4-6.7" derivedCounter="VII">more %I-items</li>
-          <li pn="section-5.4-6.8" derivedCounter="VIII">more %I-items</li>
-          <li pn="section-5.4-6.9" derivedCounter="IX">more %I-items</li>
+        <ol spacing="normal" type="%I" indent="adaptive" start="1" pn="section-5.4-6"><li pn="section-5.4-6.1" derivedCounter="I">
+            <t indent="0" pn="section-5.4-6.1.1">first %I-item</t>
+          </li>
+          <li pn="section-5.4-6.2" derivedCounter="II">
+            <t indent="0" pn="section-5.4-6.2.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.3" derivedCounter="III">
+            <t indent="0" pn="section-5.4-6.3.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.4" derivedCounter="IV">
+            <t indent="0" pn="section-5.4-6.4.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.5" derivedCounter="V">
+            <t indent="0" pn="section-5.4-6.5.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.6" derivedCounter="VI">
+            <t indent="0" pn="section-5.4-6.6.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.7" derivedCounter="VII">
+            <t indent="0" pn="section-5.4-6.7.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.8" derivedCounter="VIII">
+            <t indent="0" pn="section-5.4-6.8.1">more %I-items</t>
+          </li>
+          <li pn="section-5.4-6.9" derivedCounter="IX">
+            <t indent="0" pn="section-5.4-6.9.1">more %I-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%o" indent="adaptive" start="1" pn="section-5.4-7"><li pn="section-5.4-7.1" derivedCounter="1">first %o-item</li>
-          <li pn="section-5.4-7.2" derivedCounter="2">more %o-items</li>
-          <li pn="section-5.4-7.3" derivedCounter="3">more %o-items</li>
-          <li pn="section-5.4-7.4" derivedCounter="4">more %o-items</li>
-          <li pn="section-5.4-7.5" derivedCounter="5">more %o-items</li>
-          <li pn="section-5.4-7.6" derivedCounter="6">more %o-items</li>
-          <li pn="section-5.4-7.7" derivedCounter="7">more %o-items</li>
-          <li pn="section-5.4-7.8" derivedCounter="10">more %o-items</li>
-          <li pn="section-5.4-7.9" derivedCounter="11">more %o-items</li>
+        <ol spacing="normal" type="%o" indent="adaptive" start="1" pn="section-5.4-7"><li pn="section-5.4-7.1" derivedCounter="1">
+            <t indent="0" pn="section-5.4-7.1.1">first %o-item</t>
+          </li>
+          <li pn="section-5.4-7.2" derivedCounter="2">
+            <t indent="0" pn="section-5.4-7.2.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.3" derivedCounter="3">
+            <t indent="0" pn="section-5.4-7.3.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.4" derivedCounter="4">
+            <t indent="0" pn="section-5.4-7.4.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.5" derivedCounter="5">
+            <t indent="0" pn="section-5.4-7.5.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.6" derivedCounter="6">
+            <t indent="0" pn="section-5.4-7.6.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.7" derivedCounter="7">
+            <t indent="0" pn="section-5.4-7.7.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.8" derivedCounter="10">
+            <t indent="0" pn="section-5.4-7.8.1">more %o-items</t>
+          </li>
+          <li pn="section-5.4-7.9" derivedCounter="11">
+            <t indent="0" pn="section-5.4-7.9.1">more %o-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%x" indent="adaptive" start="1" pn="section-5.4-8"><li pn="section-5.4-8.1" derivedCounter="1">first %x-item</li>
-          <li pn="section-5.4-8.2" derivedCounter="2">more %x-items</li>
-          <li pn="section-5.4-8.3" derivedCounter="3">more %x-items</li>
-          <li pn="section-5.4-8.4" derivedCounter="4">more %x-items</li>
-          <li pn="section-5.4-8.5" derivedCounter="5">more %x-items</li>
-          <li pn="section-5.4-8.6" derivedCounter="6">more %x-items</li>
-          <li pn="section-5.4-8.7" derivedCounter="7">more %x-items</li>
-          <li pn="section-5.4-8.8" derivedCounter="8">more %x-items</li>
-          <li pn="section-5.4-8.9" derivedCounter="9">more %x-items</li>
-          <li pn="section-5.4-8.10" derivedCounter="a">more %x-items</li>
-          <li pn="section-5.4-8.11" derivedCounter="b">more %x-items</li>
-          <li pn="section-5.4-8.12" derivedCounter="c">more %x-items</li>
-          <li pn="section-5.4-8.13" derivedCounter="d">more %x-items</li>
-          <li pn="section-5.4-8.14" derivedCounter="e">more %x-items</li>
-          <li pn="section-5.4-8.15" derivedCounter="f">more %x-items</li>
-          <li pn="section-5.4-8.16" derivedCounter="10">more %x-items</li>
-          <li pn="section-5.4-8.17" derivedCounter="11">more %x-items</li>
+        <ol spacing="normal" type="%x" indent="adaptive" start="1" pn="section-5.4-8"><li pn="section-5.4-8.1" derivedCounter="1">
+            <t indent="0" pn="section-5.4-8.1.1">first %x-item</t>
+          </li>
+          <li pn="section-5.4-8.2" derivedCounter="2">
+            <t indent="0" pn="section-5.4-8.2.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.3" derivedCounter="3">
+            <t indent="0" pn="section-5.4-8.3.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.4" derivedCounter="4">
+            <t indent="0" pn="section-5.4-8.4.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.5" derivedCounter="5">
+            <t indent="0" pn="section-5.4-8.5.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.6" derivedCounter="6">
+            <t indent="0" pn="section-5.4-8.6.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.7" derivedCounter="7">
+            <t indent="0" pn="section-5.4-8.7.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.8" derivedCounter="8">
+            <t indent="0" pn="section-5.4-8.8.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.9" derivedCounter="9">
+            <t indent="0" pn="section-5.4-8.9.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.10" derivedCounter="a">
+            <t indent="0" pn="section-5.4-8.10.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.11" derivedCounter="b">
+            <t indent="0" pn="section-5.4-8.11.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.12" derivedCounter="c">
+            <t indent="0" pn="section-5.4-8.12.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.13" derivedCounter="d">
+            <t indent="0" pn="section-5.4-8.13.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.14" derivedCounter="e">
+            <t indent="0" pn="section-5.4-8.14.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.15" derivedCounter="f">
+            <t indent="0" pn="section-5.4-8.15.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.16" derivedCounter="10">
+            <t indent="0" pn="section-5.4-8.16.1">more %x-items</t>
+          </li>
+          <li pn="section-5.4-8.17" derivedCounter="11">
+            <t indent="0" pn="section-5.4-8.17.1">more %x-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%X" indent="adaptive" start="1" pn="section-5.4-9"><li pn="section-5.4-9.1" derivedCounter="1">first %X-item</li>
-          <li pn="section-5.4-9.2" derivedCounter="2">more %X-items</li>
-          <li pn="section-5.4-9.3" derivedCounter="3">more %X-items</li>
-          <li pn="section-5.4-9.4" derivedCounter="4">more %X-items</li>
-          <li pn="section-5.4-9.5" derivedCounter="5">more %X-items</li>
-          <li pn="section-5.4-9.6" derivedCounter="6">more %X-items</li>
-          <li pn="section-5.4-9.7" derivedCounter="7">more %X-items</li>
-          <li pn="section-5.4-9.8" derivedCounter="8">more %X-items</li>
-          <li pn="section-5.4-9.9" derivedCounter="9">more %X-items</li>
-          <li pn="section-5.4-9.10" derivedCounter="A">more %X-items</li>
-          <li pn="section-5.4-9.11" derivedCounter="B">more %X-items</li>
-          <li pn="section-5.4-9.12" derivedCounter="C">more %X-items</li>
-          <li pn="section-5.4-9.13" derivedCounter="D">more %X-items</li>
-          <li pn="section-5.4-9.14" derivedCounter="E">more %X-items</li>
-          <li pn="section-5.4-9.15" derivedCounter="F">more %X-items</li>
-          <li pn="section-5.4-9.16" derivedCounter="10">more %X-items</li>
-          <li pn="section-5.4-9.17" derivedCounter="11">more %X-items</li>
+        <ol spacing="normal" type="%X" indent="adaptive" start="1" pn="section-5.4-9"><li pn="section-5.4-9.1" derivedCounter="1">
+            <t indent="0" pn="section-5.4-9.1.1">first %X-item</t>
+          </li>
+          <li pn="section-5.4-9.2" derivedCounter="2">
+            <t indent="0" pn="section-5.4-9.2.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.3" derivedCounter="3">
+            <t indent="0" pn="section-5.4-9.3.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.4" derivedCounter="4">
+            <t indent="0" pn="section-5.4-9.4.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.5" derivedCounter="5">
+            <t indent="0" pn="section-5.4-9.5.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.6" derivedCounter="6">
+            <t indent="0" pn="section-5.4-9.6.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.7" derivedCounter="7">
+            <t indent="0" pn="section-5.4-9.7.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.8" derivedCounter="8">
+            <t indent="0" pn="section-5.4-9.8.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.9" derivedCounter="9">
+            <t indent="0" pn="section-5.4-9.9.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.10" derivedCounter="A">
+            <t indent="0" pn="section-5.4-9.10.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.11" derivedCounter="B">
+            <t indent="0" pn="section-5.4-9.11.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.12" derivedCounter="C">
+            <t indent="0" pn="section-5.4-9.12.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.13" derivedCounter="D">
+            <t indent="0" pn="section-5.4-9.13.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.14" derivedCounter="E">
+            <t indent="0" pn="section-5.4-9.14.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.15" derivedCounter="F">
+            <t indent="0" pn="section-5.4-9.15.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.16" derivedCounter="10">
+            <t indent="0" pn="section-5.4-9.16.1">more %X-items</t>
+          </li>
+          <li pn="section-5.4-9.17" derivedCounter="11">
+            <t indent="0" pn="section-5.4-9.17.1">more %X-items</t>
+          </li>
         </ol>
       </section>
     </section>

--- a/tests/valid/draft-template.v2v3.xml
+++ b/tests/valid/draft-template.v2v3.xml
@@ -30,7 +30,7 @@
 <?rfc multiple-initials="yes" ?>
 <!-- end of list of popular I-D processing instructions -->
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
-  <!-- xml2rfc v2v3 conversion 3.17.3 -->
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   <?v3xml2rfc silence=".*[Pp]ostal address" ?>
   <?v3xml2rfc silence="The document date .*? is more than 3 days away from today's date" ?>
   <?v3xml2rfc silence="Found SVG with width or height specified" ?>
@@ -126,8 +126,12 @@
       <t>List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
       'format'.</t>
       <ul spacing="normal">
-        <li>First bullet</li>
-        <li>Second bullet</li>
+        <li>
+          <t>First bullet</t>
+        </li>
+        <li>
+          <t>Second bullet</t>
+        </li>
       </ul>
       <t> You can write text here as well.</t>
     </section>
@@ -212,7 +216,9 @@
 
       <t>Simulating more than one paragraph in a list item using
       &lt;vspace&gt;: </t>
-      <ol spacing="normal" type="a"><li>First, a short item.</li>
+      <ol spacing="normal" type="a"><li>
+          <t>First, a short item.</t>
+        </li>
         <li>
           <t>Second, a longer list item.</t>
           <t> And
@@ -221,8 +227,10 @@
       </ol>
       <t>Simple indented paragraph using the "empty" style: </t>
       <ul empty="true" spacing="normal">
-        <li>The quick, brown fox jumped over the lazy dog and lived to fool
-          many another hunter in the great wood in the west.</li>
+        <li>
+          <t>The quick, brown fox jumped over the lazy dog and lived to fool
+          many another hunter in the great wood in the west.</t>
+        </li>
       </ul>
       <section>
         <name>Numbering Lists across Lists and Sections</name>
@@ -230,26 +238,46 @@
         &lt;list&gt; elements, maybe in separate sections using the "format"
         style and a "counter" variable.</t>
         <t>First list: </t>
-        <ol group="reqs" spacing="normal" type="R%d"><li>#1</li>
-          <li>#2</li>
-          <li>#3</li>
+        <ol group="reqs" spacing="normal" type="R%d"><li>
+            <t>#1</t>
+          </li>
+          <li>
+            <t>#2</t>
+          </li>
+          <li>
+            <t>#3</t>
+          </li>
         </ol>
         <t> Specify the indent explicitly so that all the items line up
         nicely.</t>
         <t>Second list: </t>
-        <ol group="reqs" spacing="normal" type="R%d"><li>#4</li>
-          <li>#5</li>
-          <li>#6</li>
+        <ol group="reqs" spacing="normal" type="R%d"><li>
+            <t>#4</t>
+          </li>
+          <li>
+            <t>#5</t>
+          </li>
+          <li>
+            <t>#6</t>
+          </li>
         </ol>
       </section>
       <section>
         <name>Where the List Numbering Continues</name>
         <t>List continues here.</t>
         <t>Third list: </t>
-        <ol group="reqs" spacing="normal" type="R%d"><li>#7</li>
-          <li>#8</li>
-          <li>#9</li>
-          <li>#10</li>
+        <ol group="reqs" spacing="normal" type="R%d"><li>
+            <t>#7</t>
+          </li>
+          <li>
+            <t>#8</t>
+          </li>
+          <li>
+            <t>#9</t>
+          </li>
+          <li>
+            <t>#10</t>
+          </li>
         </ol>
         <t> The end of the list.</t>
       </section>
@@ -258,7 +286,9 @@
         <t>Simulating more than one paragraph in a list item using
 	  &lt;vspace&gt;: 
         </t>
-        <ol spacing="normal" type="a"><li>First, a short item.</li>
+        <ol spacing="normal" type="a"><li>
+            <t>First, a short item.</t>
+          </li>
           <li>
             <t>Second, a longer list item.</t>
             <t> And
@@ -267,13 +297,21 @@
           <li>
             <t>and a sublist, also with letters
             </t>
-            <ol spacing="normal" type="A"><li>first subitem</li>
-              <li>second subitem</li>
+            <ol spacing="normal" type="A"><li>
+                <t>first subitem</t>
+              </li>
+              <li>
+                <t>second subitem</t>
+              </li>
               <li>
                 <t>and a sub-sublist, also with letters
                 </t>
-                <ol spacing="normal" type="a"><li>first sub-subitem</li>
-                  <li>second sub-subitem</li>
+                <ol spacing="normal" type="a"><li>
+                    <t>first sub-subitem</t>
+                  </li>
+                  <li>
+                    <t>second sub-subitem</t>
+                  </li>
                 </ol>
               </li>
             </ol>
@@ -284,80 +322,214 @@
         <name>List Formats</name>
         <t>many formats
         </t>
-        <ol spacing="normal" type="%c"><li>first %c-item</li>
-          <li>more %c-items</li>
+        <ol spacing="normal" type="%c"><li>
+            <t>first %c-item</t>
+          </li>
+          <li>
+            <t>more %c-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%C"><li>first %C-item</li>
-          <li>more %C-items</li>
+        <ol spacing="normal" type="%C"><li>
+            <t>first %C-item</t>
+          </li>
+          <li>
+            <t>more %C-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%d"><li>first %d-item.</li>
-          <li>more %d-items.</li>
+        <ol spacing="normal" type="%d"><li>
+            <t>first %d-item.</t>
+          </li>
+          <li>
+            <t>more %d-items.</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%i"><li>first %i-item</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
-          <li>more %i-items</li>
+        <ol spacing="normal" type="%i"><li>
+            <t>first %i-item</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
+          <li>
+            <t>more %i-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%I"><li>first %I-item</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
-          <li>more %I-items</li>
+        <ol spacing="normal" type="%I"><li>
+            <t>first %I-item</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
+          <li>
+            <t>more %I-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%o"><li>first %o-item</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
-          <li>more %o-items</li>
+        <ol spacing="normal" type="%o"><li>
+            <t>first %o-item</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
+          <li>
+            <t>more %o-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%x"><li>first %x-item</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
-          <li>more %x-items</li>
+        <ol spacing="normal" type="%x"><li>
+            <t>first %x-item</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
+          <li>
+            <t>more %x-items</t>
+          </li>
         </ol>
-        <ol spacing="normal" type="%X"><li>first %X-item</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
-          <li>more %X-items</li>
+        <ol spacing="normal" type="%X"><li>
+            <t>first %X-item</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
+          <li>
+            <t>more %X-items</t>
+          </li>
         </ol>
       </section>
     </section>

--- a/tests/valid/draft-template.v3.html
+++ b/tests/valid/draft-template.v3.html
@@ -11,7 +11,7 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.17.3" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <link href="tests/input/draft-template.xml" rel="alternate" type="application/rfc+xml">
@@ -212,9 +212,11 @@
 <p id="section-2-1">List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
       'format'.<a href="#section-2-1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-2-2.1">First bullet<a href="#section-2-2.1" class="pilcrow">¶</a>
+<li class="normal" id="section-2-2.1">
+          <p id="section-2-2.1.1">First bullet<a href="#section-2-2.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="normal" id="section-2-2.2">Second bullet<a href="#section-2-2.2" class="pilcrow">¶</a>
+        <li class="normal" id="section-2-2.2">
+          <p id="section-2-2.2.1">Second bullet<a href="#section-2-2.2.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <p id="section-2-3"> You can write text here as well.<a href="#section-2-3" class="pilcrow">¶</a></p>
@@ -323,7 +325,8 @@
 <p id="section-5-3">Simulating more than one paragraph in a list item using
       &lt;vspace&gt;:<a href="#section-5-3" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="section-5-4">
-<li id="section-5-4.1">First, a short item.<a href="#section-5-4.1" class="pilcrow">¶</a>
+<li id="section-5-4.1">
+          <p id="section-5-4.1.1">First, a short item.<a href="#section-5-4.1.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-5-4.2">
           <p id="section-5-4.2.1">Second, a longer list item.<a href="#section-5-4.2.1" class="pilcrow">¶</a></p>
@@ -333,8 +336,9 @@
       </ol>
 <p id="section-5-5">Simple indented paragraph using the "empty" style:<a href="#section-5-5" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
-<li class="normal ulEmpty" id="section-5-6.1">The quick, brown fox jumped over the lazy dog and lived to fool
-          many another hunter in the great wood in the west.<a href="#section-5-6.1" class="pilcrow">¶</a>
+<li class="normal ulEmpty" id="section-5-6.1">
+          <p id="section-5-6.1.1">The quick, brown fox jumped over the lazy dog and lived to fool
+          many another hunter in the great wood in the west.<a href="#section-5-6.1.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
 <section id="section-5.1">
@@ -347,15 +351,18 @@
 <p id="section-5.1-2">First list:<a href="#section-5.1-2" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.1-3">
 <dt>R1</dt>
-<dd id="section-5.1-3.1">#1<a href="#section-5.1-3.1" class="pilcrow">¶</a>
+<dd id="section-5.1-3.1">
+            <p id="section-5.1-3.1.1">#1<a href="#section-5.1-3.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R2</dt>
-<dd id="section-5.1-3.2">#2<a href="#section-5.1-3.2" class="pilcrow">¶</a>
+<dd id="section-5.1-3.2">
+            <p id="section-5.1-3.2.1">#2<a href="#section-5.1-3.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R3</dt>
-<dd id="section-5.1-3.3">#3<a href="#section-5.1-3.3" class="pilcrow">¶</a>
+<dd id="section-5.1-3.3">
+            <p id="section-5.1-3.3.1">#3<a href="#section-5.1-3.3.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -364,15 +371,18 @@
 <p id="section-5.1-5">Second list:<a href="#section-5.1-5" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.1-6">
 <dt>R4</dt>
-<dd id="section-5.1-6.1">#4<a href="#section-5.1-6.1" class="pilcrow">¶</a>
+<dd id="section-5.1-6.1">
+            <p id="section-5.1-6.1.1">#4<a href="#section-5.1-6.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R5</dt>
-<dd id="section-5.1-6.2">#5<a href="#section-5.1-6.2" class="pilcrow">¶</a>
+<dd id="section-5.1-6.2">
+            <p id="section-5.1-6.2.1">#5<a href="#section-5.1-6.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R6</dt>
-<dd id="section-5.1-6.3">#6<a href="#section-5.1-6.3" class="pilcrow">¶</a>
+<dd id="section-5.1-6.3">
+            <p id="section-5.1-6.3.1">#6<a href="#section-5.1-6.3.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -385,19 +395,23 @@
 <p id="section-5.2-2">Third list:<a href="#section-5.2-2" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.2-3">
 <dt>R7</dt>
-<dd id="section-5.2-3.1">#7<a href="#section-5.2-3.1" class="pilcrow">¶</a>
+<dd id="section-5.2-3.1">
+            <p id="section-5.2-3.1.1">#7<a href="#section-5.2-3.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R8</dt>
-<dd id="section-5.2-3.2">#8<a href="#section-5.2-3.2" class="pilcrow">¶</a>
+<dd id="section-5.2-3.2">
+            <p id="section-5.2-3.2.1">#8<a href="#section-5.2-3.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R9</dt>
-<dd id="section-5.2-3.3">#9<a href="#section-5.2-3.3" class="pilcrow">¶</a>
+<dd id="section-5.2-3.3">
+            <p id="section-5.2-3.3.1">#9<a href="#section-5.2-3.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>R10</dt>
-<dd id="section-5.2-3.4">#10<a href="#section-5.2-3.4" class="pilcrow">¶</a>
+<dd id="section-5.2-3.4">
+            <p id="section-5.2-3.4.1">#10<a href="#section-5.2-3.4.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -410,7 +424,8 @@
 <p id="section-5.3-1">Simulating more than one paragraph in a list item using
    &lt;vspace&gt;:<a href="#section-5.3-1" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="section-5.3-2">
-<li id="section-5.3-2.1">First, a short item.<a href="#section-5.3-2.1" class="pilcrow">¶</a>
+<li id="section-5.3-2.1">
+            <p id="section-5.3-2.1.1">First, a short item.<a href="#section-5.3-2.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-5.3-2.2">
             <p id="section-5.3-2.2.1">Second, a longer list item.<a href="#section-5.3-2.2.1" class="pilcrow">¶</a></p>
@@ -420,16 +435,20 @@
           <li id="section-5.3-2.3">
             <p id="section-5.3-2.3.1">and a sublist, also with letters<a href="#section-5.3-2.3.1" class="pilcrow">¶</a></p>
 <ol start="1" type="A" class="normal type-A" id="section-5.3-2.3.2">
-<li id="section-5.3-2.3.2.1">first subitem<a href="#section-5.3-2.3.2.1" class="pilcrow">¶</a>
+<li id="section-5.3-2.3.2.1">
+                <p id="section-5.3-2.3.2.1.1">first subitem<a href="#section-5.3-2.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li id="section-5.3-2.3.2.2">second subitem<a href="#section-5.3-2.3.2.2" class="pilcrow">¶</a>
+              <li id="section-5.3-2.3.2.2">
+                <p id="section-5.3-2.3.2.2.1">second subitem<a href="#section-5.3-2.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
               <li id="section-5.3-2.3.2.3">
                 <p id="section-5.3-2.3.2.3.1">and a sub-sublist, also with letters<a href="#section-5.3-2.3.2.3.1" class="pilcrow">¶</a></p>
 <ol start="1" type="a" class="normal type-a" id="section-5.3-2.3.2.3.2">
-<li id="section-5.3-2.3.2.3.2.1">first sub-subitem<a href="#section-5.3-2.3.2.3.2.1" class="pilcrow">¶</a>
+<li id="section-5.3-2.3.2.3.2.1">
+                    <p id="section-5.3-2.3.2.3.2.1.1">first sub-subitem<a href="#section-5.3-2.3.2.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
-                  <li id="section-5.3-2.3.2.3.2.2">second sub-subitem<a href="#section-5.3-2.3.2.3.2.2" class="pilcrow">¶</a>
+                  <li id="section-5.3-2.3.2.3.2.2">
+                    <p id="section-5.3-2.3.2.3.2.2.1">second sub-subitem<a href="#section-5.3-2.3.2.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
                 </ol>
 </li>
@@ -444,285 +463,352 @@
 <p id="section-5.4-1">many formats<a href="#section-5.4-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.4-2">
 <dt>a</dt>
-<dd id="section-5.4-2.1">first %c-item<a href="#section-5.4-2.1" class="pilcrow">¶</a>
+<dd id="section-5.4-2.1">
+            <p id="section-5.4-2.1.1">first %c-item<a href="#section-5.4-2.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>b</dt>
-<dd id="section-5.4-2.2">more %c-items<a href="#section-5.4-2.2" class="pilcrow">¶</a>
+<dd id="section-5.4-2.2">
+            <p id="section-5.4-2.2.1">more %c-items<a href="#section-5.4-2.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-3">
 <dt>A</dt>
-<dd id="section-5.4-3.1">first %C-item<a href="#section-5.4-3.1" class="pilcrow">¶</a>
+<dd id="section-5.4-3.1">
+            <p id="section-5.4-3.1.1">first %C-item<a href="#section-5.4-3.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>B</dt>
-<dd id="section-5.4-3.2">more %C-items<a href="#section-5.4-3.2" class="pilcrow">¶</a>
+<dd id="section-5.4-3.2">
+            <p id="section-5.4-3.2.1">more %C-items<a href="#section-5.4-3.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-4">
 <dt>1</dt>
-<dd id="section-5.4-4.1">first %d-item.<a href="#section-5.4-4.1" class="pilcrow">¶</a>
+<dd id="section-5.4-4.1">
+            <p id="section-5.4-4.1.1">first %d-item.<a href="#section-5.4-4.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>2</dt>
-<dd id="section-5.4-4.2">more %d-items.<a href="#section-5.4-4.2" class="pilcrow">¶</a>
+<dd id="section-5.4-4.2">
+            <p id="section-5.4-4.2.1">more %d-items.<a href="#section-5.4-4.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-5">
 <dt>i</dt>
-<dd id="section-5.4-5.1">first %i-item<a href="#section-5.4-5.1" class="pilcrow">¶</a>
+<dd id="section-5.4-5.1">
+            <p id="section-5.4-5.1.1">first %i-item<a href="#section-5.4-5.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>ii</dt>
-<dd id="section-5.4-5.2">more %i-items<a href="#section-5.4-5.2" class="pilcrow">¶</a>
+<dd id="section-5.4-5.2">
+            <p id="section-5.4-5.2.1">more %i-items<a href="#section-5.4-5.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>iii</dt>
-<dd id="section-5.4-5.3">more %i-items<a href="#section-5.4-5.3" class="pilcrow">¶</a>
+<dd id="section-5.4-5.3">
+            <p id="section-5.4-5.3.1">more %i-items<a href="#section-5.4-5.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>iv</dt>
-<dd id="section-5.4-5.4">more %i-items<a href="#section-5.4-5.4" class="pilcrow">¶</a>
+<dd id="section-5.4-5.4">
+            <p id="section-5.4-5.4.1">more %i-items<a href="#section-5.4-5.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>v</dt>
-<dd id="section-5.4-5.5">more %i-items<a href="#section-5.4-5.5" class="pilcrow">¶</a>
+<dd id="section-5.4-5.5">
+            <p id="section-5.4-5.5.1">more %i-items<a href="#section-5.4-5.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>vi</dt>
-<dd id="section-5.4-5.6">more %i-items<a href="#section-5.4-5.6" class="pilcrow">¶</a>
+<dd id="section-5.4-5.6">
+            <p id="section-5.4-5.6.1">more %i-items<a href="#section-5.4-5.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>vii</dt>
-<dd id="section-5.4-5.7">more %i-items<a href="#section-5.4-5.7" class="pilcrow">¶</a>
+<dd id="section-5.4-5.7">
+            <p id="section-5.4-5.7.1">more %i-items<a href="#section-5.4-5.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>viii</dt>
-<dd id="section-5.4-5.8">more %i-items<a href="#section-5.4-5.8" class="pilcrow">¶</a>
+<dd id="section-5.4-5.8">
+            <p id="section-5.4-5.8.1">more %i-items<a href="#section-5.4-5.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>ix</dt>
-<dd id="section-5.4-5.9">more %i-items<a href="#section-5.4-5.9" class="pilcrow">¶</a>
+<dd id="section-5.4-5.9">
+            <p id="section-5.4-5.9.1">more %i-items<a href="#section-5.4-5.9.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-6">
 <dt>I</dt>
-<dd id="section-5.4-6.1">first %I-item<a href="#section-5.4-6.1" class="pilcrow">¶</a>
+<dd id="section-5.4-6.1">
+            <p id="section-5.4-6.1.1">first %I-item<a href="#section-5.4-6.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>II</dt>
-<dd id="section-5.4-6.2">more %I-items<a href="#section-5.4-6.2" class="pilcrow">¶</a>
+<dd id="section-5.4-6.2">
+            <p id="section-5.4-6.2.1">more %I-items<a href="#section-5.4-6.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>III</dt>
-<dd id="section-5.4-6.3">more %I-items<a href="#section-5.4-6.3" class="pilcrow">¶</a>
+<dd id="section-5.4-6.3">
+            <p id="section-5.4-6.3.1">more %I-items<a href="#section-5.4-6.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>IV</dt>
-<dd id="section-5.4-6.4">more %I-items<a href="#section-5.4-6.4" class="pilcrow">¶</a>
+<dd id="section-5.4-6.4">
+            <p id="section-5.4-6.4.1">more %I-items<a href="#section-5.4-6.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>V</dt>
-<dd id="section-5.4-6.5">more %I-items<a href="#section-5.4-6.5" class="pilcrow">¶</a>
+<dd id="section-5.4-6.5">
+            <p id="section-5.4-6.5.1">more %I-items<a href="#section-5.4-6.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>VI</dt>
-<dd id="section-5.4-6.6">more %I-items<a href="#section-5.4-6.6" class="pilcrow">¶</a>
+<dd id="section-5.4-6.6">
+            <p id="section-5.4-6.6.1">more %I-items<a href="#section-5.4-6.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>VII</dt>
-<dd id="section-5.4-6.7">more %I-items<a href="#section-5.4-6.7" class="pilcrow">¶</a>
+<dd id="section-5.4-6.7">
+            <p id="section-5.4-6.7.1">more %I-items<a href="#section-5.4-6.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>VIII</dt>
-<dd id="section-5.4-6.8">more %I-items<a href="#section-5.4-6.8" class="pilcrow">¶</a>
+<dd id="section-5.4-6.8">
+            <p id="section-5.4-6.8.1">more %I-items<a href="#section-5.4-6.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>IX</dt>
-<dd id="section-5.4-6.9">more %I-items<a href="#section-5.4-6.9" class="pilcrow">¶</a>
+<dd id="section-5.4-6.9">
+            <p id="section-5.4-6.9.1">more %I-items<a href="#section-5.4-6.9.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-7">
 <dt>1</dt>
-<dd id="section-5.4-7.1">first %o-item<a href="#section-5.4-7.1" class="pilcrow">¶</a>
+<dd id="section-5.4-7.1">
+            <p id="section-5.4-7.1.1">first %o-item<a href="#section-5.4-7.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>2</dt>
-<dd id="section-5.4-7.2">more %o-items<a href="#section-5.4-7.2" class="pilcrow">¶</a>
+<dd id="section-5.4-7.2">
+            <p id="section-5.4-7.2.1">more %o-items<a href="#section-5.4-7.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>3</dt>
-<dd id="section-5.4-7.3">more %o-items<a href="#section-5.4-7.3" class="pilcrow">¶</a>
+<dd id="section-5.4-7.3">
+            <p id="section-5.4-7.3.1">more %o-items<a href="#section-5.4-7.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>4</dt>
-<dd id="section-5.4-7.4">more %o-items<a href="#section-5.4-7.4" class="pilcrow">¶</a>
+<dd id="section-5.4-7.4">
+            <p id="section-5.4-7.4.1">more %o-items<a href="#section-5.4-7.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>5</dt>
-<dd id="section-5.4-7.5">more %o-items<a href="#section-5.4-7.5" class="pilcrow">¶</a>
+<dd id="section-5.4-7.5">
+            <p id="section-5.4-7.5.1">more %o-items<a href="#section-5.4-7.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>6</dt>
-<dd id="section-5.4-7.6">more %o-items<a href="#section-5.4-7.6" class="pilcrow">¶</a>
+<dd id="section-5.4-7.6">
+            <p id="section-5.4-7.6.1">more %o-items<a href="#section-5.4-7.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>7</dt>
-<dd id="section-5.4-7.7">more %o-items<a href="#section-5.4-7.7" class="pilcrow">¶</a>
+<dd id="section-5.4-7.7">
+            <p id="section-5.4-7.7.1">more %o-items<a href="#section-5.4-7.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>10</dt>
-<dd id="section-5.4-7.8">more %o-items<a href="#section-5.4-7.8" class="pilcrow">¶</a>
+<dd id="section-5.4-7.8">
+            <p id="section-5.4-7.8.1">more %o-items<a href="#section-5.4-7.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>11</dt>
-<dd id="section-5.4-7.9">more %o-items<a href="#section-5.4-7.9" class="pilcrow">¶</a>
+<dd id="section-5.4-7.9">
+            <p id="section-5.4-7.9.1">more %o-items<a href="#section-5.4-7.9.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-8">
 <dt>1</dt>
-<dd id="section-5.4-8.1">first %x-item<a href="#section-5.4-8.1" class="pilcrow">¶</a>
+<dd id="section-5.4-8.1">
+            <p id="section-5.4-8.1.1">first %x-item<a href="#section-5.4-8.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>2</dt>
-<dd id="section-5.4-8.2">more %x-items<a href="#section-5.4-8.2" class="pilcrow">¶</a>
+<dd id="section-5.4-8.2">
+            <p id="section-5.4-8.2.1">more %x-items<a href="#section-5.4-8.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>3</dt>
-<dd id="section-5.4-8.3">more %x-items<a href="#section-5.4-8.3" class="pilcrow">¶</a>
+<dd id="section-5.4-8.3">
+            <p id="section-5.4-8.3.1">more %x-items<a href="#section-5.4-8.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>4</dt>
-<dd id="section-5.4-8.4">more %x-items<a href="#section-5.4-8.4" class="pilcrow">¶</a>
+<dd id="section-5.4-8.4">
+            <p id="section-5.4-8.4.1">more %x-items<a href="#section-5.4-8.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>5</dt>
-<dd id="section-5.4-8.5">more %x-items<a href="#section-5.4-8.5" class="pilcrow">¶</a>
+<dd id="section-5.4-8.5">
+            <p id="section-5.4-8.5.1">more %x-items<a href="#section-5.4-8.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>6</dt>
-<dd id="section-5.4-8.6">more %x-items<a href="#section-5.4-8.6" class="pilcrow">¶</a>
+<dd id="section-5.4-8.6">
+            <p id="section-5.4-8.6.1">more %x-items<a href="#section-5.4-8.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>7</dt>
-<dd id="section-5.4-8.7">more %x-items<a href="#section-5.4-8.7" class="pilcrow">¶</a>
+<dd id="section-5.4-8.7">
+            <p id="section-5.4-8.7.1">more %x-items<a href="#section-5.4-8.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>8</dt>
-<dd id="section-5.4-8.8">more %x-items<a href="#section-5.4-8.8" class="pilcrow">¶</a>
+<dd id="section-5.4-8.8">
+            <p id="section-5.4-8.8.1">more %x-items<a href="#section-5.4-8.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>9</dt>
-<dd id="section-5.4-8.9">more %x-items<a href="#section-5.4-8.9" class="pilcrow">¶</a>
+<dd id="section-5.4-8.9">
+            <p id="section-5.4-8.9.1">more %x-items<a href="#section-5.4-8.9.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>a</dt>
-<dd id="section-5.4-8.10">more %x-items<a href="#section-5.4-8.10" class="pilcrow">¶</a>
+<dd id="section-5.4-8.10">
+            <p id="section-5.4-8.10.1">more %x-items<a href="#section-5.4-8.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>b</dt>
-<dd id="section-5.4-8.11">more %x-items<a href="#section-5.4-8.11" class="pilcrow">¶</a>
+<dd id="section-5.4-8.11">
+            <p id="section-5.4-8.11.1">more %x-items<a href="#section-5.4-8.11.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>c</dt>
-<dd id="section-5.4-8.12">more %x-items<a href="#section-5.4-8.12" class="pilcrow">¶</a>
+<dd id="section-5.4-8.12">
+            <p id="section-5.4-8.12.1">more %x-items<a href="#section-5.4-8.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>d</dt>
-<dd id="section-5.4-8.13">more %x-items<a href="#section-5.4-8.13" class="pilcrow">¶</a>
+<dd id="section-5.4-8.13">
+            <p id="section-5.4-8.13.1">more %x-items<a href="#section-5.4-8.13.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>e</dt>
-<dd id="section-5.4-8.14">more %x-items<a href="#section-5.4-8.14" class="pilcrow">¶</a>
+<dd id="section-5.4-8.14">
+            <p id="section-5.4-8.14.1">more %x-items<a href="#section-5.4-8.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>f</dt>
-<dd id="section-5.4-8.15">more %x-items<a href="#section-5.4-8.15" class="pilcrow">¶</a>
+<dd id="section-5.4-8.15">
+            <p id="section-5.4-8.15.1">more %x-items<a href="#section-5.4-8.15.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>10</dt>
-<dd id="section-5.4-8.16">more %x-items<a href="#section-5.4-8.16" class="pilcrow">¶</a>
+<dd id="section-5.4-8.16">
+            <p id="section-5.4-8.16.1">more %x-items<a href="#section-5.4-8.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>11</dt>
-<dd id="section-5.4-8.17">more %x-items<a href="#section-5.4-8.17" class="pilcrow">¶</a>
+<dd id="section-5.4-8.17">
+            <p id="section-5.4-8.17.1">more %x-items<a href="#section-5.4-8.17.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 <span class="break"></span><dl class="olPercent" id="section-5.4-9">
 <dt>1</dt>
-<dd id="section-5.4-9.1">first %X-item<a href="#section-5.4-9.1" class="pilcrow">¶</a>
+<dd id="section-5.4-9.1">
+            <p id="section-5.4-9.1.1">first %X-item<a href="#section-5.4-9.1.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>2</dt>
-<dd id="section-5.4-9.2">more %X-items<a href="#section-5.4-9.2" class="pilcrow">¶</a>
+<dd id="section-5.4-9.2">
+            <p id="section-5.4-9.2.1">more %X-items<a href="#section-5.4-9.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>3</dt>
-<dd id="section-5.4-9.3">more %X-items<a href="#section-5.4-9.3" class="pilcrow">¶</a>
+<dd id="section-5.4-9.3">
+            <p id="section-5.4-9.3.1">more %X-items<a href="#section-5.4-9.3.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>4</dt>
-<dd id="section-5.4-9.4">more %X-items<a href="#section-5.4-9.4" class="pilcrow">¶</a>
+<dd id="section-5.4-9.4">
+            <p id="section-5.4-9.4.1">more %X-items<a href="#section-5.4-9.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>5</dt>
-<dd id="section-5.4-9.5">more %X-items<a href="#section-5.4-9.5" class="pilcrow">¶</a>
+<dd id="section-5.4-9.5">
+            <p id="section-5.4-9.5.1">more %X-items<a href="#section-5.4-9.5.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>6</dt>
-<dd id="section-5.4-9.6">more %X-items<a href="#section-5.4-9.6" class="pilcrow">¶</a>
+<dd id="section-5.4-9.6">
+            <p id="section-5.4-9.6.1">more %X-items<a href="#section-5.4-9.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>7</dt>
-<dd id="section-5.4-9.7">more %X-items<a href="#section-5.4-9.7" class="pilcrow">¶</a>
+<dd id="section-5.4-9.7">
+            <p id="section-5.4-9.7.1">more %X-items<a href="#section-5.4-9.7.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>8</dt>
-<dd id="section-5.4-9.8">more %X-items<a href="#section-5.4-9.8" class="pilcrow">¶</a>
+<dd id="section-5.4-9.8">
+            <p id="section-5.4-9.8.1">more %X-items<a href="#section-5.4-9.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>9</dt>
-<dd id="section-5.4-9.9">more %X-items<a href="#section-5.4-9.9" class="pilcrow">¶</a>
+<dd id="section-5.4-9.9">
+            <p id="section-5.4-9.9.1">more %X-items<a href="#section-5.4-9.9.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>A</dt>
-<dd id="section-5.4-9.10">more %X-items<a href="#section-5.4-9.10" class="pilcrow">¶</a>
+<dd id="section-5.4-9.10">
+            <p id="section-5.4-9.10.1">more %X-items<a href="#section-5.4-9.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>B</dt>
-<dd id="section-5.4-9.11">more %X-items<a href="#section-5.4-9.11" class="pilcrow">¶</a>
+<dd id="section-5.4-9.11">
+            <p id="section-5.4-9.11.1">more %X-items<a href="#section-5.4-9.11.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>C</dt>
-<dd id="section-5.4-9.12">more %X-items<a href="#section-5.4-9.12" class="pilcrow">¶</a>
+<dd id="section-5.4-9.12">
+            <p id="section-5.4-9.12.1">more %X-items<a href="#section-5.4-9.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>D</dt>
-<dd id="section-5.4-9.13">more %X-items<a href="#section-5.4-9.13" class="pilcrow">¶</a>
+<dd id="section-5.4-9.13">
+            <p id="section-5.4-9.13.1">more %X-items<a href="#section-5.4-9.13.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>E</dt>
-<dd id="section-5.4-9.14">more %X-items<a href="#section-5.4-9.14" class="pilcrow">¶</a>
+<dd id="section-5.4-9.14">
+            <p id="section-5.4-9.14.1">more %X-items<a href="#section-5.4-9.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>F</dt>
-<dd id="section-5.4-9.15">more %X-items<a href="#section-5.4-9.15" class="pilcrow">¶</a>
+<dd id="section-5.4-9.15">
+            <p id="section-5.4-9.15.1">more %X-items<a href="#section-5.4-9.15.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>10</dt>
-<dd id="section-5.4-9.16">more %X-items<a href="#section-5.4-9.16" class="pilcrow">¶</a>
+<dd id="section-5.4-9.16">
+            <p id="section-5.4-9.16.1">more %X-items<a href="#section-5.4-9.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt>11</dt>
-<dd id="section-5.4-9.17">more %X-items<a href="#section-5.4-9.17" class="pilcrow">¶</a>
+<dd id="section-5.4-9.17">
+            <p id="section-5.4-9.17.1">more %X-items<a href="#section-5.4-9.17.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           August 21, 2023
+Internet-Draft                                           August 29, 2023
 Intended status: Experimental                                           
-Expires: February 22, 2024
+Expires: March 1, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 22, 2024.
+   This Internet-Draft will expire on March 1, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires February 22, 2024               [Page 1]
+Person                    Expires March 1, 2024                 [Page 1]
 
 Internet-Draft             xml2rfc index tests               August 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires February 22, 2024               [Page 2]
+Person                    Expires March 1, 2024                 [Page 2]
 
 Internet-Draft             xml2rfc index tests               August 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires February 22, 2024               [Page 3]
+Person                    Expires March 1, 2024                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-08-21T04:28:58" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-08-29T11:20:28" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="21" month="08" year="2023"/>
+    <date day="29" month="08" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 22 February 2024.
+        This Internet-Draft will expire on 1 March 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           August 21, 2023
+Internet-Draft                                           August 29, 2023
 Intended status: Experimental                                           
-Expires: February 22, 2024
+Expires: March 1, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 22, 2024.
+   This Internet-Draft will expire on March 1, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires February 22, 2024</td>
+<td class="center">Expires March 1, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-21" class="published">August 21, 2023</time>
+<time datetime="2023-08-29" class="published">August 29, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-02-22">February 22, 2024</time></dd>
+<dd class="expires"><time datetime="2024-03-01">March 1, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on February 22, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on March 1, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                          21 August 2023
+                                                          29 August 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -1460,27 +1460,31 @@ li > p:last-of-type:only-child {
 <li class="normal ulEmpty" id="section-4-4.1">
           <p id="section-4-4.1.1">Address Family Identifier (AFI):<a href="#section-4-4.1.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-4-4.1.2.1">This field is the same as the one used in <span>[<a href="#RFC4760" class="cite xref">RFC4760</a>]</span>.<a href="#section-4-4.1.2.1" class="pilcrow">¶</a>
+<li class="normal" id="section-4-4.1.2.1">
+              <p id="section-4-4.1.2.1.1">This field is the same as the one used in <span>[<a href="#RFC4760" class="cite xref">RFC4760</a>]</span>.<a href="#section-4-4.1.2.1.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>
         <li class="normal ulEmpty" id="section-4-4.2">
           <p id="section-4-4.2.1">Subsequent Address Family Identifier (SAFI):<a href="#section-4-4.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-4-4.2.2.1">This field is the same as the one used in <span>[<a href="#RFC4760" class="cite xref">RFC4760</a>]</span>.<a href="#section-4-4.2.2.1" class="pilcrow">¶</a>
+<li class="normal" id="section-4-4.2.2.1">
+              <p id="section-4-4.2.2.1.1">This field is the same as the one used in <span>[<a href="#RFC4760" class="cite xref">RFC4760</a>]</span>.<a href="#section-4-4.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>
         <li class="normal ulEmpty" id="section-4-4.3">
           <p id="section-4-4.3.1">Send/Receive:<a href="#section-4-4.3.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-4-4.3.2.1">This field indicates whether the sender is (a) able to
+<li class="normal" id="section-4-4.3.2.1">
+              <p id="section-4-4.3.2.1.1">This field indicates whether the sender is (a) able to
               receive multiple paths from its peer (value 1), (b) able to send
               multiple paths to its peer (value 2), or (c) both (value 3) for
-              the &lt;AFI, SAFI&gt;.<a href="#section-4-4.3.2.1" class="pilcrow">¶</a>
+              the &lt;AFI, SAFI&gt;.<a href="#section-4-4.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-4-4.3.2.2">If any other value is received, then the capability SHOULD be
-              treated as not understood and ignored <span>[<a href="#RFC5492" class="cite xref">RFC5492</a>]</span>.<a href="#section-4-4.3.2.2" class="pilcrow">¶</a>
+            <li class="normal" id="section-4-4.3.2.2">
+              <p id="section-4-4.3.2.2.1">If any other value is received, then the capability SHOULD be
+              treated as not understood and ignored <span>[<a href="#RFC5492" class="cite xref">RFC5492</a>]</span>.<a href="#section-4-4.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>

--- a/tests/valid/rfc7911.prepped.xml
+++ b/tests/valid/rfc7911.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" number="7911" category="std" consensus="true" submissionType="IETF" ipr="trust200902" docName="draft-ietf-idr-add-paths" obsoletes="" updates="" xml:lang="en" tocInclude="true" sortRefs="true" symRefs="true" prepTime="2023-08-02T01:28:17" indexInclude="true" scripts="Common,Latin" tocDepth="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" number="7911" category="std" consensus="true" submissionType="IETF" ipr="trust200902" docName="draft-ietf-idr-add-paths" obsoletes="" updates="" xml:lang="en" tocInclude="true" sortRefs="true" symRefs="true" prepTime="2023-08-29T11:29:51" indexInclude="true" scripts="Common,Latin" tocDepth="3">
   <link href="https://dx.doi.org/10.17487/rfc7911" rel="alternate"/>
   <link href="urn:issn:2070-1721" rel="alternate"/>
   <link href="https://datatracker.ietf.org/doc/draft-ietf-idr-add-paths" rel="prev"/>
@@ -241,24 +241,32 @@
         <li pn="section-4-4.1">
           <t indent="0" pn="section-4-4.1.1">Address Family Identifier (AFI): </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4-4.1.2">
-            <li pn="section-4-4.1.2.1">This field is the same as the one used in <xref format="default" target="RFC4760" sectionFormat="of" derivedContent="RFC4760"/>.</li>
+            <li pn="section-4-4.1.2.1">
+              <t indent="0" pn="section-4-4.1.2.1.1">This field is the same as the one used in <xref format="default" target="RFC4760" sectionFormat="of" derivedContent="RFC4760"/>.</t>
+            </li>
           </ul>
         </li>
         <li pn="section-4-4.2">
           <t indent="0" pn="section-4-4.2.1">Subsequent Address Family Identifier (SAFI): </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4-4.2.2">
-            <li pn="section-4-4.2.2.1">This field is the same as the one used in <xref format="default" target="RFC4760" sectionFormat="of" derivedContent="RFC4760"/>.</li>
+            <li pn="section-4-4.2.2.1">
+              <t indent="0" pn="section-4-4.2.2.1.1">This field is the same as the one used in <xref format="default" target="RFC4760" sectionFormat="of" derivedContent="RFC4760"/>.</t>
+            </li>
           </ul>
         </li>
         <li pn="section-4-4.3">
           <t indent="0" pn="section-4-4.3.1">Send/Receive: </t>
           <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4-4.3.2">
-            <li pn="section-4-4.3.2.1">This field indicates whether the sender is (a) able to
+            <li pn="section-4-4.3.2.1">
+              <t indent="0" pn="section-4-4.3.2.1.1">This field indicates whether the sender is (a) able to
               receive multiple paths from its peer (value 1), (b) able to send
               multiple paths to its peer (value 2), or (c) both (value 3) for
-              the &lt;AFI, SAFI&gt;.</li>
-            <li pn="section-4-4.3.2.2">If any other value is received, then the capability SHOULD be
-              treated as not understood and ignored <xref format="default" target="RFC5492" sectionFormat="of" derivedContent="RFC5492"/>.</li>
+              the &lt;AFI, SAFI&gt;.</t>
+            </li>
+            <li pn="section-4-4.3.2.2">
+              <t indent="0" pn="section-4-4.3.2.2.1">If any other value is received, then the capability SHOULD be
+              treated as not understood and ignored <xref format="default" target="RFC5492" sectionFormat="of" derivedContent="RFC5492"/>.</t>
+            </li>
           </ul>
         </li>
       </ul>

--- a/tests/valid/rfc7911.v2v3.xml
+++ b/tests/valid/rfc7911.v2v3.xml
@@ -11,7 +11,7 @@
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" number="7911" category="std" consensus="true" submissionType="IETF" ipr="trust200902" docName="draft-ietf-idr-add-paths" obsoletes="" updates="" xml:lang="en" tocInclude="true" sortRefs="true" symRefs="true" version="3">
-  <!-- xml2rfc v2v3 conversion 3.17.5 -->
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   <link href="https://datatracker.ietf.org/doc/draft-ietf-idr-add-paths" rel="prev"/>
   <front>
     <title abbrev="ADD-PATH">Advertisement of Multiple Paths in BGP</title>
@@ -159,24 +159,32 @@
         <li>
           <t>Address Family Identifier (AFI): </t>
           <ul spacing="normal">
-            <li>This field is the same as the one used in <xref format="default" target="RFC4760"/>.</li>
+            <li>
+              <t>This field is the same as the one used in <xref format="default" target="RFC4760"/>.</t>
+            </li>
           </ul>
         </li>
         <li>
           <t>Subsequent Address Family Identifier (SAFI): </t>
           <ul spacing="normal">
-            <li>This field is the same as the one used in <xref format="default" target="RFC4760"/>.</li>
+            <li>
+              <t>This field is the same as the one used in <xref format="default" target="RFC4760"/>.</t>
+            </li>
           </ul>
         </li>
         <li>
           <t>Send/Receive: </t>
           <ul spacing="normal">
-            <li>This field indicates whether the sender is (a) able to
+            <li>
+              <t>This field indicates whether the sender is (a) able to
               receive multiple paths from its peer (value 1), (b) able to send
               multiple paths to its peer (value 2), or (c) both (value 3) for
-              the &lt;AFI, SAFI&gt;.</li>
-            <li>If any other value is received, then the capability SHOULD be
-              treated as not understood and ignored <xref format="default" target="RFC5492"/>.</li>
+              the &lt;AFI, SAFI&gt;.</t>
+            </li>
+            <li>
+              <t>If any other value is received, then the capability SHOULD be
+              treated as not understood and ignored <xref format="default" target="RFC5492"/>.</t>
+            </li>
           </ul>
         </li>
       </ul>

--- a/tests/valid/rfc7911.v3.html
+++ b/tests/valid/rfc7911.v3.html
@@ -16,7 +16,7 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.15.3" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="7911" name="rfc.number">
 <link href="tests/input/rfc7911.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -280,27 +280,31 @@
 <li class="normal ulEmpty" id="section-4-4.1">
           <p id="section-4-4.1.1">Address Family Identifier (AFI):<a href="#section-4-4.1.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-4-4.1.2.1">This field is the same as the one used in <span>[<a href="#RFC4760" class="cite xref">RFC4760</a>]</span>.<a href="#section-4-4.1.2.1" class="pilcrow">¶</a>
+<li class="normal" id="section-4-4.1.2.1">
+              <p id="section-4-4.1.2.1.1">This field is the same as the one used in <span>[<a href="#RFC4760" class="cite xref">RFC4760</a>]</span>.<a href="#section-4-4.1.2.1.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>
         <li class="normal ulEmpty" id="section-4-4.2">
           <p id="section-4-4.2.1">Subsequent Address Family Identifier (SAFI):<a href="#section-4-4.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-4-4.2.2.1">This field is the same as the one used in <span>[<a href="#RFC4760" class="cite xref">RFC4760</a>]</span>.<a href="#section-4-4.2.2.1" class="pilcrow">¶</a>
+<li class="normal" id="section-4-4.2.2.1">
+              <p id="section-4-4.2.2.1.1">This field is the same as the one used in <span>[<a href="#RFC4760" class="cite xref">RFC4760</a>]</span>.<a href="#section-4-4.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>
         <li class="normal ulEmpty" id="section-4-4.3">
           <p id="section-4-4.3.1">Send/Receive:<a href="#section-4-4.3.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-4-4.3.2.1">This field indicates whether the sender is (a) able to
+<li class="normal" id="section-4-4.3.2.1">
+              <p id="section-4-4.3.2.1.1">This field indicates whether the sender is (a) able to
               receive multiple paths from its peer (value 1), (b) able to send
               multiple paths to its peer (value 2), or (c) both (value 3) for
-              the &lt;AFI, SAFI&gt;.<a href="#section-4-4.3.2.1" class="pilcrow">¶</a>
+              the &lt;AFI, SAFI&gt;.<a href="#section-4-4.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="normal" id="section-4-4.3.2.2">If any other value is received, then the capability SHOULD be
-              treated as not understood and ignored <span>[<a href="#RFC5492" class="cite xref">RFC5492</a>]</span>.<a href="#section-4-4.3.2.2" class="pilcrow">¶</a>
+            <li class="normal" id="section-4-4.3.2.2">
+              <p id="section-4-4.3.2.2.1">If any other value is received, then the capability SHOULD be
+              treated as not understood and ignored <span>[<a href="#RFC5492" class="cite xref">RFC5492</a>]</span>.<a href="#section-4-4.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
 </li>

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           August 21, 2023
+Internet-Draft                                           August 29, 2023
 Intended status: Experimental                                           
-Expires: February 22, 2024
+Expires: March 1, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 22, 2024.
+   This Internet-Draft will expire on March 1, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires February 22, 2024               [Page 1]
+Person                    Expires March 1, 2024                 [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
 
-Person                  Expires February 22, 2024               [Page 2]
+Person                    Expires March 1, 2024                 [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
 
-Person                  Expires February 22, 2024               [Page 3]
+Person                    Expires March 1, 2024                 [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires February 22, 2024               [Page 4]
+Person                    Expires March 1, 2024                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-08-21T04:29:06" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-08-29T11:20:36" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="21" month="08" year="2023"/>
+    <date day="29" month="08" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 22 February 2024.
+        This Internet-Draft will expire on 1 March 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           August 21, 2023
+Internet-Draft                                           August 29, 2023
 Intended status: Experimental                                           
-Expires: February 22, 2024
+Expires: March 1, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 22, 2024.
+   This Internet-Draft will expire on March 1, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires February 22, 2024</td>
+<td class="center">Expires March 1, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-21" class="published">August 21, 2023</time>
+<time datetime="2023-08-29" class="published">August 29, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-02-22">February 22, 2024</time></dd>
+<dd class="expires"><time datetime="2024-03-01">March 1, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on February 22, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on March 1, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/writers/v2v3.py
+++ b/xml2rfc/writers/v2v3.py
@@ -848,6 +848,8 @@ class V2v3XmlWriter(BaseV3Writer):
         stripattr(l, ['hangIndent'])
         if tag in ['ol', 'ul']:
             for t in l.findall('./t'):
+                new = self.element('t', line=t.sourceline)
+                self.wrap_content(t, new)
                 self.replace(t, 'li')
         elif tag == 'dl':
             if indent:


### PR DESCRIPTION
This change preserves `<t>` elements inside `<ol>` and `<li>` elements
on v2v3 conversion.

Fixes #850