### PR TITLE
fix: Add xml extension to BibXML requests

### DIFF
--- a/tests/input/draft-template.xml
+++ b/tests/input/draft-template.xml
@@ -553,6 +553,8 @@ main(int argc, char *argv[])
           <date year="1972" />
         </front>
       </reference>
+      <?rfc include="reference.I-D.draft-iab-xml2rfcv2-00.xml" ?>
+      <?rfc include="reference.I-D.iab-xml2rfc" ?>
     </references>
 
     <section anchor="app-additional" title="Additional Stuff">

--- a/tests/valid/draft-template.exp.xml
+++ b/tests/valid/draft-template.exp.xml
@@ -580,6 +580,30 @@ main(int argc, char *argv[])
           <date year="1972"/>
         </front>
       </reference>
+      <reference anchor="I-D.iab-xml2rfcv2" target="https://datatracker.ietf.org/doc/html/draft-iab-xml2rfcv2-00" xml:base="https://bib.ietf.org/public/rfc/bibxml-ids/reference.I-D.draft-iab-xml2rfcv2-00.xml">
+        <front>
+          <title>The 'XML2RFC' version 2 Vocabulary</title>
+          <author fullname="Julian Reschke" initials="J." surname="Reschke"/>
+          <date day="9" month="January" year="2015"/>
+          <abstract>
+            <t>This document defines the 'XML2RFC' version 2 vocabulary; an XML- based language used for writing RFCs and Internet-Drafts. Version 2 represents the current state of the vocabulary (as implemented by several tools and as used by the RFC Editor) around 2014. Editorial Note (To be removed by RFC Editor) Discussion of this draft takes place on the XML2RFC mailing list (xml2rfc@ietf.org), which has its home page at &lt;https://www.ietf.org/mailman/listinfo/xml2rfc&gt;.</t>
+          </abstract>
+        </front>
+        <seriesInfo name="Internet-Draft" value="draft-iab-xml2rfcv2-00"/>
+      </reference>
+      <reference anchor="I-D.iab-xml2rfc" target="https://datatracker.ietf.org/doc/html/draft-iab-xml2rfc-04" xml:base="https://bib.ietf.org/public/rfc/bibxml-ids/reference.I-D.iab-xml2rfc.xml">
+        <front>
+          <title>The "xml2rfc" Version 3 Vocabulary</title>
+          <author fullname="Paul E. Hoffman" initials="P. E." surname="Hoffman">
+            <organization>ICANN</organization>
+          </author>
+          <date day="22" month="June" year="2016"/>
+          <abstract>
+            <t>This document defines the "xml2rfc" version 3 vocabulary: an XML-based language used for writing RFCs and Internet-Drafts. It is heavily derived from the version 2 vocabulary that is also under discussion. This document obsoletes the v2 grammar described in RFC 7749.</t>
+          </abstract>
+        </front>
+        <seriesInfo name="Internet-Draft" value="draft-iab-xml2rfc-04"/>
+      </reference>
     </references>
     <section anchor="app-additional" title="Additional Stuff">
       <t>This becomes an Appendix.</t>

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -2021,6 +2021,14 @@ main(int argc, char *argv[])
         <dd>
 <span class="refAuthor">Mad Dominators, Inc.</span>, <span class="refTitle">"Ultimate Plan for Taking Over the World"</span>, <time datetime="1984" class="refDate">1984</time>, <span>&lt;<a href="http://www.example.com/dominator.html">http://www.example.com/dominator.html</a>&gt;</span>. </dd>
 <dd class="break"></dd>
+<dt id="I-D.iab-xml2rfc">[I-D.iab-xml2rfc]</dt>
+        <dd>
+<span class="refAuthor">Hoffman, P. E.</span>, <span class="refTitle">"The "xml2rfc" Version 3 Vocabulary"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-iab-xml2rfc-04</span>, <time datetime="2016-06-22" class="refDate">22 June 2016</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-iab-xml2rfc-04">https://datatracker.ietf.org/doc/html/draft-iab-xml2rfc-04</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="I-D.iab-xml2rfcv2">[I-D.iab-xml2rfcv2]</dt>
+        <dd>
+<span class="refAuthor">Reschke, J.</span>, <span class="refTitle">"The 'XML2RFC' version 2 Vocabulary"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-iab-xml2rfcv2-00</span>, <time datetime="2015-01-09" class="refDate">9 January 2015</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-iab-xml2rfcv2-00">https://datatracker.ietf.org/doc/html/draft-iab-xml2rfcv2-00</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="I-D.narten-iana-considerations-rfc2434bis">[I-D.narten-iana-considerations-rfc2434bis]</dt>
         <dd>
 <span class="refAuthor">Alvestrand, H. T.</span> and <span class="refAuthor">T. Narten</span>, <span class="refTitle">"Guidelines for Writing an IANA Considerations Section in RFCs"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-narten-iana-considerations-rfc2434bis-09</span>, <time datetime="2008-03-26" class="refDate">26 March 2008</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-narten-iana-considerations-rfc2434bis-09">https://datatracker.ietf.org/doc/html/draft-narten-iana-considerations-rfc2434bis-09</a>&gt;</span>. </dd>

--- a/tests/valid/draft-template.pages.text
+++ b/tests/valid/draft-template.pages.text
@@ -562,6 +562,18 @@ Davies & Zhao           Expires September 2, 2009              [Page 10]
 Internet-Draft              Abbreviated Title                 March 2009
 
 
+   [I-D.iab-xml2rfc]
+              Hoffman, P. E., "The "xml2rfc" Version 3 Vocabulary", Work
+              in Progress, Internet-Draft, draft-iab-xml2rfc-04, June
+              22, 2016, <https://datatracker.ietf.org/doc/html/draft-
+              iab-xml2rfc-04>.
+
+   [I-D.iab-xml2rfcv2]
+              Reschke, J., "The 'XML2RFC' version 2 Vocabulary", Work in
+              Progress, Internet-Draft, draft-iab-xml2rfcv2-00, January
+              9, 2015, <https://datatracker.ietf.org/doc/html/draft-iab-
+              xml2rfcv2-00>.
+
    [I-D.narten-iana-considerations-rfc2434bis]
               Alvestrand, H. T. and T. Narten, "Guidelines for Writing
               an IANA Considerations Section in RFCs", Work in Progress,
@@ -600,6 +612,12 @@ Authors' Addresses
    Email: elwynd@dial.pipex.com
 
 
+
+Davies & Zhao           Expires September 2, 2009              [Page 11]
+
+Internet-Draft              Abbreviated Title                 March 2009
+
+
    Quintin Zhao
    Huawei Technology
    125 Nagog Technology Park
@@ -613,4 +631,42 @@ Authors' Addresses
 
 
 
-Davies & Zhao           Expires September 2, 2009              [Page 11]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Davies & Zhao           Expires September 2, 2009              [Page 12]

--- a/tests/valid/draft-template.prepped.xml
+++ b/tests/valid/draft-template.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" consensus="false" prepTime="2023-06-05T18:55:02" indexInclude="true" scripts="Common,Latin" submissionType="IETF">
-  <!-- xml2rfc v2v3 conversion 3.17.2 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" consensus="false" prepTime="2023-06-16T03:59:19" indexInclude="true" scripts="Common,Latin" submissionType="IETF">
+  <!-- xml2rfc v2v3 conversion 3.17.3 -->
   
   
   
@@ -649,6 +649,32 @@ main(int argc, char *argv[])
             </author>
             <date year="1984"/>
           </front>
+        </reference>
+        <reference anchor="I-D.iab-xml2rfc" target="https://datatracker.ietf.org/doc/html/draft-iab-xml2rfc-04" xml:base="https://bib.ietf.org/public/rfc/bibxml-ids/reference.I-D.iab-xml2rfc.xml" quoteTitle="true" derivedAnchor="I-D.iab-xml2rfc">
+          <front>
+            <title>The "xml2rfc" Version 3 Vocabulary</title>
+            <author fullname="Paul E. Hoffman" initials="P. E." surname="Hoffman">
+              <organization showOnFrontPage="true">ICANN</organization>
+            </author>
+            <date day="22" month="June" year="2016"/>
+            <abstract>
+              <t indent="0">This document defines the "xml2rfc" version 3 vocabulary: an XML-based language used for writing RFCs and Internet-Drafts. It is heavily derived from the version 2 vocabulary that is also under discussion. This document obsoletes the v2 grammar described in RFC 7749.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-iab-xml2rfc-04"/>
+          <refcontent>Work in Progress</refcontent>
+        </reference>
+        <reference anchor="I-D.iab-xml2rfcv2" target="https://datatracker.ietf.org/doc/html/draft-iab-xml2rfcv2-00" xml:base="https://bib.ietf.org/public/rfc/bibxml-ids/reference.I-D.draft-iab-xml2rfcv2-00.xml" quoteTitle="true" derivedAnchor="I-D.iab-xml2rfcv2">
+          <front>
+            <title>The 'XML2RFC' version 2 Vocabulary</title>
+            <author fullname="Julian Reschke" initials="J." surname="Reschke"/>
+            <date day="9" month="January" year="2015"/>
+            <abstract>
+              <t indent="0">This document defines the 'XML2RFC' version 2 vocabulary; an XML- based language used for writing RFCs and Internet-Drafts. Version 2 represents the current state of the vocabulary (as implemented by several tools and as used by the RFC Editor) around 2014. Editorial Note (To be removed by RFC Editor) Discussion of this draft takes place on the XML2RFC mailing list (xml2rfc@ietf.org), which has its home page at &lt;https://www.ietf.org/mailman/listinfo/xml2rfc&gt;.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-iab-xml2rfcv2-00"/>
+          <refcontent>Work in Progress</refcontent>
         </reference>
         <reference anchor="I-D.narten-iana-considerations-rfc2434bis" target="https://datatracker.ietf.org/doc/html/draft-narten-iana-considerations-rfc2434bis-09" xml:base="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.narten-iana-considerations-rfc2434bis.xml" quoteTitle="true" derivedAnchor="I-D.narten-iana-considerations-rfc2434bis">
           <front>

--- a/tests/valid/draft-template.text
+++ b/tests/valid/draft-template.text
@@ -457,6 +457,18 @@ Table of Contents
               Mad Dominators, Inc., "Ultimate Plan for Taking Over the
               World", 1984, <http://www.example.com/dominator.html>.
 
+   [I-D.iab-xml2rfc]
+              Hoffman, P. E., "The "xml2rfc" Version 3 Vocabulary", Work
+              in Progress, Internet-Draft, draft-iab-xml2rfc-04, June
+              22, 2016, <https://datatracker.ietf.org/doc/html/draft-
+              iab-xml2rfc-04>.
+
+   [I-D.iab-xml2rfcv2]
+              Reschke, J., "The 'XML2RFC' version 2 Vocabulary", Work in
+              Progress, Internet-Draft, draft-iab-xml2rfcv2-00, January
+              9, 2015, <https://datatracker.ietf.org/doc/html/draft-iab-
+              xml2rfcv2-00>.
+
    [I-D.narten-iana-considerations-rfc2434bis]
               Alvestrand, H. T. and T. Narten, "Guidelines for Writing
               an IANA Considerations Section in RFCs", Work in Progress,

--- a/tests/valid/draft-template.txt
+++ b/tests/valid/draft-template.txt
@@ -562,6 +562,18 @@ Davies & Zhao           Expires 2 September 2009               [Page 10]
 Internet-Draft              Abbreviated Title                 March 2009
 
 
+   [I-D.iab-xml2rfc]
+              Hoffman, P. E., "The "xml2rfc" Version 3 Vocabulary", Work
+              in Progress, Internet-Draft, draft-iab-xml2rfc-04, 22 June
+              2016, <https://datatracker.ietf.org/doc/html/draft-iab-
+              xml2rfc-04>.
+
+   [I-D.iab-xml2rfcv2]
+              Reschke, J., "The 'XML2RFC' version 2 Vocabulary", Work in
+              Progress, Internet-Draft, draft-iab-xml2rfcv2-00, 9
+              January 2015, <https://datatracker.ietf.org/doc/html/
+              draft-iab-xml2rfcv2-00>.
+
    [I-D.narten-iana-considerations-rfc2434bis]
               Alvestrand, H. T. and T. Narten, "Guidelines for Writing
               an IANA Considerations Section in RFCs", Work in Progress,
@@ -600,6 +612,12 @@ Authors' Addresses
    Email: elwynd@dial.pipex.com
 
 
+
+Davies & Zhao           Expires 2 September 2009               [Page 11]
+
+Internet-Draft              Abbreviated Title                 March 2009
+
+
    Quintin Zhao
    Huawei Technology
    125 Nagog Technology Park
@@ -613,4 +631,42 @@ Authors' Addresses
 
 
 
-Davies & Zhao           Expires 2 September 2009               [Page 11]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Davies & Zhao           Expires 2 September 2009               [Page 12]

--- a/tests/valid/draft-template.v2v3.xml
+++ b/tests/valid/draft-template.v2v3.xml
@@ -30,7 +30,7 @@
 <?rfc multiple-initials="yes" ?>
 <!-- end of list of popular I-D processing instructions -->
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="info" docName="draft-ietf-xml2rfc-template-05" ipr="trust200902" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
-  <!-- xml2rfc v2v3 conversion 3.14.2 -->
+  <!-- xml2rfc v2v3 conversion 3.17.3 -->
   <?v3xml2rfc silence=".*[Pp]ostal address" ?>
   <?v3xml2rfc silence="The document date .*? is more than 3 days away from today's date" ?>
   <?v3xml2rfc silence="Found SVG with width or height specified" ?>
@@ -562,6 +562,8 @@ main(int argc, char *argv[])
             <date year="1972"/>
           </front>
         </reference>
+        <xi:include href="https://datatracker.ietf.org/doc/bibxml3/draft-iab-xml2rfcv2.xml"/>
+        <xi:include href="https://datatracker.ietf.org/doc/bibxml3/draft-iab-xml2rfc.xml"/>
       </references>
     </references>
     <section anchor="app-additional">

--- a/tests/valid/draft-template.v3.html
+++ b/tests/valid/draft-template.v3.html
@@ -11,7 +11,7 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.15.3" name="generator">
+<meta content="xml2rfc 3.17.3" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <link href="tests/input/draft-template.xml" rel="alternate" type="application/rfc+xml">
@@ -841,9 +841,17 @@ main(int argc, char *argv[])
         <dd>
 <span class="refAuthor">Mad Dominators, Inc.</span>, <span class="refTitle">"Ultimate Plan for Taking Over the World"</span>, <time datetime="1984" class="refDate">1984</time>, <span>&lt;<a href="http://www.example.com/dominator.html">http://www.example.com/dominator.html</a>&gt;</span>. </dd>
 <dd class="break"></dd>
+<dt id="I-D.iab-xml2rfc">[I-D.iab-xml2rfc]</dt>
+        <dd>
+<span class="refAuthor">Hoffman, P. E.</span>, <span class="refTitle">"The "xml2rfc" Version 3 Vocabulary"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-iab-xml2rfc-04</span>, <time datetime="2016-06-22" class="refDate">June 22, 2016</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-iab-xml2rfc-04">https://datatracker.ietf.org/doc/html/draft-iab-xml2rfc-04</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="I-D.iab-xml2rfcv2">[I-D.iab-xml2rfcv2]</dt>
+        <dd>
+<span class="refAuthor">Reschke, J.</span>, <span class="refTitle">"The 'XML2RFC' version 2 Vocabulary"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-iab-xml2rfcv2-00</span>, <time datetime="2015-01-09" class="refDate">January 9, 2015</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-iab-xml2rfcv2-00">https://datatracker.ietf.org/doc/html/draft-iab-xml2rfcv2-00</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="I-D.narten-iana-considerations-rfc2434bis">[I-D.narten-iana-considerations-rfc2434bis]</dt>
         <dd>
-<span class="refAuthor">Narten, T.</span> and <span class="refAuthor">H. Alvestrand</span>, <span class="refTitle">"Guidelines for Writing an IANA Considerations Section in RFCs"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-narten-iana-considerations-rfc2434bis-09</span>, <time datetime="2008-03-26" class="refDate">March 26, 2008</time>, <span>&lt;<a href="https://www.ietf.org/archive/id/draft-narten-iana-considerations-rfc2434bis-09.txt">https://www.ietf.org/archive/id/draft-narten-iana-considerations-rfc2434bis-09.txt</a>&gt;</span>. </dd>
+<span class="refAuthor">Alvestrand, H. T.</span> and <span class="refAuthor">T. Narten</span>, <span class="refTitle">"Guidelines for Writing an IANA Considerations Section in RFCs"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-narten-iana-considerations-rfc2434bis-09</span>, <time datetime="2008-03-26" class="refDate">March 26, 2008</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-narten-iana-considerations-rfc2434bis-09">https://datatracker.ietf.org/doc/html/draft-narten-iana-considerations-rfc2434bis-09</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC2629">[RFC2629]</dt>
         <dd>

--- a/xml2rfc/parser.py
+++ b/xml2rfc/parser.py
@@ -227,12 +227,10 @@ class CachingResolver(lxml.etree.Resolver):
                     result = os.path.join(self.source_dir, basename)
                     attempts.append(result)
         else:
-            if self.options and self.options.vocabulary == 'v3':
-                paths = [ request ]
-            elif not request.endswith('.xml'):
-                paths = [ request, request + '.xml' ]
+            if not request.endswith('.xml'):
+                paths = [ request + '.xml', request ]
             else:
-                paths = [ request ]                
+                paths = [ request ]
             if os.path.isabs(paths[0]):
                 # Absolute path, return as-is
                 for path in paths:


### PR DESCRIPTION
This change adds a `.xml` extension when the `.xml` extension is missing in BibXML reference requests.

Fixes #1003