### PR TITLE
fix: Reset seen_slugs cache on every prep run

### DIFF
--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -33,7 +33,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2
-    platformdirs 3.6.0
+    platformdirs 3.7.0
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.31.0
@@ -1260,8 +1260,8 @@ li > p:last-of-type:only-child {
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
-        <h2 id="name-status-of-this-memo-2">
-<a href="#name-status-of-this-memo-2" class="section-name selfRef">Status of This Memo</a>
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
         </h2>
 <p id="section-boilerplate.1-1">
         This Internet-Draft is submitted in full conformance with the
@@ -1282,8 +1282,8 @@ li > p:last-of-type:only-child {
 </div>
 <div id="copyright">
 <section id="section-boilerplate.2">
-        <h2 id="name-copyright-notice-2">
-<a href="#name-copyright-notice-2" class="section-name selfRef">Copyright Notice</a>
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
             Copyright (c) 2013 IETF Trust and the persons identified as the
@@ -1302,185 +1302,185 @@ li > p:last-of-type:only-child {
 </div>
 <div id="toc">
 <section id="section-toc.1">
-        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents-2">
-<a href="#name-table-of-contents-2" class="section-name selfRef">Table of Contents</a>
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
         </h2>
 <nav class="toc"><ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
-            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction-2" class="internal xref">Introduction</a></p>
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-pandoc-to-rfc-2" class="internal xref">Pandoc to RFC</a></p>
+            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-pandoc-to-rfc" class="internal xref">Pandoc to RFC</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.1">
-                <p id="section-toc.1-1.2.2.1.1" class="keepWithNext"><a href="#section-2.1" class="auto internal xref">2.1</a>.  <a href="#name-dependencies-2" class="internal xref">Dependencies</a></p>
+                <p id="section-toc.1-1.2.2.1.1" class="keepWithNext"><a href="#section-2.1" class="auto internal xref">2.1</a>.  <a href="#name-dependencies" class="internal xref">Dependencies</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-starting-a-new-project-2" class="internal xref">Starting a new project</a></p>
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-starting-a-new-project" class="internal xref">Starting a new project</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-supported-features-2" class="internal xref">Supported Features</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-supported-features" class="internal xref">Supported Features</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-unsupported-features-2" class="internal xref">Unsupported Features</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-unsupported-features" class="internal xref">Unsupported Features</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-acknowledgements-2" class="internal xref">Acknowledgements</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-pandoc-constructs-2" class="internal xref">Pandoc Constructs</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-pandoc-constructs" class="internal xref">Pandoc Constructs</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
-                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="auto internal xref">7.1</a>.  <a href="#name-paragraph-2" class="internal xref">Paragraph</a></p>
+                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="auto internal xref">7.1</a>.  <a href="#name-paragraph" class="internal xref">Paragraph</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
-                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="auto internal xref">7.2</a>.  <a href="#name-section-2" class="internal xref">Section</a></p>
+                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="auto internal xref">7.2</a>.  <a href="#name-section" class="internal xref">Section</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3">
-                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="auto internal xref">7.3</a>.  <a href="#name-list-styles-2" class="internal xref">List Styles</a></p>
+                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="auto internal xref">7.3</a>.  <a href="#name-list-styles" class="internal xref">List Styles</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.1">
-                    <p id="section-toc.1-1.7.2.3.2.1.1"><a href="#section-7.3.1" class="auto internal xref">7.3.1</a>.  <a href="#name-symbol-2" class="internal xref">Symbol</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.1.1"><a href="#section-7.3.1" class="auto internal xref">7.3.1</a>.  <a href="#name-symbol" class="internal xref">Symbol</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.2">
-                    <p id="section-toc.1-1.7.2.3.2.2.1"><a href="#section-7.3.2" class="auto internal xref">7.3.2</a>.  <a href="#name-number-2" class="internal xref">Number</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.2.1"><a href="#section-7.3.2" class="auto internal xref">7.3.2</a>.  <a href="#name-number" class="internal xref">Number</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.3">
-                    <p id="section-toc.1-1.7.2.3.2.3.1"><a href="#section-7.3.3" class="auto internal xref">7.3.3</a>.  <a href="#name-empty-2" class="internal xref">Empty</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.3.1"><a href="#section-7.3.3" class="auto internal xref">7.3.3</a>.  <a href="#name-empty" class="internal xref">Empty</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.4">
-                    <p id="section-toc.1-1.7.2.3.2.4.1"><a href="#section-7.3.4" class="auto internal xref">7.3.4</a>.  <a href="#name-roman-2" class="internal xref">Roman</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.4.1"><a href="#section-7.3.4" class="auto internal xref">7.3.4</a>.  <a href="#name-roman" class="internal xref">Roman</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.5">
-                    <p id="section-toc.1-1.7.2.3.2.5.1"><a href="#section-7.3.5" class="auto internal xref">7.3.5</a>.  <a href="#name-letter-2" class="internal xref">Letter</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.5.1"><a href="#section-7.3.5" class="auto internal xref">7.3.5</a>.  <a href="#name-letter" class="internal xref">Letter</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3.2.6">
-                    <p id="section-toc.1-1.7.2.3.2.6.1"><a href="#section-7.3.6" class="auto internal xref">7.3.6</a>.  <a href="#name-hanging-2" class="internal xref">Hanging</a></p>
+                    <p id="section-toc.1-1.7.2.3.2.6.1"><a href="#section-7.3.6" class="auto internal xref">7.3.6</a>.  <a href="#name-hanging" class="internal xref">Hanging</a></p>
 </li>
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4">
-                <p id="section-toc.1-1.7.2.4.1"><a href="#section-7.4" class="auto internal xref">7.4</a>.  <a href="#name-figure-artwork-2" class="internal xref">Figure/Artwork</a></p>
+                <p id="section-toc.1-1.7.2.4.1"><a href="#section-7.4" class="auto internal xref">7.4</a>.  <a href="#name-figure-artwork" class="internal xref">Figure/Artwork</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.4.2.1">
-                    <p id="section-toc.1-1.7.2.4.2.1.1"><a href="#section-7.4.1" class="auto internal xref">7.4.1</a>.  <a href="#name-references-5" class="internal xref">References</a></p>
+                    <p id="section-toc.1-1.7.2.4.2.1.1"><a href="#section-7.4.1" class="auto internal xref">7.4.1</a>.  <a href="#name-references" class="internal xref">References</a></p>
 </li>
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.5">
-                <p id="section-toc.1-1.7.2.5.1"><a href="#section-7.5" class="auto internal xref">7.5</a>.  <a href="#name-block-quote-2" class="internal xref">Block Quote</a></p>
+                <p id="section-toc.1-1.7.2.5.1"><a href="#section-7.5" class="auto internal xref">7.5</a>.  <a href="#name-block-quote" class="internal xref">Block Quote</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.6">
-                <p id="section-toc.1-1.7.2.6.1"><a href="#section-7.6" class="auto internal xref">7.6</a>.  <a href="#name-references-6" class="internal xref">References</a></p>
+                <p id="section-toc.1-1.7.2.6.1"><a href="#section-7.6" class="auto internal xref">7.6</a>.  <a href="#name-references-2" class="internal xref">References</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.6.2.1">
-                    <p id="section-toc.1-1.7.2.6.2.1.1"><a href="#section-7.6.1" class="auto internal xref">7.6.1</a>.  <a href="#name-external-2" class="internal xref">External</a></p>
+                    <p id="section-toc.1-1.7.2.6.2.1.1"><a href="#section-7.6.1" class="auto internal xref">7.6.1</a>.  <a href="#name-external" class="internal xref">External</a></p>
 </li>
                   <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.6.2.2">
-                    <p id="section-toc.1-1.7.2.6.2.2.1"><a href="#section-7.6.2" class="auto internal xref">7.6.2</a>.  <a href="#name-internal-2" class="internal xref">Internal</a></p>
+                    <p id="section-toc.1-1.7.2.6.2.2.1"><a href="#section-7.6.2" class="auto internal xref">7.6.2</a>.  <a href="#name-internal" class="internal xref">Internal</a></p>
 </li>
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.7">
-                <p id="section-toc.1-1.7.2.7.1"><a href="#section-7.7" class="auto internal xref">7.7</a>.  <a href="#name-spanx-styles-2" class="internal xref">Spanx Styles</a></p>
+                <p id="section-toc.1-1.7.2.7.1"><a href="#section-7.7" class="auto internal xref">7.7</a>.  <a href="#name-spanx-styles" class="internal xref">Spanx Styles</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.8">
-                <p id="section-toc.1-1.7.2.8.1"><a href="#section-7.8" class="auto internal xref">7.8</a>.  <a href="#name-tables-2" class="internal xref">Tables</a></p>
+                <p id="section-toc.1-1.7.2.8.1"><a href="#section-7.8" class="auto internal xref">7.8</a>.  <a href="#name-tables" class="internal xref">Tables</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.8.2.1">
-                    <p id="section-toc.1-1.7.2.8.2.1.1"><a href="#section-7.8.1" class="auto internal xref">7.8.1</a>.  <a href="#name-references-7" class="internal xref">References</a></p>
+                    <p id="section-toc.1-1.7.2.8.2.1.1"><a href="#section-7.8.1" class="auto internal xref">7.8.1</a>.  <a href="#name-references-3" class="internal xref">References</a></p>
 </li>
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.9">
-                <p id="section-toc.1-1.7.2.9.1"><a href="#section-7.9" class="auto internal xref">7.9</a>.  <a href="#name-indexes-2" class="internal xref">Indexes</a></p>
+                <p id="section-toc.1-1.7.2.9.1"><a href="#section-7.9" class="auto internal xref">7.9</a>.  <a href="#name-indexes" class="internal xref">Indexes</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-usage-guidelines-2" class="internal xref">Usage guidelines</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-usage-guidelines" class="internal xref">Usage guidelines</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1">
-                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="auto internal xref">8.1</a>.  <a href="#name-working-with-multiple-files-2" class="internal xref">Working with multiple files</a></p>
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="auto internal xref">8.1</a>.  <a href="#name-working-with-multiple-files" class="internal xref">Working with multiple files</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.2">
-                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="auto internal xref">8.2</a>.  <a href="#name-setting-the-title-2" class="internal xref">Setting the title</a></p>
+                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="auto internal xref">8.2</a>.  <a href="#name-setting-the-title" class="internal xref">Setting the title</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.3">
-                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="auto internal xref">8.3</a>.  <a href="#name-uploading-the-xml-txt-2" class="internal xref">Uploading the XML/txt</a></p>
+                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="auto internal xref">8.3</a>.  <a href="#name-uploading-the-xml-txt" class="internal xref">Uploading the XML/txt</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.4">
-                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="auto internal xref">8.4</a>.  <a href="#name-vim-syntax-highlighting-2" class="internal xref">VIM syntax highlighting</a></p>
+                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="auto internal xref">8.4</a>.  <a href="#name-vim-syntax-highlighting" class="internal xref">VIM syntax highlighting</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-security-considerations-2" class="internal xref">Security Considerations</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-iana-considerations-2" class="internal xref">IANA Considerations</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-references-8" class="internal xref">References</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-references-4" class="internal xref">References</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.1">
-                <p id="section-toc.1-1.11.2.1.1"><a href="#section-11.1" class="auto internal xref">11.1</a>.  <a href="#name-informative-references-2" class="internal xref">Informative References</a></p>
+                <p id="section-toc.1-1.11.2.1.1"><a href="#section-11.1" class="auto internal xref">11.1</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.2">
-                <p id="section-toc.1-1.11.2.2.1"><a href="#section-11.2" class="auto internal xref">11.2</a>.  <a href="#name-normative-references-2" class="internal xref">Normative References</a></p>
+                <p id="section-toc.1-1.11.2.2.1"><a href="#section-11.2" class="auto internal xref">11.2</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-tests-2" class="internal xref">Tests</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-tests" class="internal xref">Tests</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1">
-                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-A.1" class="auto internal xref">A.1</a>.  <a href="#name-a-very-long-title-considerat" class="internal xref">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a></p>
+                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-A.1" class="auto internal xref">A.1</a>.  <a href="#name-a-very-long-title-considera" class="internal xref">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1.2.1">
-                    <p id="section-toc.1-1.12.2.1.2.1.1"><a href="#appendix-A.1.1" class="auto internal xref">A.1.1</a>.  <a href="#name-s-mime-encrypted-and-signed-" class="internal xref">S/MIME encrypted and signed over a simple message, Injected Headers with hcp_minimal (+ Legacy Display)</a></p>
+                    <p id="section-toc.1-1.12.2.1.2.1.1"><a href="#appendix-A.1.1" class="auto internal xref">A.1.1</a>.  <a href="#name-s-mime-encrypted-and-signed" class="internal xref">S/MIME encrypted and signed over a simple message, Injected Headers with hcp_minimal (+ Legacy Display)</a></p>
 </li>
                 </ul>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.2">
-                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-A.2" class="auto internal xref">A.2</a>.  <a href="#name-markup-in-heading-2" class="internal xref">Markup in heading</a></p>
+                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-A.2" class="auto internal xref">A.2</a>.  <a href="#name-markup-in-heading" class="internal xref">Markup in heading</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.3">
-                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-A.3" class="auto internal xref">A.3</a>.  <a href="#name-blockquote-2" class="internal xref">Blockquote</a></p>
+                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-A.3" class="auto internal xref">A.3</a>.  <a href="#name-blockquote" class="internal xref">Blockquote</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.4">
-                <p id="section-toc.1-1.12.2.4.1"><a href="#appendix-A.4" class="auto internal xref">A.4</a>.  <a href="#name-verbatim-code-blocks-2" class="internal xref">Verbatim code blocks</a></p>
+                <p id="section-toc.1-1.12.2.4.1"><a href="#appendix-A.4" class="auto internal xref">A.4</a>.  <a href="#name-verbatim-code-blocks" class="internal xref">Verbatim code blocks</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.5">
-                <p id="section-toc.1-1.12.2.5.1"><a href="#appendix-A.5" class="auto internal xref">A.5</a>.  <a href="#name-reference-tests-2" class="internal xref">Reference Tests</a></p>
+                <p id="section-toc.1-1.12.2.5.1"><a href="#appendix-A.5" class="auto internal xref">A.5</a>.  <a href="#name-reference-tests" class="internal xref">Reference Tests</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.6">
-                <p id="section-toc.1-1.12.2.6.1"><a href="#appendix-A.6" class="auto internal xref">A.6</a>.  <a href="#name-spanx-tests-2" class="internal xref">Spanx Tests</a></p>
+                <p id="section-toc.1-1.12.2.6.1"><a href="#appendix-A.6" class="auto internal xref">A.6</a>.  <a href="#name-spanx-tests" class="internal xref">Spanx Tests</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.7">
-                <p id="section-toc.1-1.12.2.7.1"><a href="#appendix-A.7" class="auto internal xref">A.7</a>.  <a href="#name-list-tests-2" class="internal xref">List Tests</a></p>
+                <p id="section-toc.1-1.12.2.7.1"><a href="#appendix-A.7" class="auto internal xref">A.7</a>.  <a href="#name-list-tests" class="internal xref">List Tests</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.8">
-                <p id="section-toc.1-1.12.2.8.1"><a href="#appendix-A.8" class="auto internal xref">A.8</a>.  <a href="#name-table-tests-2" class="internal xref">Table Tests</a></p>
+                <p id="section-toc.1-1.12.2.8.1"><a href="#appendix-A.8" class="auto internal xref">A.8</a>.  <a href="#name-table-tests" class="internal xref">Table Tests</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.9">
-                <p id="section-toc.1-1.12.2.9.1"><a href="#appendix-A.9" class="auto internal xref">A.9</a>.  <a href="#name-numbered-examples-2" class="internal xref">Numbered examples</a></p>
+                <p id="section-toc.1-1.12.2.9.1"><a href="#appendix-A.9" class="auto internal xref">A.9</a>.  <a href="#name-numbered-examples" class="internal xref">Numbered examples</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.10">
-                <p id="section-toc.1-1.12.2.10.1"><a href="#appendix-A.10" class="auto internal xref">A.10</a>. <a href="#name-figure-tests-2" class="internal xref">Figure tests</a></p>
+                <p id="section-toc.1-1.12.2.10.1"><a href="#appendix-A.10" class="auto internal xref">A.10</a>. <a href="#name-figure-tests" class="internal xref">Figure tests</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.11">
-                <p id="section-toc.1-1.12.2.11.1"><a href="#appendix-A.11" class="auto internal xref">A.11</a>. <a href="#name-verse-tests-2" class="internal xref">Verse tests</a></p>
+                <p id="section-toc.1-1.12.2.11.1"><a href="#appendix-A.11" class="auto internal xref">A.11</a>. <a href="#name-verse-tests" class="internal xref">Verse tests</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-index-2" class="internal xref">Index</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-index" class="internal xref">Index</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="auto internal xref"></a><a href="#name-authors-address-2" class="internal xref">Author's Address</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="auto internal xref"></a><a href="#name-authors-address" class="internal xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -1488,8 +1488,8 @@ li > p:last-of-type:only-child {
 </div>
 <div id="introduction">
 <section id="section-1">
-      <h2 id="name-introduction-2">
-<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction-2" class="section-name selfRef">Introduction</a>
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
       </h2>
 <p id="section-1-1">
             This document presents a technique for using Pandoc syntax as a
@@ -1511,8 +1511,8 @@ li > p:last-of-type:only-child {
 </div>
 <div id="pandoc-to-rfc">
 <section id="section-2">
-      <h2 id="name-pandoc-to-rfc-2">
-<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-pandoc-to-rfc-2" class="section-name selfRef">Pandoc to RFC</a>
+      <h2 id="name-pandoc-to-rfc">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-pandoc-to-rfc" class="section-name selfRef">Pandoc to RFC</a>
       </h2>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="section-2-1.1">
@@ -1548,7 +1548,7 @@ li > p:last-of-type:only-child {
             conversions are, in some way amusing, as we start off with
             (almost) plain text, use elaborate XML and end up with plain text
             again.<a href="#section-2-4" class="pilcrow">¶</a></p>
-<span id="name-attempt-to-justify-pandoc2rf"></span><div id="fig-attempt-to">
+<span id="name-attempt-to-justify-pandoc2r"></span><div id="fig-attempt-to">
 <figure id="figure-1">
         <div class="alignLeft art-text artwork" id="section-2-5.1">
 <pre>
@@ -1565,7 +1565,7 @@ non-existent  |                       | xsltproc
 </pre>
 </div>
 <figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
-<a href="#name-attempt-to-justify-pandoc2rf" class="selfRef">Attempt to justify Pandoc2rfc.</a>
+<a href="#name-attempt-to-justify-pandoc2r" class="selfRef">Attempt to justify Pandoc2rfc.</a>
         </figcaption></figure>
 </div>
 <p id="section-2-6">
@@ -1577,7 +1577,7 @@ non-existent  |                       | xsltproc
             <code>back</code> section of
             an RFC.  The simplest way is to create a template XML file and
             include the appropriate XML:<a href="#section-2-6" class="pilcrow">¶</a></p>
-<span id="name-a-minimal-templatexml-2"></span><div id="fig-a-minimal-">
+<span id="name-a-minimal-templatexml"></span><div id="fig-a-minimal-">
 <figure id="figure-2">
         <div class="alignLeft art-text artwork" id="section-2-7.1">
 <pre>
@@ -1604,7 +1604,7 @@ non-existent  |                       | xsltproc
 </pre>
 </div>
 <figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
-<a href="#name-a-minimal-templatexml-2" class="selfRef">A minimal template.xml.</a>
+<a href="#name-a-minimal-templatexml" class="selfRef">A minimal template.xml.</a>
         </figcaption></figure>
 </div>
 <p id="section-2-8">
@@ -1631,8 +1631,8 @@ non-existent  |                       | xsltproc
             repository</a>.<a href="#section-2-10" class="pilcrow">¶</a></p>
 <div id="dependencies">
 <section id="section-2.1">
-        <h3 id="name-dependencies-2">
-<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-dependencies-2" class="section-name selfRef">Dependencies</a>
+        <h3 id="name-dependencies">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-dependencies" class="section-name selfRef">Dependencies</a>
         </h3>
 <p id="section-2.1-1">
                It needs <code>xsltproc</code>
@@ -1656,8 +1656,8 @@ non-existent  |                       | xsltproc
 </div>
 <div id="starting-a-new-project">
 <section id="section-3">
-      <h2 id="name-starting-a-new-project-2">
-<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-starting-a-new-project-2" class="section-name selfRef">Starting a new project</a>
+      <h2 id="name-starting-a-new-project">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-starting-a-new-project" class="section-name selfRef">Starting a new project</a>
       </h2>
 <p id="section-3-1">
             When starting a new project with
@@ -1692,8 +1692,8 @@ non-existent  |                       | xsltproc
 </div>
 <div id="supported-features">
 <section id="section-4">
-      <h2 id="name-supported-features-2">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-supported-features-2" class="section-name selfRef">Supported Features</a>
+      <h2 id="name-supported-features">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-supported-features" class="section-name selfRef">Supported Features</a>
       </h2>
 <ul class="normal">
 <li class="normal" id="section-4-1.1">
@@ -1776,8 +1776,8 @@ non-existent  |                       | xsltproc
 </div>
 <div id="unsupported-features">
 <section id="section-5">
-      <h2 id="name-unsupported-features-2">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-unsupported-features-2" class="section-name selfRef">Unsupported Features</a>
+      <h2 id="name-unsupported-features">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-unsupported-features" class="section-name selfRef">Unsupported Features</a>
       </h2>
 <ul class="normal">
 <li class="normal" id="section-5-1.1">
@@ -1794,8 +1794,8 @@ non-existent  |                       | xsltproc
 </div>
 <div id="acknowledgements">
 <section id="section-6">
-      <h2 id="name-acknowledgements-2">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-acknowledgements-2" class="section-name selfRef">Acknowledgements</a>
+      <h2 id="name-acknowledgements">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
 <p id="section-6-1">
             The following people have helped to make Pandoc2rfc what it is today: Benno Overeinder, Erlend Hamnaberg, Matthijs Mekking, Trygve Laugstoel.<a href="#section-6-1" class="pilcrow">¶</a></p>
@@ -1805,8 +1805,8 @@ non-existent  |                       | xsltproc
 </div>
 <div id="pandoc-constructs">
 <section id="section-7">
-      <h2 id="name-pandoc-constructs-2">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-pandoc-constructs-2" class="section-name selfRef">Pandoc Constructs</a>
+      <h2 id="name-pandoc-constructs">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-pandoc-constructs" class="section-name selfRef">Pandoc Constructs</a>
       </h2>
 <p id="section-7-1">
             So, what syntax do you need to use to get the correct output? Well, it is
@@ -1817,8 +1817,8 @@ non-existent  |                       | xsltproc
             For convenience we list the most important ones in the following sections.<a href="#section-7-2" class="pilcrow">¶</a></p>
 <div id="paragraph">
 <section id="section-7.1">
-        <h3 id="name-paragraph-2">
-<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-paragraph-2" class="section-name selfRef">Paragraph</a>
+        <h3 id="name-paragraph">
+<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-paragraph" class="section-name selfRef">Paragraph</a>
         </h3>
 <p id="section-7.1-1">
                Paragraphs are separated with an empty line.<a href="#section-7.1-1" class="pilcrow">¶</a></p>
@@ -1826,8 +1826,8 @@ non-existent  |                       | xsltproc
 </div>
 <div id="section">
 <section id="section-7.2">
-        <h3 id="name-section-2">
-<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-section-2" class="section-name selfRef">Section</a>
+        <h3 id="name-section">
+<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-section" class="section-name selfRef">Section</a>
         </h3>
 <p id="section-7.2-1">
                Just use the normal sectioning commands available in Pandoc, for instance:<a href="#section-7.2-1" class="pilcrow">¶</a></p>
@@ -1850,15 +1850,15 @@ Bla
 </div>
 <div id="list-styles">
 <section id="section-7.3">
-        <h3 id="name-list-styles-2">
-<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-list-styles-2" class="section-name selfRef">List Styles</a>
+        <h3 id="name-list-styles">
+<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-list-styles" class="section-name selfRef">List Styles</a>
         </h3>
 <p id="section-7.3-1">
                A good number of styles are supported.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
 <div id="symbol">
 <section id="section-7.3.1">
-          <h4 id="name-symbol-2">
-<a href="#section-7.3.1" class="section-number selfRef">7.3.1. </a><a href="#name-symbol-2" class="section-name selfRef">Symbol</a>
+          <h4 id="name-symbol">
+<a href="#section-7.3.1" class="section-number selfRef">7.3.1. </a><a href="#name-symbol" class="section-name selfRef">Symbol</a>
           </h4>
 <div class="alignLeft art-text artwork" id="section-7.3.1-1">
 <pre>
@@ -1882,8 +1882,8 @@ A symbol list.
 </div>
 <div id="number">
 <section id="section-7.3.2">
-          <h4 id="name-number-2">
-<a href="#section-7.3.2" class="section-number selfRef">7.3.2. </a><a href="#name-number-2" class="section-name selfRef">Number</a>
+          <h4 id="name-number">
+<a href="#section-7.3.2" class="section-number selfRef">7.3.2. </a><a href="#name-number" class="section-name selfRef">Number</a>
           </h4>
 <div class="alignLeft art-text artwork" id="section-7.3.2-1">
 <pre>
@@ -1907,8 +1907,8 @@ A numbered list.
 </div>
 <div id="empty">
 <section id="section-7.3.3">
-          <h4 id="name-empty-2">
-<a href="#section-7.3.3" class="section-number selfRef">7.3.3. </a><a href="#name-empty-2" class="section-name selfRef">Empty</a>
+          <h4 id="name-empty">
+<a href="#section-7.3.3" class="section-number selfRef">7.3.3. </a><a href="#name-empty" class="section-name selfRef">Empty</a>
           </h4>
 <p id="section-7.3.3-1">
                   Using the default list markers from Pandoc:<a href="#section-7.3.3-1" class="pilcrow">¶</a></p>
@@ -1934,8 +1934,8 @@ A list using the default list markers.
 </div>
 <div id="roman">
 <section id="section-7.3.4">
-          <h4 id="name-roman-2">
-<a href="#section-7.3.4" class="section-number selfRef">7.3.4. </a><a href="#name-roman-2" class="section-name selfRef">Roman</a>
+          <h4 id="name-roman">
+<a href="#section-7.3.4" class="section-number selfRef">7.3.4. </a><a href="#name-roman" class="section-name selfRef">Roman</a>
           </h4>
 <p id="section-7.3.4-1">
                   Use the supported Pandoc syntax:<a href="#section-7.3.4-1" class="pilcrow">¶</a></p>
@@ -1985,8 +1985,8 @@ II. Item two.
 </div>
 <div id="letter">
 <section id="section-7.3.5">
-          <h4 id="name-letter-2">
-<a href="#section-7.3.5" class="section-number selfRef">7.3.5. </a><a href="#name-letter-2" class="section-name selfRef">Letter</a>
+          <h4 id="name-letter">
+<a href="#section-7.3.5" class="section-number selfRef">7.3.5. </a><a href="#name-letter" class="section-name selfRef">Letter</a>
           </h4>
 <p id="section-7.3.5-1">
                   A numbered list.<a href="#section-7.3.5-1" class="pilcrow">¶</a></p>
@@ -2032,8 +2032,8 @@ B.  Item two.
 </div>
 <div id="hanging">
 <section id="section-7.3.6">
-          <h4 id="name-hanging-2">
-<a href="#section-7.3.6" class="section-number selfRef">7.3.6. </a><a href="#name-hanging-2" class="section-name selfRef">Hanging</a>
+          <h4 id="name-hanging">
+<a href="#section-7.3.6" class="section-number selfRef">7.3.6. </a><a href="#name-hanging" class="section-name selfRef">Hanging</a>
           </h4>
 <p id="section-7.3.6-1">
                   This is more like a description list, so we need to use:<a href="#section-7.3.6-1" class="pilcrow">¶</a></p>
@@ -2061,8 +2061,8 @@ Second item that needs clarification:
 </div>
 <div id="figureartwork">
 <section id="section-7.4">
-        <h3 id="name-figure-artwork-2">
-<a href="#section-7.4" class="section-number selfRef">7.4. </a><a href="#name-figure-artwork-2" class="section-name selfRef">Figure/Artwork</a>
+        <h3 id="name-figure-artwork">
+<a href="#section-7.4" class="section-number selfRef">7.4. </a><a href="#name-figure-artwork" class="section-name selfRef">Figure/Artwork</a>
         </h3>
 <p id="section-7.4-1">
                Indent the paragraph with 4 spaces.<a href="#section-7.4-1" class="pilcrow">¶</a></p>
@@ -2087,8 +2087,8 @@ Like this
                <code>@figure:\</code>.<a href="#section-7.4-3" class="pilcrow">¶</a></p>
 <div id="references">
 <section id="section-7.4.1">
-          <h4 id="name-references-5">
-<a href="#section-7.4.1" class="section-number selfRef">7.4.1. </a><a href="#name-references-5" class="section-name selfRef">References</a>
+          <h4 id="name-references">
+<a href="#section-7.4.1" class="section-number selfRef">7.4.1. </a><a href="#name-references" class="section-name selfRef">References</a>
           </h4>
 <p id="section-7.4.1-1">
                   The reference anchor attribute will be: <code>fig:</code>
@@ -2124,8 +2124,8 @@ Like this
 </div>
 <div id="block-quote">
 <section id="section-7.5">
-        <h3 id="name-block-quote-2">
-<a href="#section-7.5" class="section-number selfRef">7.5. </a><a href="#name-block-quote-2" class="section-name selfRef">Block Quote</a>
+        <h3 id="name-block-quote">
+<a href="#section-7.5" class="section-number selfRef">7.5. </a><a href="#name-block-quote" class="section-name selfRef">Block Quote</a>
         </h3>
 <p id="section-7.5-1">
                Any paragraph like:<a href="#section-7.5-1" class="pilcrow">¶</a></p>
@@ -2141,13 +2141,13 @@ Like this
 </div>
 <div id="references-1">
 <section id="section-7.6">
-        <h3 id="name-references-6">
-<a href="#section-7.6" class="section-number selfRef">7.6. </a><a href="#name-references-6" class="section-name selfRef">References</a>
+        <h3 id="name-references-2">
+<a href="#section-7.6" class="section-number selfRef">7.6. </a><a href="#name-references-2" class="section-name selfRef">References</a>
         </h3>
 <div id="external">
 <section id="section-7.6.1">
-          <h4 id="name-external-2">
-<a href="#section-7.6.1" class="section-number selfRef">7.6.1. </a><a href="#name-external-2" class="section-name selfRef">External</a>
+          <h4 id="name-external">
+<a href="#section-7.6.1" class="section-number selfRef">7.6.1. </a><a href="#name-external" class="section-name selfRef">External</a>
           </h4>
 <p id="section-7.6.1-1">
                   Any reference like:<a href="#section-7.6.1-1" class="pilcrow">¶</a></p>
@@ -2162,8 +2162,8 @@ Like this
 </div>
 <div id="internal">
 <section id="section-7.6.2">
-          <h4 id="name-internal-2">
-<a href="#section-7.6.2" class="section-number selfRef">7.6.2. </a><a href="#name-internal-2" class="section-name selfRef">Internal</a>
+          <h4 id="name-internal">
+<a href="#section-7.6.2" class="section-number selfRef">7.6.2. </a><a href="#name-internal" class="section-name selfRef">Internal</a>
           </h4>
 <p id="section-7.6.2-1">
                   Any reference like:<a href="#section-7.6.2-1" class="pilcrow">¶</a></p>
@@ -2201,8 +2201,8 @@ See [](#pandoc-constructs)
 </div>
 <div id="spanx-styles">
 <section id="section-7.7">
-        <h3 id="name-spanx-styles-2">
-<a href="#section-7.7" class="section-number selfRef">7.7. </a><a href="#name-spanx-styles-2" class="section-name selfRef">Spanx Styles</a>
+        <h3 id="name-spanx-styles">
+<a href="#section-7.7" class="section-number selfRef">7.7. </a><a href="#name-spanx-styles" class="section-name selfRef">Spanx Styles</a>
         </h3>
 <p id="section-7.7-1">
                The verb style can be selected with back-tics:
@@ -2222,12 +2222,12 @@ See [](#pandoc-constructs)
 </div>
 <div id="tables">
 <section id="section-7.8">
-        <h3 id="name-tables-2">
-<a href="#section-7.8" class="section-number selfRef">7.8. </a><a href="#name-tables-2" class="section-name selfRef">Tables</a>
+        <h3 id="name-tables">
+<a href="#section-7.8" class="section-number selfRef">7.8. </a><a href="#name-tables" class="section-name selfRef">Tables</a>
         </h3>
 <p id="section-7.8-1">
                A table can be entered as:<a href="#section-7.8-1" class="pilcrow">¶</a></p>
-<span id="name-a-caption-describing-the-fig"></span><div id="fig-a-caption-">
+<span id="name-a-caption-describing-the-fi"></span><div id="fig-a-caption-">
 <figure id="figure-3">
           <div class="alignLeft art-text artwork" id="section-7.8-2.1">
 <pre>
@@ -2241,7 +2241,7 @@ See [](#pandoc-constructs)
 </pre>
 </div>
 <figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
-<a href="#name-a-caption-describing-the-fig" class="selfRef">A caption describing the figure describing the table.</a>
+<a href="#name-a-caption-describing-the-fi" class="selfRef">A caption describing the figure describing the table.</a>
           </figcaption></figure>
 </div>
 <p id="section-7.8-3">
@@ -2253,8 +2253,8 @@ See [](#pandoc-constructs)
                is copied over to the generated XML.<a href="#section-7.8-3" class="pilcrow">¶</a></p>
 <div id="references-2">
 <section id="section-7.8.1">
-          <h4 id="name-references-7">
-<a href="#section-7.8.1" class="section-number selfRef">7.8.1. </a><a href="#name-references-7" class="section-name selfRef">References</a>
+          <h4 id="name-references-3">
+<a href="#section-7.8.1" class="section-number selfRef">7.8.1. </a><a href="#name-references-3" class="section-name selfRef">References</a>
           </h4>
 <p id="section-7.8.1-1">
                   The caption is <em>always</em>
@@ -2294,8 +2294,8 @@ See [](#pandoc-constructs)
 </div>
 <div id="indexes">
 <section id="section-7.9">
-        <h3 id="name-indexes-2">
-<a href="#section-7.9" class="section-number selfRef">7.9. </a><a href="#name-indexes-2" class="section-name selfRef">Indexes</a>
+        <h3 id="name-indexes">
+<a href="#section-7.9" class="section-number selfRef">7.9. </a><a href="#name-indexes" class="section-name selfRef">Indexes</a>
         </h3>
 <p id="section-7.9-1">
                The footnote syntax of Pandoc is slightly abused to support an index. Footnotes are entered in two steps, you have a marker in the text, and later you give actual footnote text. Like this:<a href="#section-7.9-1" class="pilcrow">¶</a></p>
@@ -2326,13 +2326,13 @@ See [](#pandoc-constructs)
 </div>
 <div id="usage-guidelines">
 <section id="section-8">
-      <h2 id="name-usage-guidelines-2">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-usage-guidelines-2" class="section-name selfRef">Usage guidelines</a>
+      <h2 id="name-usage-guidelines">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-usage-guidelines" class="section-name selfRef">Usage guidelines</a>
       </h2>
 <div id="working-with-multiple-files">
 <section id="section-8.1">
-        <h3 id="name-working-with-multiple-files-2">
-<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-working-with-multiple-files-2" class="section-name selfRef">Working with multiple files</a>
+        <h3 id="name-working-with-multiple-files">
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-working-with-multiple-files" class="section-name selfRef">Working with multiple files</a>
         </h3>
 <p id="section-8.1-1">
                As an author you will probably break up a draft in multiple files, each dealing
@@ -2355,8 +2355,8 @@ allsections.pdc: section.pdc.1 section.pdc.2 section.pdc.3
 </div>
 <div id="setting-the-title">
 <section id="section-8.2">
-        <h3 id="name-setting-the-title-2">
-<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-setting-the-title-2" class="section-name selfRef">Setting the title</a>
+        <h3 id="name-setting-the-title">
+<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-setting-the-title" class="section-name selfRef">Setting the title</a>
         </h3>
 <p id="section-8.2-1">
                If you use double quotes in the documents title in the
@@ -2379,8 +2379,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </div>
 <div id="uploading-the-xmltxt">
 <section id="section-8.3">
-        <h3 id="name-uploading-the-xml-txt-2">
-<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-uploading-the-xml-txt-2" class="section-name selfRef">Uploading the XML/txt</a>
+        <h3 id="name-uploading-the-xml-txt">
+<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-uploading-the-xml-txt" class="section-name selfRef">Uploading the XML/txt</a>
         </h3>
 <p id="section-8.3-1">
                The <code>draft.xml</code> target will
@@ -2390,8 +2390,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </div>
 <div id="vim-syntax-highlighting">
 <section id="section-8.4">
-        <h3 id="name-vim-syntax-highlighting-2">
-<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-vim-syntax-highlighting-2" class="section-name selfRef">VIM syntax highlighting</a>
+        <h3 id="name-vim-syntax-highlighting">
+<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-vim-syntax-highlighting" class="section-name selfRef">VIM syntax highlighting</a>
         </h3>
 <p id="section-8.4-1">
                If you are a VIM user you might be interested in a syntax highlighting file (see
@@ -2403,8 +2403,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </div>
 <div id="security-considerations">
 <section id="section-9">
-      <h2 id="name-security-considerations-2">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-security-considerations-2" class="section-name selfRef">Security Considerations</a>
+      <h2 id="name-security-considerations">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
 <p id="section-9-1">
             This document raises no security issues.<a href="#section-9-1" class="pilcrow">¶</a></p>
@@ -2412,20 +2412,20 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </div>
 <div id="iana-considerations">
 <section id="section-10">
-      <h2 id="name-iana-considerations-2">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-iana-considerations-2" class="section-name selfRef">IANA Considerations</a>
+      <h2 id="name-iana-considerations">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
 <p id="section-10-1">
             This document has no actions for IANA.<a href="#section-10-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <section id="section-11">
-      <h2 id="name-references-8">
-<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-references-8" class="section-name selfRef">References</a>
+      <h2 id="name-references-4">
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-references-4" class="section-name selfRef">References</a>
       </h2>
 <section id="section-11.1">
-        <h3 id="name-informative-references-2">
-<a href="#section-11.1" class="section-number selfRef">11.1. </a><a href="#name-informative-references-2" class="section-name selfRef">Informative References</a>
+        <h3 id="name-informative-references">
+<a href="#section-11.1" class="section-number selfRef">11.1. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
 <dt id="VIM">[VIM]</dt>
@@ -2435,8 +2435,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </dl>
 </section>
 <section id="section-11.2">
-        <h3 id="name-normative-references-2">
-<a href="#section-11.2" class="section-number selfRef">11.2. </a><a href="#name-normative-references-2" class="section-name selfRef">Normative References</a>
+        <h3 id="name-normative-references">
+<a href="#section-11.2" class="section-number selfRef">11.2. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
         </h3>
 <dl class="references">
 <dt id="RFC2119">[RFC2119]</dt>
@@ -2452,22 +2452,22 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </section>
 <div id="tests">
 <section id="appendix-A">
-      <h2 id="name-tests-2">
-<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-tests-2" class="section-name selfRef">Tests</a>
+      <h2 id="name-tests">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-tests" class="section-name selfRef">Tests</a>
       </h2>
 <p id="appendix-A-1">
             This appendix consists out of a few tests that should all render to proper
             <code>xml2rfc</code> XML.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
 <div id="a-very-long-title-considerations-with-regards-to-the-already-deployed-routing-policy">
 <section id="appendix-A.1">
-        <h3 id="name-a-very-long-title-considerat">
-<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-a-very-long-title-considerat" class="section-name selfRef">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a>
+        <h3 id="name-a-very-long-title-considera">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-a-very-long-title-considera" class="section-name selfRef">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a>
         </h3>
 <p id="appendix-A.1-1">
                Test a very long title.<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 <section id="appendix-A.1.1">
-          <h4 id="name-s-mime-encrypted-and-signed-">
-<a href="#appendix-A.1.1" class="section-number selfRef">A.1.1. </a><a href="#name-s-mime-encrypted-and-signed-" class="section-name selfRef">S/MIME encrypted and signed over a simple message, Injected Headers with hcp_minimal (+ Legacy Display)</a>
+          <h4 id="name-s-mime-encrypted-and-signed">
+<a href="#appendix-A.1.1" class="section-number selfRef">A.1.1. </a><a href="#name-s-mime-encrypted-and-signed" class="section-name selfRef">S/MIME encrypted and signed over a simple message, Injected Headers with hcp_minimal (+ Legacy Display)</a>
           </h4>
 <p id="appendix-A.1.1-1">Test long title edge case<a href="#appendix-A.1.1-1" class="pilcrow">¶</a></p>
 </section>
@@ -2475,8 +2475,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </div>
 <div id="markup-in-heading">
 <section id="appendix-A.2">
-        <h3 id="name-markup-in-heading-2">
-<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-markup-in-heading-2" class="section-name selfRef">Markup in heading</a>
+        <h3 id="name-markup-in-heading">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-markup-in-heading" class="section-name selfRef">Markup in heading</a>
         </h3>
 <p id="appendix-A.2-1">
                This is discarded by <code>xml2rfc</code>.<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
@@ -2484,8 +2484,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </div>
 <div id="blockquote">
 <section id="appendix-A.3">
-        <h3 id="name-blockquote-2">
-<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-blockquote-2" class="section-name selfRef">Blockquote</a>
+        <h3 id="name-blockquote">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-blockquote" class="section-name selfRef">Blockquote</a>
         </h3>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="appendix-A.3-1.1">
@@ -2496,8 +2496,8 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </div>
 <div id="verbatim-code-blocks">
 <section id="appendix-A.4">
-        <h3 id="name-verbatim-code-blocks-2">
-<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-verbatim-code-blocks-2" class="section-name selfRef">Verbatim code blocks</a>
+        <h3 id="name-verbatim-code-blocks">
+<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-verbatim-code-blocks" class="section-name selfRef">Verbatim code blocks</a>
         </h3>
 <div class="alignLeft art-text artwork" id="appendix-A.4-1">
 <pre>
@@ -2509,8 +2509,8 @@ jkasjksajassjasjsajsajkas
 </div>
 <div id="reference-tests">
 <section id="appendix-A.5">
-        <h3 id="name-reference-tests-2">
-<a href="#appendix-A.5" class="section-number selfRef">A.5. </a><a href="#name-reference-tests-2" class="section-name selfRef">Reference Tests</a>
+        <h3 id="name-reference-tests">
+<a href="#appendix-A.5" class="section-number selfRef">A.5. </a><a href="#name-reference-tests" class="section-name selfRef">Reference Tests</a>
         </h3>
 <p id="appendix-A.5-1">
                Refer to <span><a href="#RFC2119" class="internal xref">RFC 2119</a> [<a href="#RFC2119" class="cite xref">RFC2119</a>]</span> if you will. Or maybe you want to inspect <a href="#fig-a-minimal-" class="auto internal xref">Figure 2</a> in <a href="#pandoc-to-rfc" class="auto internal xref">Section 2</a> again. Or you might want to <a href="http://miek.nl">Click here</a>.<a href="#appendix-A.5-1" class="pilcrow">¶</a></p>
@@ -2518,8 +2518,8 @@ jkasjksajassjasjsajsajkas
 </div>
 <div id="spanx-tests">
 <section id="appendix-A.6">
-        <h3 id="name-spanx-tests-2">
-<a href="#appendix-A.6" class="section-number selfRef">A.6. </a><a href="#name-spanx-tests-2" class="section-name selfRef">Spanx Tests</a>
+        <h3 id="name-spanx-tests">
+<a href="#appendix-A.6" class="section-number selfRef">A.6. </a><a href="#name-spanx-tests" class="section-name selfRef">Spanx Tests</a>
         </h3>
 <ul class="normal ulEmpty">
 <li class="normal ulEmpty" id="appendix-A.6-1.1">
@@ -2539,8 +2539,8 @@ jkasjksajassjasjsajsajkas
 </div>
 <div id="list-tests">
 <section id="appendix-A.7">
-        <h3 id="name-list-tests-2">
-<a href="#appendix-A.7" class="section-number selfRef">A.7. </a><a href="#name-list-tests-2" class="section-name selfRef">List Tests</a>
+        <h3 id="name-list-tests">
+<a href="#appendix-A.7" class="section-number selfRef">A.7. </a><a href="#name-list-tests" class="section-name selfRef">List Tests</a>
         </h3>
 <ol start="1" type="1" class="normal type-1" id="appendix-A.7-1">
 <li id="appendix-A.7-1.1">
@@ -2735,7 +2735,7 @@ Artwork
         <dd class="break"></dd>
 </dl>
 <p id="appendix-A.7-20">
-               And default list markers.<span id="iref-list-default-markers-1-2" class="iref"></span><a href="#appendix-A.7-20" class="pilcrow">¶</a></p>
+               And default list markers.<span id="iref-list-default-markers-1" class="iref"></span><a href="#appendix-A.7-20" class="pilcrow">¶</a></p>
 <p id="appendix-A.7-21">
                Some surrounding text, to make it look better.<a href="#appendix-A.7-21" class="pilcrow">¶</a></p>
 <ul class="normal ulEmpty">
@@ -2779,7 +2779,7 @@ Artwork
         <dd class="break"></dd>
 </dl>
 <p id="appendix-A.7-28">
-               <span id="iref-list-uppercase-letters-2-2" class="iref"></span><a href="#appendix-A.7-28" class="pilcrow">¶</a></p>
+               <span id="iref-list-uppercase-letters-2" class="iref"></span><a href="#appendix-A.7-28" class="pilcrow">¶</a></p>
 <p id="appendix-A.7-29">
                And artwork in a description list.<a href="#appendix-A.7-29" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlParallel" id="appendix-A.7-30">
@@ -2830,14 +2830,14 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
 </div>
 <div id="anchor-table-tests">
 <section id="appendix-A.8">
-        <h3 id="name-table-tests-2">
-<a href="#appendix-A.8" class="section-number selfRef">A.8. </a><a href="#name-table-tests-2" class="section-name selfRef">Table Tests</a>
+        <h3 id="name-table-tests">
+<a href="#appendix-A.8" class="section-number selfRef">A.8. </a><a href="#name-table-tests" class="section-name selfRef">Table Tests</a>
         </h3>
-<span id="name-demonstration-of-simple-tabl"></span><div id="tab-demonstrat">
+<span id="name-demonstration-of-simple-tab"></span><div id="tab-demonstrat">
 <table class="center" id="table-1">
           <caption>
 <a href="#table-1" class="selfRef">Table 1</a>:
-<a href="#name-demonstration-of-simple-tabl" class="selfRef">Demonstration of simple table
+<a href="#name-demonstration-of-simple-tab" class="selfRef">Demonstration of simple table
         syntax.</a>
           </caption>
 <thead>
@@ -2870,11 +2870,11 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
           </tbody>
         </table>
 </div>
-<span id="name-heres-the-caption-it-too-may"></span><div id="tab-here-s-the">
+<span id="name-heres-the-caption-it-too-ma"></span><div id="tab-here-s-the">
 <table class="center" id="table-2">
           <caption>
 <a href="#table-2" class="selfRef">Table 2</a>:
-<a href="#name-heres-the-caption-it-too-may" class="selfRef">Here's the caption. It, too, may span multiple lines. This is a
+<a href="#name-heres-the-caption-it-too-ma" class="selfRef">Here's the caption. It, too, may span multiple lines. This is a
         multiline table. This is verbatim text.</a>
           </caption>
 <thead>
@@ -2902,12 +2902,12 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
         </table>
 </div>
 <p id="appendix-A.8-3">
-               <span id="iref-table-simple-3-2" class="iref"></span><a href="#appendix-A.8-3" class="pilcrow">¶</a></p>
-<span id="name-sample-grid-table-2"></span><div id="tab-sample-gri">
+               <span id="iref-table-simple-3" class="iref"></span><a href="#appendix-A.8-3" class="pilcrow">¶</a></p>
+<span id="name-sample-grid-table"></span><div id="tab-sample-gri">
 <table class="center" id="table-3">
           <caption>
 <a href="#table-3" class="selfRef">Table 3</a>:
-<a href="#name-sample-grid-table-2" class="selfRef">Sample grid table.</a>
+<a href="#name-sample-grid-table" class="selfRef">Sample grid table.</a>
           </caption>
 <thead>
             <tr>
@@ -2964,7 +2964,7 @@ See [](#tab-here-s-the)
 <p id="appendix-A.8-9">
                Which will become "See <a href="#tab-here-s-the" class="auto internal xref">Table 2</a>".<a href="#appendix-A.8-9" class="pilcrow">¶</a></p>
 <p id="appendix-A.8-10">
-               <span id="iref-table-grid-4-2" class="iref"></span><a href="#appendix-A.8-10" class="pilcrow">¶</a></p>
+               <span id="iref-table-grid-4" class="iref"></span><a href="#appendix-A.8-10" class="pilcrow">¶</a></p>
 <p id="appendix-A.8-11">
                We should also be able to refer to the table numbers directly, to say things like 
                'Look at Tables
@@ -2975,8 +2975,8 @@ See [](#tab-here-s-the)
 </div>
 <div id="numbered-examples">
 <section id="appendix-A.9">
-        <h3 id="name-numbered-examples-2">
-<a href="#appendix-A.9" class="section-number selfRef">A.9. </a><a href="#name-numbered-examples-2" class="section-name selfRef">Numbered examples</a>
+        <h3 id="name-numbered-examples">
+<a href="#appendix-A.9" class="section-number selfRef">A.9. </a><a href="#name-numbered-examples" class="section-name selfRef">Numbered examples</a>
         </h3>
 <p id="appendix-A.9-1">
                This is another example:<a href="#appendix-A.9-1" class="pilcrow">¶</a></p>
@@ -2991,10 +2991,10 @@ See [](#tab-here-s-the)
 </div>
 <div id="anchor-figure-tests">
 <section id="appendix-A.10">
-        <h3 id="name-figure-tests-2">
-<a href="#appendix-A.10" class="section-number selfRef">A.10. </a><a href="#name-figure-tests-2" class="section-name selfRef">Figure tests</a>
+        <h3 id="name-figure-tests">
+<a href="#appendix-A.10" class="section-number selfRef">A.10. </a><a href="#name-figure-tests" class="section-name selfRef">Figure tests</a>
         </h3>
-<span id="name-this-is-the-caption-with-tex"></span><div id="fig-this-is-th">
+<span id="name-this-is-the-caption-with-te"></span><div id="fig-this-is-th">
 <figure id="figure-4">
           <div class="alignLeft art-text artwork" id="appendix-A.10-1.1">
 <pre>
@@ -3005,12 +3005,12 @@ This is a figure
 </pre>
 </div>
 <figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
-<a href="#name-this-is-the-caption-with-tex" class="selfRef">This is the caption, with text in `typewriter`. Which isnt converted to a &lt;spanx&gt; style, because this is copied as-is.</a>
+<a href="#name-this-is-the-caption-with-te" class="selfRef">This is the caption, with text in `typewriter`. Which isnt converted to a &lt;spanx&gt; style, because this is copied as-is.</a>
           </figcaption></figure>
 </div>
 <p id="appendix-A.10-2">
                And how a figure that is not centered, do to using <code>figure</code> and not <code>Figure</code>.<a href="#appendix-A.10-2" class="pilcrow">¶</a></p>
-<span id="name-a-non-centered-figure-2"></span><div id="fig-a-non-cent">
+<span id="name-a-non-centered-figure"></span><div id="fig-a-non-cent">
 <figure id="figure-5">
           <div class="alignLeft art-text artwork" id="appendix-A.10-3.1">
 <pre>
@@ -3019,7 +3019,7 @@ This is a figure
 </pre>
 </div>
 <figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
-<a href="#name-a-non-centered-figure-2" class="selfRef">A non centered figure.</a>
+<a href="#name-a-non-centered-figure" class="selfRef">A non centered figure.</a>
           </figcaption></figure>
 </div>
 <p id="appendix-A.10-4">
@@ -3035,8 +3035,8 @@ This is a figure with a title
 </div>
 <div id="verse-tests">
 <section id="appendix-A.11">
-        <h3 id="name-verse-tests-2">
-<a href="#appendix-A.11" class="section-number selfRef">A.11. </a><a href="#name-verse-tests-2" class="section-name selfRef">Verse tests</a>
+        <h3 id="name-verse-tests">
+<a href="#appendix-A.11" class="section-number selfRef">A.11. </a><a href="#name-verse-tests" class="section-name selfRef">Verse tests</a>
         </h3>
 <p id="appendix-A.11-1">
                This is a verse text This is another line<a href="#appendix-A.11-1" class="pilcrow">¶</a></p>
@@ -3045,8 +3045,8 @@ This is a figure with a title
 </section>
 </div>
 <section id="appendix-B">
-      <h2 id="name-index-2">
-<a href="#name-index-2" class="section-name selfRef">Index</a>
+      <h2 id="name-index">
+<a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
 <p id="appendix-B-1">
@@ -3124,8 +3124,8 @@ This is a figure with a title
 </section>
 <div id="authors-addresses">
 <section id="appendix-C">
-      <h2 id="name-authors-address-2">
-<a href="#name-authors-address-2" class="section-name selfRef">Author's Address</a>
+      <h2 id="name-authors-address">
+<a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>
 <address class="vcard">
         <div dir="auto" class="left"><span class="fn nameRole">R. (Miek) Gieben</span></div>

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -22,7 +22,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2
-    platformdirs 3.6.0
+    platformdirs 3.7.0
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.31.0
@@ -1250,8 +1250,8 @@ li > p:last-of-type:only-child {
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
-        <h2 id="name-status-of-this-memo-2">
-<a href="#name-status-of-this-memo-2" class="section-name selfRef">Status of This Memo</a>
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
         </h2>
 <p id="section-boilerplate.1-1">
         This Internet-Draft is submitted in full conformance with the
@@ -1272,8 +1272,8 @@ li > p:last-of-type:only-child {
 </div>
 <div id="copyright">
 <section id="section-boilerplate.2">
-        <h2 id="name-copyright-notice-2">
-<a href="#name-copyright-notice-2" class="section-name selfRef">Copyright Notice</a>
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
             Copyright (c) 2009 IETF Trust and the persons identified as
@@ -1288,96 +1288,96 @@ li > p:last-of-type:only-child {
 </div>
 <div id="toc">
 <section id="section-toc.1">
-        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents-2">
-<a href="#name-table-of-contents-2" class="section-name selfRef">Table of Contents</a>
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
         </h2>
 <nav class="toc"><ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
-            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction-2" class="internal xref">Introduction</a></p>
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.1">
-                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-requirements-language-2" class="internal xref">Requirements Language</a></p>
+                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-requirements-language" class="internal xref">Requirements Language</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-simple-list-2" class="internal xref">Simple List</a></p>
+            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-simple-list" class="internal xref">Simple List</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-figures-2" class="internal xref">Figures</a></p>
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-figures" class="internal xref">Figures</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-subsections-and-tables-2" class="internal xref">Subsections and Tables</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-subsections-and-tables" class="internal xref">Subsections and Tables</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1">
-                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="auto internal xref">4.1</a>.  <a href="#name-a-subsection-2" class="internal xref">A Subsection</a></p>
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="auto internal xref">4.1</a>.  <a href="#name-a-subsection" class="internal xref">A Subsection</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2">
-                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="auto internal xref">4.2</a>.  <a href="#name-tables-2" class="internal xref">Tables</a></p>
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="auto internal xref">4.2</a>.  <a href="#name-tables" class="internal xref">Tables</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-more-about-lists-2" class="internal xref">More about Lists</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-more-about-lists" class="internal xref">More about Lists</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.1">
-                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="auto internal xref">5.1</a>.  <a href="#name-numbering-lists-across-lists" class="internal xref">Numbering Lists across Lists and Sections</a></p>
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="auto internal xref">5.1</a>.  <a href="#name-numbering-lists-across-list" class="internal xref">Numbering Lists across Lists and Sections</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
-                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-where-the-list-numbering-con" class="internal xref">Where the List Numbering Continues</a></p>
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-where-the-list-numbering-co" class="internal xref">Where the List Numbering Continues</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
-                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-nested-lists-2" class="internal xref">nested lists</a></p>
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-nested-lists" class="internal xref">nested lists</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
-                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="auto internal xref">5.4</a>.  <a href="#name-list-formats-2" class="internal xref">List Formats</a></p>
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="auto internal xref">5.4</a>.  <a href="#name-list-formats" class="internal xref">List Formats</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-example-of-code-or-mib-modul" class="internal xref">Example of Code or MIB Module To Be Extracted</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-example-of-code-or-mib-modu" class="internal xref">Example of Code or MIB Module To Be Extracted</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-acknowledgements-2" class="internal xref">Acknowledgements</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-iana-considerations-2" class="internal xref">IANA Considerations</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-security-considerations-2" class="internal xref">Security Considerations</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-references-2" class="internal xref">References</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-references" class="internal xref">References</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.1">
-                <p id="section-toc.1-1.10.2.1.1"><a href="#section-10.1" class="auto internal xref">10.1</a>.  <a href="#name-normative-references-2" class="internal xref">Normative References</a></p>
+                <p id="section-toc.1-1.10.2.1.1"><a href="#section-10.1" class="auto internal xref">10.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.2">
-                <p id="section-toc.1-1.10.2.2.1"><a href="#section-10.2" class="auto internal xref">10.2</a>.  <a href="#name-informative-references-2" class="internal xref">Informative References</a></p>
+                <p id="section-toc.1-1.10.2.2.1"><a href="#section-10.2" class="auto internal xref">10.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-additional-stuff-2" class="internal xref">Additional Stuff</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-additional-stuff" class="internal xref">Additional Stuff</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-contributors-2" class="internal xref">Contributors</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-contributors" class="internal xref">Contributors</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#appendix-C" class="auto internal xref"></a><a href="#name-authors-addresses-2" class="internal xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-C" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
 </section>
 </div>
 <section id="section-1">
-      <h2 id="name-introduction-2">
-<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction-2" class="section-name selfRef">Introduction</a>
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
       </h2>
 <p id="section-1-1">The original specification of xml2rfc format is in <span><a href="#RFC2629" class="internal xref">RFC 2629</a> [<a href="#RFC2629" class="cite xref">RFC2629</a>]</span>.<a href="#section-1-1" class="pilcrow">¶</a></p>
 <section id="section-1.1">
-        <h3 id="name-requirements-language-2">
-<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-requirements-language-2" class="section-name selfRef">Requirements Language</a>
+        <h3 id="name-requirements-language">
+<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-requirements-language" class="section-name selfRef">Requirements Language</a>
         </h3>
 <p id="section-1.1-1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
         "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
@@ -1386,8 +1386,8 @@ li > p:last-of-type:only-child {
 </section>
 <div id="simple_list">
 <section id="section-2">
-      <h2 id="name-simple-list-2">
-<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-simple-list-2" class="section-name selfRef">Simple List</a>
+      <h2 id="name-simple-list">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-simple-list" class="section-name selfRef">Simple List</a>
       </h2>
 <p id="section-2-1">List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
       'format'.<a href="#section-2-1" class="pilcrow">¶</a></p>
@@ -1401,8 +1401,8 @@ li > p:last-of-type:only-child {
 </section>
 </div>
 <section id="section-3">
-      <h2 id="name-figures-2">
-<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-figures-2" class="section-name selfRef">Figures</a>
+      <h2 id="name-figures">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-figures" class="section-name selfRef">Figures</a>
       </h2>
 <p id="section-3-1">Figures should not exceed 69 characters wide to allow for the indent
       of sections.<a href="#section-3-1" class="pilcrow">¶</a></p>
@@ -1428,29 +1428,29 @@ li > p:last-of-type:only-child {
       <em>significant</em> in figures even if you don't use CDATA.<a href="#section-3-5" class="pilcrow">¶</a></p>
 </section>
 <section id="section-4">
-      <h2 id="name-subsections-and-tables-2">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-subsections-and-tables-2" class="section-name selfRef">Subsections and Tables</a>
+      <h2 id="name-subsections-and-tables">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-subsections-and-tables" class="section-name selfRef">Subsections and Tables</a>
       </h2>
 <section id="section-4.1">
-        <h3 id="name-a-subsection-2">
-<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-a-subsection-2" class="section-name selfRef">A Subsection</a>
+        <h3 id="name-a-subsection">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-a-subsection" class="section-name selfRef">A Subsection</a>
         </h3>
 <p id="section-4.1-1">By default 3 levels of nesting show in table of contents but that
         can be adjusted with the value of the "tocdepth" processing
         instruction.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
 </section>
 <section id="section-4.2">
-        <h3 id="name-tables-2">
-<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-tables-2" class="section-name selfRef">Tables</a>
+        <h3 id="name-tables">
+<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-tables" class="section-name selfRef">Tables</a>
         </h3>
 <p id="section-4.2-1">.. are very similar to figures:<a href="#section-4.2-1" class="pilcrow">¶</a></p>
 <p id="section-4.2-2" class="keepWithNext">Tables use ttcol to define column headers and widths.
           Every cell then has a "c" element for its content.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
-<span id="name-a-very-simple-table-2"></span><div id="table_example">
+<span id="name-a-very-simple-table"></span><div id="table_example">
 <table class="center" id="table-1">
           <caption>
 <a href="#table-1" class="selfRef">Table 1</a>:
-<a href="#name-a-very-simple-table-2" class="selfRef">A Very Simple Table</a>
+<a href="#name-a-very-simple-table" class="selfRef">A Very Simple Table</a>
           </caption>
 <thead>
             <tr>
@@ -1479,8 +1479,8 @@ li > p:last-of-type:only-child {
 </section>
 <div id="nested_lists">
 <section id="section-5">
-      <h2 id="name-more-about-lists-2">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-more-about-lists-2" class="section-name selfRef">More about Lists</a>
+      <h2 id="name-more-about-lists">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-more-about-lists" class="section-name selfRef">More about Lists</a>
       </h2>
 <p id="section-5-1">Lists with 'hanging labels': the list item is indented the amount of
       the hangIndent:<a href="#section-5-1" class="pilcrow">¶</a></p>
@@ -1518,8 +1518,8 @@ li > p:last-of-type:only-child {
 </li>
       </ul>
 <section id="section-5.1">
-        <h3 id="name-numbering-lists-across-lists">
-<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-numbering-lists-across-lists" class="section-name selfRef">Numbering Lists across Lists and Sections</a>
+        <h3 id="name-numbering-lists-across-list">
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-numbering-lists-across-list" class="section-name selfRef">Numbering Lists across Lists and Sections</a>
         </h3>
 <p id="section-5.1-1">Numbering items continuously although they are in separate
         &lt;list&gt; elements, maybe in separate sections using the "format"
@@ -1558,8 +1558,8 @@ li > p:last-of-type:only-child {
 </dl>
 </section>
 <section id="section-5.2">
-        <h3 id="name-where-the-list-numbering-con">
-<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-where-the-list-numbering-con" class="section-name selfRef">Where the List Numbering Continues</a>
+        <h3 id="name-where-the-list-numbering-co">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-where-the-list-numbering-co" class="section-name selfRef">Where the List Numbering Continues</a>
         </h3>
 <p id="section-5.2-1">List continues here.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
 <p id="section-5.2-2">Third list:<a href="#section-5.2-2" class="pilcrow">¶</a></p>
@@ -1584,8 +1584,8 @@ li > p:last-of-type:only-child {
 <p id="section-5.2-4"> The end of the list.<a href="#section-5.2-4" class="pilcrow">¶</a></p>
 </section>
 <section id="section-5.3">
-        <h3 id="name-nested-lists-2">
-<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-nested-lists-2" class="section-name selfRef">nested lists</a>
+        <h3 id="name-nested-lists">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-nested-lists" class="section-name selfRef">nested lists</a>
         </h3>
 <p id="section-5.3-1">Simulating more than one paragraph in a list item using
    &lt;vspace&gt;:<a href="#section-5.3-1" class="pilcrow">¶</a></p>
@@ -1618,8 +1618,8 @@ li > p:last-of-type:only-child {
         </ol>
 </section>
 <section id="section-5.4">
-        <h3 id="name-list-formats-2">
-<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-list-formats-2" class="section-name selfRef">List Formats</a>
+        <h3 id="name-list-formats">
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-list-formats" class="section-name selfRef">List Formats</a>
         </h3>
 <p id="section-5.4-1">many formats<a href="#section-5.4-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="olPercent" id="section-5.4-2">
@@ -1911,8 +1911,8 @@ li > p:last-of-type:only-child {
 </div>
 <div id="codeExample">
 <section id="section-6">
-      <h2 id="name-example-of-code-or-mib-modul">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-example-of-code-or-mib-modul" class="section-name selfRef">Example of Code or MIB Module To Be Extracted</a>
+      <h2 id="name-example-of-code-or-mib-modu">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-example-of-code-or-mib-modu" class="section-name selfRef">Example of Code or MIB Module To Be Extracted</a>
       </h2>
 <p id="section-6-1" class="keepWithNext">The &lt;artwork&gt; element has a number of extra attributes
         that can be used to substitute a more aesthetically pleasing rendition
@@ -1956,8 +1956,8 @@ main(int argc, char *argv[])
 </div>
 <div id="Acknowledgements">
 <section id="section-7">
-      <h2 id="name-acknowledgements-2">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-acknowledgements-2" class="section-name selfRef">Acknowledgements</a>
+      <h2 id="name-acknowledgements">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
 <p id="section-7-1">This template was derived from an initial version written by Pekka
       Savola and contributed by him to the xml2rfc project.<a href="#section-7-1" class="pilcrow">¶</a></p>
@@ -1968,8 +1968,8 @@ main(int argc, char *argv[])
 </div>
 <div id="IANA">
 <section id="section-8">
-      <h2 id="name-iana-considerations-2">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-iana-considerations-2" class="section-name selfRef">IANA Considerations</a>
+      <h2 id="name-iana-considerations">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
 <p id="section-8-1">This memo includes no request to IANA.<a href="#section-8-1" class="pilcrow">¶</a></p>
 <p id="section-8-2">All drafts are required to have an IANA considerations section (see
@@ -1982,20 +1982,20 @@ main(int argc, char *argv[])
 </div>
 <div id="Security">
 <section id="section-9">
-      <h2 id="name-security-considerations-2">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-security-considerations-2" class="section-name selfRef">Security Considerations</a>
+      <h2 id="name-security-considerations">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
 <p id="section-9-1">All drafts are required to have a security considerations section.
       See <span><a href="#RFC3552" class="internal xref">RFC 3552</a> [<a href="#RFC3552" class="cite xref">RFC3552</a>]</span> for a guide.<a href="#section-9-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <section id="section-10">
-      <h2 id="name-references-2">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-references-2" class="section-name selfRef">References</a>
+      <h2 id="name-references">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-references" class="section-name selfRef">References</a>
       </h2>
 <section id="section-10.1">
-        <h3 id="name-normative-references-2">
-<a href="#section-10.1" class="section-number selfRef">10.1. </a><a href="#name-normative-references-2" class="section-name selfRef">Normative References</a>
+        <h3 id="name-normative-references">
+<a href="#section-10.1" class="section-number selfRef">10.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
         </h3>
 <dl class="references">
 <dt id="min_ref">[min_ref]</dt>
@@ -2009,8 +2009,8 @@ main(int argc, char *argv[])
 </dl>
 </section>
 <section id="section-10.2">
-        <h3 id="name-informative-references-2">
-<a href="#section-10.2" class="section-number selfRef">10.2. </a><a href="#name-informative-references-2" class="section-name selfRef">Informative References</a>
+        <h3 id="name-informative-references">
+<a href="#section-10.2" class="section-number selfRef">10.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
 <dt id="DOI_10.1145_2975159">[DOI_10.1145_2975159]</dt>
@@ -2042,24 +2042,24 @@ main(int argc, char *argv[])
 </section>
 <div id="app-additional">
 <section id="appendix-A">
-      <h2 id="name-additional-stuff-2">
-<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-additional-stuff-2" class="section-name selfRef">Additional Stuff</a>
+      <h2 id="name-additional-stuff">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-additional-stuff" class="section-name selfRef">Additional Stuff</a>
       </h2>
 <p id="appendix-A-1">This becomes an Appendix.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="contributors">
 <section id="appendix-B">
-      <h2 id="name-contributors-2">
-<a href="#name-contributors-2" class="section-name selfRef">Contributors</a>
+      <h2 id="name-contributors">
+<a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
 <p id="appendix-B-1">This becomes an unnumbered section<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authors-addresses">
 <section id="appendix-C">
-      <h2 id="name-authors-addresses-2">
-<a href="#name-authors-addresses-2" class="section-name selfRef">Authors' Addresses</a>
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>
 <address class="vcard">
         <div dir="auto" class="left"><span class="fn nameRole">Elwyn Davies (<span class="role">editor</span>)</span></div>

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             June 19, 2023
+Internet-Draft                                             June 22, 2023
 Intended status: Experimental                                           
-Expires: December 21, 2023
+Expires: December 24, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 21, 2023.
+   This Internet-Draft will expire on December 24, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires December 21, 2023               [Page 1]
+Person                  Expires December 24, 2023               [Page 1]
 
 Internet-Draft             xml2rfc index tests                 June 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires December 21, 2023               [Page 2]
+Person                  Expires December 24, 2023               [Page 2]
 
 Internet-Draft             xml2rfc index tests                 June 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires December 21, 2023               [Page 3]
+Person                  Expires December 24, 2023               [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-06-19T05:27:04" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-06-22T15:05:51" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.17.3 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="19" month="06" year="2023"/>
+    <date day="22" month="06" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 21 December 2023.
+        This Internet-Draft will expire on 24 December 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             June 19, 2023
+Internet-Draft                                             June 22, 2023
 Intended status: Experimental                                           
-Expires: December 21, 2023
+Expires: December 24, 2023
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 21, 2023.
+   This Internet-Draft will expire on December 24, 2023.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 21, 2023</td>
+<td class="center">Expires December 24, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-06-19" class="published">June 19, 2023</time>
+<time datetime="2023-06-22" class="published">June 22, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-12-21">December 21, 2023</time></dd>
+<dd class="expires"><time datetime="2023-12-24">December 24, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 21, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 24, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                            19 June 2023
+                                                            22 June 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -26,7 +26,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.2
-    platformdirs 3.6.0
+    platformdirs 3.7.0
     pycountry 22.3.5
     PyYAML 6.0
     requests 2.31.0
@@ -1268,8 +1268,8 @@ li > p:last-of-type:only-child {
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
-        <h2 id="name-status-of-this-memo-2">
-<a href="#name-status-of-this-memo-2" class="section-name selfRef">Status of This Memo</a>
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
         </h2>
 <p id="section-boilerplate.1-1">
             This is an Internet Standards Track document.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
@@ -1288,8 +1288,8 @@ li > p:last-of-type:only-child {
 </div>
 <div id="copyright">
 <section id="section-boilerplate.2">
-        <h2 id="name-copyright-notice-2">
-<a href="#name-copyright-notice-2" class="section-name selfRef">Copyright Notice</a>
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
             Copyright (c) 2016 IETF Trust and the persons identified as the
@@ -1308,63 +1308,63 @@ li > p:last-of-type:only-child {
 </div>
 <div id="toc">
 <section id="section-toc.1">
-        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents-2">
-<a href="#name-table-of-contents-2" class="section-name selfRef">Table of Contents</a>
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
         </h2>
 <nav class="toc"><ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
-            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction-2" class="internal xref">Introduction</a></p>
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.1">
-                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-specification-of-requirement" class="internal xref">Specification of Requirements</a></p>
+                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-specification-of-requiremen" class="internal xref">Specification of Requirements</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-how-to-identify-a-path-2" class="internal xref">How to Identify a Path</a></p>
+            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-how-to-identify-a-path" class="internal xref">How to Identify a Path</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-extended-nlri-encodings-2" class="internal xref">Extended NLRI Encodings</a></p>
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-extended-nlri-encodings" class="internal xref">Extended NLRI Encodings</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-add-path-capability-2" class="internal xref">ADD-PATH Capability</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-add-path-capability" class="internal xref">ADD-PATH Capability</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-operation-2" class="internal xref">Operation</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-operation" class="internal xref">Operation</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-deployment-considerations-2" class="internal xref">Deployment Considerations</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-deployment-considerations" class="internal xref">Deployment Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-iana-considerations-2" class="internal xref">IANA Considerations</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-security-considerations-2" class="internal xref">Security Considerations</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-references-2" class="internal xref">References</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-references" class="internal xref">References</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.1">
-                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="auto internal xref">9.1</a>.  <a href="#name-normative-references-2" class="internal xref">Normative References</a></p>
+                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="auto internal xref">9.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
-                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="auto internal xref">9.2</a>.  <a href="#name-informative-references-2" class="internal xref">Informative References</a></p>
+                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="auto internal xref">9.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-acknowledgments-2" class="internal xref">Acknowledgments</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-acknowledgments" class="internal xref">Acknowledgments</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-authors-addresses-2" class="internal xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
 </section>
 </div>
 <section id="section-1">
-      <h2 id="name-introduction-2">
-<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction-2" class="section-name selfRef">Introduction</a>
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
       </h2>
 <p id="section-1-1">The BGP specification <span>[<a href="#RFC4271" class="cite xref">RFC4271</a>]</span> defines an Update-Send Process to advertise the
       routes chosen by the Decision Process to other BGP speakers. No
@@ -1382,8 +1382,8 @@ li > p:last-of-type:only-child {
       convergence in a network by providing potential alternate or backup paths, 
       respectively.<a href="#section-1-3" class="pilcrow">¶</a></p>
 <section id="section-1.1">
-        <h3 id="name-specification-of-requirement">
-<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-specification-of-requirement" class="section-name selfRef">Specification of Requirements</a>
+        <h3 id="name-specification-of-requiremen">
+<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-specification-of-requiremen" class="section-name selfRef">Specification of Requirements</a>
         </h3>
 <p id="section-1.1-1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
         "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
@@ -1391,8 +1391,8 @@ li > p:last-of-type:only-child {
 </section>
 </section>
 <section id="section-2">
-      <h2 id="name-how-to-identify-a-path-2">
-<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-how-to-identify-a-path-2" class="section-name selfRef">How to Identify a Path</a>
+      <h2 id="name-how-to-identify-a-path">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-how-to-identify-a-path" class="section-name selfRef">How to Identify a Path</a>
       </h2>
 <p id="section-2-1">As defined in <span>[<a href="#RFC4271" class="cite xref">RFC4271</a>]</span>, a path refers to the information reported in the
       Path Attribute field of an UPDATE message. As the procedures specified
@@ -1416,8 +1416,8 @@ li > p:last-of-type:only-child {
 </section>
 <div id="code">
 <section id="section-3">
-      <h2 id="name-extended-nlri-encodings-2">
-<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-extended-nlri-encodings-2" class="section-name selfRef">Extended NLRI Encodings</a>
+      <h2 id="name-extended-nlri-encodings">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-extended-nlri-encodings" class="section-name selfRef">Extended NLRI Encodings</a>
       </h2>
 <p id="section-3-1">In order to carry the Path Identifier in an UPDATE message, the NLRI
       encoding MUST be extended by prepending the Path Identifier field, which
@@ -1438,8 +1438,8 @@ li > p:last-of-type:only-child {
 </div>
 <div id="capa">
 <section id="section-4">
-      <h2 id="name-add-path-capability-2">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-add-path-capability-2" class="section-name selfRef">ADD-PATH Capability</a>
+      <h2 id="name-add-path-capability">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-add-path-capability" class="section-name selfRef">ADD-PATH Capability</a>
       </h2>
 <p id="section-4-1">The ADD-PATH Capability is a BGP capability <span>[<a href="#RFC5492" class="cite xref">RFC5492</a>]</span>, with Capability Code
       69. The Capability Length field of this capability is
@@ -1492,8 +1492,8 @@ li > p:last-of-type:only-child {
 </div>
 <div id="ops">
 <section id="section-5">
-      <h2 id="name-operation-2">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-operation-2" class="section-name selfRef">Operation</a>
+      <h2 id="name-operation">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-operation" class="section-name selfRef">Operation</a>
       </h2>
 <p id="section-5-1">The Path Identifier specified in <a href="#code" class="auto internal xref">Section 3</a> can be used to
       advertise multiple paths for the same address prefix without subsequent
@@ -1531,8 +1531,8 @@ li > p:last-of-type:only-child {
 </section>
 </div>
 <section id="section-6">
-      <h2 id="name-deployment-considerations-2">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-deployment-considerations-2" class="section-name selfRef">Deployment Considerations</a>
+      <h2 id="name-deployment-considerations">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-deployment-considerations" class="section-name selfRef">Deployment Considerations</a>
       </h2>
 <p id="section-6-1">The extension proposed in this document provides a mechanism for a
       BGP speaker to advertise multiple paths over a BGP session. Care needs
@@ -1555,16 +1555,16 @@ li > p:last-of-type:only-child {
       additional information is outside the scope of this document.<a href="#section-6-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-7">
-      <h2 id="name-iana-considerations-2">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-iana-considerations-2" class="section-name selfRef">IANA Considerations</a>
+      <h2 id="name-iana-considerations">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
 <p id="section-7-1">IANA has assigned the value 69 for the ADD-PATH Capability
       described in this document. This registration is in the "Capability
       Codes" registry.<a href="#section-7-1" class="pilcrow">¶</a></p>
 </section>
 <section id="section-8">
-      <h2 id="name-security-considerations-2">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-security-considerations-2" class="section-name selfRef">Security Considerations</a>
+      <h2 id="name-security-considerations">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
 <p id="section-8-1">This document defines a BGP extension that allows the advertisement
       of multiple paths for the same address prefix without the new paths
@@ -1585,12 +1585,12 @@ li > p:last-of-type:only-child {
 <p id="section-8-3">Security concerns in the base operation of <span><a href="#RFC4271" class="internal xref">BGP</a> [<a href="#RFC4271" class="cite xref">RFC4271</a>]</span> also apply.<a href="#section-8-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-9">
-      <h2 id="name-references-2">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-references-2" class="section-name selfRef">References</a>
+      <h2 id="name-references">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-references" class="section-name selfRef">References</a>
       </h2>
 <section id="section-9.1">
-        <h3 id="name-normative-references-2">
-<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-normative-references-2" class="section-name selfRef">Normative References</a>
+        <h3 id="name-normative-references">
+<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
         </h3>
 <dl class="references">
 <dt id="RFC2119">[RFC2119]</dt>
@@ -1612,8 +1612,8 @@ li > p:last-of-type:only-child {
 </dl>
 </section>
 <section id="section-9.2">
-        <h3 id="name-informative-references-2">
-<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-informative-references-2" class="section-name selfRef">Informative References</a>
+        <h3 id="name-informative-references">
+<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
 <dt id="ADDPATH">[ADDPATH]</dt>
@@ -1644,8 +1644,8 @@ li > p:last-of-type:only-child {
 </section>
 </section>
 <section id="appendix-A">
-      <h2 id="name-acknowledgments-2">
-<a href="#name-acknowledgments-2" class="section-name selfRef">Acknowledgments</a>
+      <h2 id="name-acknowledgments">
+<a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
       </h2>
 <p id="appendix-A-1">We would like to thank David Cook and Naiming Shen for their
       contributions to the design and development of the extension.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
@@ -1657,8 +1657,8 @@ li > p:last-of-type:only-child {
 </section>
 <div id="authors-addresses">
 <section id="appendix-B">
-      <h2 id="name-authors-addresses-2">
-<a href="#name-authors-addresses-2" class="section-name selfRef">Authors' Addresses</a>
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>
 <address class="vcard">
         <div dir="auto" class="left"><span class="fn nameRole">Daniel Walton</span></div>

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             June 19, 2023
+Internet-Draft                                             June 22, 2023
 Intended status: Experimental                                           
-Expires: December 21, 2023
+Expires: December 24, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 21, 2023.
+   This Internet-Draft will expire on December 24, 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires December 21, 2023               [Page 1]
+Person                  Expires December 24, 2023               [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests               June 2023
 
 
 
-Person                  Expires December 21, 2023               [Page 2]
+Person                  Expires December 24, 2023               [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests               June 2023
 
 
 
-Person                  Expires December 21, 2023               [Page 3]
+Person                  Expires December 24, 2023               [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests               June 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires December 21, 2023               [Page 4]
+Person                  Expires December 24, 2023               [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-06-19T05:27:12" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-06-22T15:05:59" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.17.3 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="19" month="06" year="2023"/>
+    <date day="22" month="06" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 21 December 2023.
+        This Internet-Draft will expire on 24 December 2023.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             June 19, 2023
+Internet-Draft                                             June 22, 2023
 Intended status: Experimental                                           
-Expires: December 21, 2023
+Expires: December 24, 2023
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 21, 2023.
+   This Internet-Draft will expire on December 24, 2023.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 21, 2023</td>
+<td class="center">Expires December 24, 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-06-19" class="published">June 19, 2023</time>
+<time datetime="2023-06-22" class="published">June 22, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-12-21">December 21, 2023</time></dd>
+<dd class="expires"><time datetime="2023-12-24">December 24, 2023</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 21, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 24, 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/writers/preptool.py
+++ b/xml2rfc/writers/preptool.py
@@ -211,6 +211,7 @@ class PrepToolWriter(BaseV3Writer):
         e.text = '\n'.join(lines)
 
     def prep(self):
+        self._seen_slugs = set()  # Reset cache before prepping
         self.xinclude()
         # Set up reference mapping for later use.  Done here, and not earlier,
         # to capture any references pulled in by the XInclude we just did.


### PR DESCRIPTION
The `writers.preptool.slugify_name()` helper kept a set of `seen_slugs` as a module-level variable. As a result, uniqueness among slugs was enforced for the entire lifetime of a module import, including across `PrepToolWriter` instances and across multiple calls to `prep()`.

In xml2rfc itself, this appears to have been adding unnecessary "-2" suffixes on many HTML ids, at least in the tests. For datatracker's use of xml2rfc as a library, this was causing difficulties with long-lived celery workers by adding suffixes to prevent collisions between entirely separate drafts and eventually running out of unique slugs.

This makes the `slugify_name()` procedure a method on `PrepToolWriter` and resets the `seen_slugs` cache, now a property of the instance, on each invocation of `prep()`