### PR TITLE
fix: Switch from appdirs to platformdirs, since it is maintained

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-platformdirs
+platformdirs>=3.6.0
 configargparse>=1.2.3
 google-i18n-address>=3.0.0
 intervaltree>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-appdirs>=1.4.4
+platformdirs
 configargparse>=1.2.3
 google-i18n-address>=3.0.0
 intervaltree>=3.1.0

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -28,7 +28,7 @@
 <!-- Generator version information:
   xml2rfc 3.17.3
     Python 3.10.6
-    appdirs 1.4.4
+    platformdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 3.1.0
     intervaltree 3.1.0

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -28,12 +28,12 @@
 <!-- Generator version information:
   xml2rfc 3.17.3
     Python 3.10.6
-    platformdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 3.1.0
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2
+    platformdirs 3.6.0
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.31.0

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -17,12 +17,12 @@
 <!-- Generator version information:
   xml2rfc 3.17.3
     Python 3.10.6
-    platformdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 3.1.0
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2
+    platformdirs 3.6.0
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.31.0

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -17,7 +17,7 @@
 <!-- Generator version information:
   xml2rfc 3.17.3
     Python 3.10.6
-    appdirs 1.4.4
+    platformdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 3.1.0
     intervaltree 3.1.0

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             June 14, 2023
+Internet-Draft                                             June 19, 2023
 Intended status: Experimental                                           
-Expires: December 16, 2023
+Expires: December 21, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 16, 2023.
+   This Internet-Draft will expire on December 21, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires December 16, 2023               [Page 1]
+Person                  Expires December 21, 2023               [Page 1]
 
 Internet-Draft             xml2rfc index tests                 June 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires December 16, 2023               [Page 2]
+Person                  Expires December 21, 2023               [Page 2]
 
 Internet-Draft             xml2rfc index tests                 June 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires December 16, 2023               [Page 3]
+Person                  Expires December 21, 2023               [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-06-14T21:40:34" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-06-19T05:27:04" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.17.3 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="14" month="06" year="2023"/>
+    <date day="19" month="06" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 16 December 2023.
+        This Internet-Draft will expire on 21 December 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             June 14, 2023
+Internet-Draft                                             June 19, 2023
 Intended status: Experimental                                           
-Expires: December 16, 2023
+Expires: December 21, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 16, 2023.
+   This Internet-Draft will expire on December 21, 2023.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 16, 2023</td>
+<td class="center">Expires December 21, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-06-14" class="published">June 14, 2023</time>
+<time datetime="2023-06-19" class="published">June 19, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-12-16">December 16, 2023</time></dd>
+<dd class="expires"><time datetime="2023-12-21">December 21, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 16, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 21, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                            14 June 2023
+                                                            19 June 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc6787.html
+++ b/tests/valid/rfc6787.html
@@ -27,7 +27,7 @@
 <!-- Generator version information:
   xml2rfc 3.13.1
     Python 3.9.13
-    appdirs 1.4.4
+    platformdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 2.5.2
     html5lib 1.1

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -21,7 +21,7 @@
 <!-- Generator version information:
   xml2rfc 3.17.3
     Python 3.10.6
-    appdirs 1.4.4
+    platformdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 3.1.0
     intervaltree 3.1.0

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -21,12 +21,12 @@
 <!-- Generator version information:
   xml2rfc 3.17.3
     Python 3.10.6
-    platformdirs 1.4.4
     ConfigArgParse 1.5.3
     google-i18n-address 3.1.0
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2
+    platformdirs 3.6.0
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.31.0

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             June 14, 2023
+Internet-Draft                                             June 19, 2023
 Intended status: Experimental                                           
-Expires: December 16, 2023
+Expires: December 21, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 16, 2023.
+   This Internet-Draft will expire on December 21, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires December 16, 2023               [Page 1]
+Person                  Expires December 21, 2023               [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests               June 2023
 
 
 
-Person                  Expires December 16, 2023               [Page 2]
+Person                  Expires December 21, 2023               [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests               June 2023
 
 
 
-Person                  Expires December 16, 2023               [Page 3]
+Person                  Expires December 21, 2023               [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires December 16, 2023               [Page 4]
+Person                  Expires December 21, 2023               [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-06-14T21:40:43" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-06-19T05:27:12" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.17.3 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="14" month="06" year="2023"/>
+    <date day="19" month="06" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 16 December 2023.
+        This Internet-Draft will expire on 21 December 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             June 14, 2023
+Internet-Draft                                             June 19, 2023
 Intended status: Experimental                                           
-Expires: December 16, 2023
+Expires: December 21, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 16, 2023.
+   This Internet-Draft will expire on December 21, 2023.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 16, 2023</td>
+<td class="center">Expires December 21, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-06-14" class="published">June 14, 2023</time>
+<time datetime="2023-06-19" class="published">June 19, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-12-16">December 16, 2023</time></dd>
+<dd class="expires"><time datetime="2023-12-21">December 21, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 16, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 21, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, unicode_literals
 
-import appdirs
+import platformdirs
 import configargparse
 import datetime
 import io
@@ -150,7 +150,7 @@ def main():
     global optionparser
     # Populate options
     config_paths = ['/etc/xml2rfc.conf', '~/.xml2rfc.conf']
-    user_conf = os.path.join(appdirs.user_config_dir(), 'xml2rfc.conf')
+    user_conf = os.path.join(platformdirs.user_config_dir(), 'xml2rfc.conf')
     if not user_conf in config_paths:
         config_paths.append(user_conf)
 


### PR DESCRIPTION
Platformdirs is API compatible with appdirs, all that needs to be changed is the module name.  It is a friendly fork of appdirs that was created after appdirs went unmaintained in 2020.

I've tried this out at tests all still pass.  I think it's a straightforward change and it's better to use something that's got active maintainers.