### PR TITLE
Include page numbers in the TOC when generating PDF.

### DIFF
--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -215,6 +215,12 @@ page_css_template = """
       margin-top: 1em;
     }}
   }}
+  #toc nav ul li p a:nth-child(2)::after {{
+    content: target-counter(attr(href), page);
+    position: absolute;
+    right: 0px;
+    text-indent: 0px;
+  }}
 }}
 """
 


### PR DESCRIPTION
Previously, the table of contents only included the section numbers and a link into the document.  Neither is really helpful when navigating a printout.

Add page numbers to the table of contents in the generated PDF.