### PR TITLE
fix: Remove extend-to-zoom from viewport in CSS

### DIFF
--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -24,7 +24,6 @@
 
 @viewport {
   zoom: 1.0;
-  width: extend-to-zoom;
 }
 @-ms-viewport {
   width: extend-to-zoom;


### PR DESCRIPTION
This change removes the `width: extend-to-zoom` setting from `@viewport`.

Fixes #974