### PR TITLE
fix: Remove old tools server from BibXML lookup locations

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.17.2</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.17.3</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.17.2" name="generator">
-<meta content="xml2rfc-docs-3.17.2" name="ietf.draft">
+<meta content="xml2rfc 3.17.3" name="generator">
+<meta content="xml2rfc-docs-3.17.3" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-06-05" class="published">5 June 2023</time>
+<time datetime="2023-06-14" class="published">14 June 2023</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
@@ -49,7 +49,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.17.2</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.17.3</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -371,7 +371,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://ietf-tools.github.io/xml2rfc/">https://ietf-tools.github.io/xml2rfc/</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.17.2.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.17.3.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6366,7 +6366,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.17.2:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.17.3:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.17.2" name="generator">
+<meta content="xml2rfc 3.17.3" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -26,11 +26,11 @@
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.17.2
+  xml2rfc 3.17.3
     Python 3.10.6
     appdirs 1.4.4
     ConfigArgParse 1.5.3
-    google-i18n-address 3.0.0
+    google-i18n-address 3.1.0
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -11,15 +11,15 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.17.2" name="generator">
+<meta content="xml2rfc 3.17.3" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.17.2
+  xml2rfc 3.17.3
     Python 3.10.6
     appdirs 1.4.4
     ConfigArgParse 1.5.3
-    google-i18n-address 3.0.0
+    google-i18n-address 3.1.0
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              June 5, 2023
+Internet-Draft                                             June 14, 2023
 Intended status: Experimental                                           
-Expires: December 7, 2023
+Expires: December 16, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 7, 2023.
+   This Internet-Draft will expire on December 16, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires December 7, 2023                [Page 1]
+Person                  Expires December 16, 2023               [Page 1]
 
 Internet-Draft             xml2rfc index tests                 June 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires December 7, 2023                [Page 2]
+Person                  Expires December 16, 2023               [Page 2]
 
 Internet-Draft             xml2rfc index tests                 June 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires December 7, 2023                [Page 3]
+Person                  Expires December 16, 2023               [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-06-05T18:57:39" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.17.2 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-06-14T21:40:34" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.17.3 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="05" month="06" year="2023"/>
+    <date day="14" month="06" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 7 December 2023.
+        This Internet-Draft will expire on 16 December 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              June 5, 2023
+Internet-Draft                                             June 14, 2023
 Intended status: Experimental                                           
-Expires: December 7, 2023
+Expires: December 16, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 7, 2023.
+   This Internet-Draft will expire on December 16, 2023.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.17.2" name="generator">
+<meta content="xml2rfc 3.17.3" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 7, 2023</td>
+<td class="center">Expires December 16, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-06-05" class="published">June 5, 2023</time>
+<time datetime="2023-06-14" class="published">June 14, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-12-07">December 7, 2023</time></dd>
+<dd class="expires"><time datetime="2023-12-16">December 16, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 7, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 16, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                             5 June 2023
+                                                            14 June 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.17.2
-                          xml2rfc-docs-3.17.2
+                         xml2rfc release 3.17.3
+                          xml2rfc-docs-3.17.3
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://ietf-tools.github.io/xml2rfc/.
 
-   This documentation applies to xml2rfc version 3.17.2.
+   This documentation applies to xml2rfc version 3.17.3.
 
 2.  Schema Version 3 Elements
 
@@ -4319,7 +4319,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.17.2:
+   Jinja2 template, as of xml2rfc version 3.17.3:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -16,14 +16,14 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.17.2" name="generator">
+<meta content="xml2rfc 3.17.3" name="generator">
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.17.2
+  xml2rfc 3.17.3
     Python 3.10.6
     appdirs 1.4.4
     ConfigArgParse 1.5.3
-    google-i18n-address 3.0.0
+    google-i18n-address 3.1.0
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              June 5, 2023
+Internet-Draft                                             June 14, 2023
 Intended status: Experimental                                           
-Expires: December 7, 2023
+Expires: December 16, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 7, 2023.
+   This Internet-Draft will expire on December 16, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires December 7, 2023                [Page 1]
+Person                  Expires December 16, 2023               [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests               June 2023
 
 
 
-Person                  Expires December 7, 2023                [Page 2]
+Person                  Expires December 16, 2023               [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests               June 2023
 
 
 
-Person                  Expires December 7, 2023                [Page 3]
+Person                  Expires December 16, 2023               [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires December 7, 2023                [Page 4]
+Person                  Expires December 16, 2023               [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-06-05T18:57:47" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.17.2 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-06-14T21:40:43" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.17.3 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="05" month="06" year="2023"/>
+    <date day="14" month="06" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 7 December 2023.
+        This Internet-Draft will expire on 16 December 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              June 5, 2023
+Internet-Draft                                             June 14, 2023
 Intended status: Experimental                                           
-Expires: December 7, 2023
+Expires: December 16, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 7, 2023.
+   This Internet-Draft will expire on December 16, 2023.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.17.2" name="generator">
+<meta content="xml2rfc 3.17.3" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 7, 2023</td>
+<td class="center">Expires December 16, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-06-05" class="published">June 5, 2023</time>
+<time datetime="2023-06-14" class="published">June 14, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-12-07">December 7, 2023</time></dd>
+<dd class="expires"><time datetime="2023-12-16">December 16, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 7, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 16, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/parser.py
+++ b/xml2rfc/parser.py
@@ -55,11 +55,7 @@ class CachingResolver(lxml.etree.Resolver):
                  templates_path=base.default_options.template_dir, verbose=None, quiet=None,
                  no_network=None, network_locs= [
                      'https://bib.ietf.org/public/rfc/',
-                     'https://xml2rfc.ietf.org/public/rfc/',
-                     'https://xml2rfc.tools.ietf.org/public/rfc/',
                      'http://bib.ietf.org/public/rfc/',
-                     'http://xml2rfc.ietf.org/public/rfc/',
-                     'http://xml2rfc.tools.ietf.org/public/rfc/',
                  ],
                  rfc_number=None, options=base.default_options):
         self.quiet = quiet if quiet != None else options.quiet
@@ -197,9 +193,7 @@ class CachingResolver(lxml.etree.Resolver):
               on the CLI this is set by $XML_LIBRARY, defaulting to 
               ['/usr/share/xml2rfc'].  On the GUI this can be configured
               manually but has the same initial defaults.
-            - NETWORK refers to the online citation library.  On the CLI this
-              is http://xml2rfc.ietf.org/public/rfc/.  On the GUI this 
-              can be configured manually but has the same initial default.
+            - NETWORK refers to the online citation library.
 
             The caches in read_dirs are consulted in sequence order to find the
             request.  If not found, the request will be cached at write_dir.
@@ -481,11 +475,7 @@ class XmlRfcParser:
                  cache_path=None, templates_path=base.default_options.template_dir, library_dirs=None, add_xmlns=False,
                  no_network=None, network_locs=[
                      'https://bib.ietf.org/public/rfc/',
-                     'https://xml2rfc.ietf.org/public/rfc/',
-                     'https://xml2rfc.tools.ietf.org/public/rfc/',
                      'http://bib.ietf.org/public/rfc/',
-                     'http://xml2rfc.ietf.org/public/rfc/',
-                     'http://xml2rfc.tools.ietf.org/public/rfc/',
                  ]
                  ):
         self.options = options

--- a/xml2rfc/parser.py
+++ b/xml2rfc/parser.py
@@ -55,7 +55,6 @@ class CachingResolver(lxml.etree.Resolver):
                  templates_path=base.default_options.template_dir, verbose=None, quiet=None,
                  no_network=None, network_locs= [
                      'https://bib.ietf.org/public/rfc/',
-                     'http://bib.ietf.org/public/rfc/',
                  ],
                  rfc_number=None, options=base.default_options):
         self.quiet = quiet if quiet != None else options.quiet
@@ -475,7 +474,6 @@ class XmlRfcParser:
                  cache_path=None, templates_path=base.default_options.template_dir, library_dirs=None, add_xmlns=False,
                  no_network=None, network_locs=[
                      'https://bib.ietf.org/public/rfc/',
-                     'http://bib.ietf.org/public/rfc/',
                  ]
                  ):
         self.options = options


### PR DESCRIPTION
Fixes #1002