### PR TITLE
fix: Warn when reference uses PIs

### DIFF
--- a/xml2rfc/parser.py
+++ b/xml2rfc/parser.py
@@ -645,6 +645,8 @@ class XmlRfcParser:
                 pis = xmlrfc.pis.copy() 
                 if 'include' in pidict and pidict['include']:
                     request = pidict['include']
+                    if xmlrfc.getroot().get('version', '3') in ['3', ]:
+                        xml2rfc.log.warn(f'XInclude should be used instead of PI include for {request}')
                     path = self.cachingResolver.getReferenceRequest(request,
                            # Pass the line number in XML for error bubbling
                            include=True, line_no=getattr(element, 'sourceline', 0))


### PR DESCRIPTION
`XInclude` should be used instead of ENTITY references and XML Processing Instructions (PIs) that allow external inclusions [1].

This change adds a warning when include PIs (`<?rfc include='<reference>' ?>`) are used with xml2rfc v3.

Fixes #1006

[1] https://datatracker.ietf.org/doc/html/rfc7991#appendix-B.1