### PR TITLE
fix: Avoid running v2v3 conversion and preptool on prepped documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ datetime_regex = [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][T_ ][0-9][0-9]:[0-9]
 version_regex =  [Vv]ersion [23N]\(\.[0-9N]\+\)\+\(\.dev\)\?
 date_regex = \([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\|\([0-9]\([0-9]\)\? \)\?[ADFJMOS][a-u]\* [12][0-9][0-9][0-9]\)
 legacydate_regex = [ADFJMOS][a-u]* [123]*[0-9], [12][0-9][0-9][0-9]$$
+expire_regex = This Internet-Draft will expire on.*$
 generator_regex = name="generator"
 libversion_regex = \(pyflakes\|PyYAML\|requests\|setuptools\|six\|Weasyprint\) [0-9]\+\(\.[0-9]\+\)*
 
@@ -130,10 +131,10 @@ tests/out/%.prepped.xml: tests/input/%.xml tests/out/%.v3.html tests/out/%.text 
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --out $@ --prep $<"
 	@echo " Checking generation of .html from prepped .xml"
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --out $(basename $@).html --html --external-css --external-js --legacy-date-format --no-inline-version $@" 2> /dev/null || { err=$$?; echo "Error output when generating .html from prepped .xml"; exit $$err; }
-	@diff -u -I '$(datetime_regex)' -I '$(version_regex)' -I '$(date_regex)' -I '$(generator_regex)' -I 'rel="alternate"' tests/out/$(notdir $(basename $(basename $@))).v3.html $(basename $@).html || { echo "Diff failed for $(basename $@).html output (2)"; exit 1; }
+	@diff -u -I '$(datetime_regex)' -I '$(version_regex)' -I '$(date_regex)' -I '$(legacydate_regex)' -I '$(expire_regex)' -I '$(generator_regex)' -I 'rel="alternate"' tests/out/$(notdir $(basename $(basename $@))).v3.html $(basename $@).html || { echo "Diff failed for $(basename $@).html output (2)"; exit 1; }
 	@echo " Checking generation of .text from prepped .xml"
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --out $(basename $@).text --text --no-pagination --external-css --external-js --legacy-date-format $@" 2> /dev/null || { err=$$?; echo "Error output when generating .text from prepped .xml"; exit $$err; }
-	@diff -u -I '$(datetime_regex)' -I '$(version_regex)' -I '$(date_regex)' -I '$(generator_regex)' -I 'rel="alternate"' tests/out/$(notdir $(basename $(basename $@))).text $(basename $@).text || { echo "Diff failed for $(basename $@).text output (3)"; exit 1; }
+	@diff -u -I '$(datetime_regex)' -I '$(version_regex)' -I '$(date_regex)' -I '$(legacydate_regex)' -I '$(expire_regex)' -I '$(generator_regex)' -I 'rel="alternate"' tests/out/$(notdir $(basename $(basename $@))).text $(basename $@).text || { echo "Diff failed for $(basename $@).text output (3)"; exit 1; }
 
 tests/out/docfile.xml:
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --allow-local-file-access --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --doc --out $@"

--- a/tests/input/elements.xml
+++ b/tests/input/elements.xml
@@ -1270,7 +1270,6 @@ for opt, value in opts:
       </section>
       <section>
          <name>Wide artwork</name>
-         <?v3xml2rfc silence="Artwork too wide, reducing indentation" ?>
          <artwork>
 0        1         2         3         4         5         6         7
 123456789012345678901234567890123456789012345678901234567890123456789012

--- a/tests/input/rfc7911.xml
+++ b/tests/input/rfc7911.xml
@@ -7,8 +7,6 @@
 <?rfc subcompact="no"?>
 
 <rfc number="7911" category="std" consensus="yes" submissionType="IETF" ipr="trust200902" docName="draft-ietf-idr-add-paths">
-  <?v3xml2rfc silence="The 'docName' attribute of the .rfc/. element should have a revision number" ?>
-  <?v3xml2rfc silence="The document date .*? is more than 3 days away from today's date" ?>
   <front>
     <title abbrev="ADD-PATH">Advertisement of Multiple Paths in BGP</title>
 

--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">July 2023</td>
+<td class="right">August 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-07-27" class="published">27 July 2023</time>
+<time datetime="2023-08-02" class="published">2 August 2023</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">

--- a/tests/valid/elements.prepped.xml
+++ b/tests/valid/elements.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" submissionType="independent" ipr="trust200902" docName="elements-00" category="info" obsoletes="1234,5678,9012,3456,7890" sortRefs="true" indexInclude="false" prepTime="2023-07-27T20:11:18" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" submissionType="independent" ipr="trust200902" docName="elements-00" category="info" obsoletes="1234,5678,9012,3456,7890" sortRefs="true" indexInclude="false" prepTime="2023-08-02T01:35:51" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   
    
    
@@ -1479,8 +1479,7 @@ for opt, value in opts:
     </section>
     <section numbered="true" removeInRFC="false" toc="include" pn="section-15">
       <name slugifiedName="name-wide-artwork">Wide artwork</name>
-      
-         <artwork align="left" pn="section-15-1">
+      <artwork align="left" pn="section-15-1">
 0        1         2         3         4         5         6         7
 123456789012345678901234567890123456789012345678901234567890123456789012
          </artwork>

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             July 27, 2023
+Internet-Draft                                            August 2, 2023
 Intended status: Experimental                                           
-Expires: January 28, 2024
+Expires: February 3, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 28, 2024.
+   This Internet-Draft will expire on February 3, 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                  Expires January 28, 2024                [Page 1]
+Person                  Expires February 3, 2024                [Page 1]
 
-Internet-Draft             xml2rfc index tests                 July 2023
+Internet-Draft             xml2rfc index tests               August 2023
 
 
    This is another section!
@@ -109,9 +109,9 @@ Index
 
 
 
-Person                  Expires January 28, 2024                [Page 2]
+Person                  Expires February 3, 2024                [Page 2]
 
-Internet-Draft             xml2rfc index tests                 July 2023
+Internet-Draft             xml2rfc index tests               August 2023
 
 
       E
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires January 28, 2024                [Page 3]
+Person                  Expires February 3, 2024                [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-07-27T20:05:08" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-08-02T00:11:46" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.17.5 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="27" month="07" year="2023"/>
+    <date day="02" month="08" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 28 January 2024.
+        This Internet-Draft will expire on 3 February 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             July 27, 2023
+Internet-Draft                                            August 2, 2023
 Intended status: Experimental                                           
-Expires: January 28, 2024
+Expires: February 3, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 28, 2024.
+   This Internet-Draft will expire on February 3, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">July 2023</td>
+<td class="right">August 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires January 28, 2024</td>
+<td class="center">Expires February 3, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-07-27" class="published">July 27, 2023</time>
+<time datetime="2023-08-02" class="published">August 2, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-01-28">January 28, 2024</time></dd>
+<dd class="expires"><time datetime="2024-02-03">February 3, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on January 28, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on February 3, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                            27 July 2023
+                                                           2 August 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.exp.xml
+++ b/tests/valid/rfc7911.exp.xml
@@ -6,8 +6,6 @@
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" number="7911" category="std" consensus="yes" submissionType="IETF" ipr="trust200902" docName="draft-ietf-idr-add-paths" obsoletes="" updates="" xml:lang="en">
-  <?v3xml2rfc silence="The 'docName' attribute of the .rfc/. element should have a revision number" ?>
-  <?v3xml2rfc silence="The document date .*? is more than 3 days away from today's date" ?>
   <front>
     <title abbrev="ADD-PATH">Advertisement of Multiple Paths in BGP</title>
     <author fullname="Daniel Walton" initials="D." surname="Walton">

--- a/tests/valid/rfc7911.prepped.xml
+++ b/tests/valid/rfc7911.prepped.xml
@@ -1,10 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" number="7911" category="std" consensus="true" submissionType="IETF" ipr="trust200902" docName="draft-ietf-idr-add-paths" obsoletes="" updates="" xml:lang="en" tocInclude="true" sortRefs="true" symRefs="true" prepTime="2023-07-26T21:43:02" indexInclude="true" scripts="Common,Latin" tocDepth="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" number="7911" category="std" consensus="true" submissionType="IETF" ipr="trust200902" docName="draft-ietf-idr-add-paths" obsoletes="" updates="" xml:lang="en" tocInclude="true" sortRefs="true" symRefs="true" prepTime="2023-08-02T01:28:17" indexInclude="true" scripts="Common,Latin" tocDepth="3">
   <link href="https://dx.doi.org/10.17487/rfc7911" rel="alternate"/>
   <link href="urn:issn:2070-1721" rel="alternate"/>
   <link href="https://datatracker.ietf.org/doc/draft-ietf-idr-add-paths" rel="prev"/>
-  
-  
   <front>
     <title abbrev="ADD-PATH">Advertisement of Multiple Paths in BGP</title>
     <seriesInfo name="RFC" value="7911" stream="IETF"/>

--- a/tests/valid/rfc7911.v2v3.xml
+++ b/tests/valid/rfc7911.v2v3.xml
@@ -11,10 +11,8 @@
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" number="7911" category="std" consensus="true" submissionType="IETF" ipr="trust200902" docName="draft-ietf-idr-add-paths" obsoletes="" updates="" xml:lang="en" tocInclude="true" sortRefs="true" symRefs="true" version="3">
-  <!-- xml2rfc v2v3 conversion 3.12.10 -->
+  <!-- xml2rfc v2v3 conversion 3.17.5 -->
   <link href="https://datatracker.ietf.org/doc/draft-ietf-idr-add-paths" rel="prev"/>
-  <?v3xml2rfc silence="The 'docName' attribute of the .rfc/. element should have a revision number" ?>
-  <?v3xml2rfc silence="The document date .*? is more than 3 days away from today's date" ?>
   <front>
     <title abbrev="ADD-PATH">Advertisement of Multiple Paths in BGP</title>
     <seriesInfo name="RFC" value="7911"/>

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             July 27, 2023
+Internet-Draft                                            August 2, 2023
 Intended status: Experimental                                           
-Expires: January 28, 2024
+Expires: February 3, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 28, 2024.
+   This Internet-Draft will expire on February 3, 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                  Expires January 28, 2024                [Page 1]
+Person                  Expires February 3, 2024                [Page 1]
 
-Internet-Draft          xml2rfc sourcecode tests               July 2023
+Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
    print("01")
@@ -109,9 +109,9 @@ Internet-Draft          xml2rfc sourcecode tests               July 2023
 
 
 
-Person                  Expires January 28, 2024                [Page 2]
+Person                  Expires February 3, 2024                [Page 2]
 
-Internet-Draft          xml2rfc sourcecode tests               July 2023
+Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
    print("49")
@@ -165,9 +165,9 @@ Internet-Draft          xml2rfc sourcecode tests               July 2023
 
 
 
-Person                  Expires January 28, 2024                [Page 3]
+Person                  Expires February 3, 2024                [Page 3]
 
-Internet-Draft          xml2rfc sourcecode tests               July 2023
+Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
    print("47")
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires January 28, 2024                [Page 4]
+Person                  Expires February 3, 2024                [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-07-27T20:05:16" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-08-02T00:11:54" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.17.5 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="27" month="07" year="2023"/>
+    <date day="02" month="08" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 28 January 2024.
+        This Internet-Draft will expire on 3 February 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             July 27, 2023
+Internet-Draft                                            August 2, 2023
 Intended status: Experimental                                           
-Expires: January 28, 2024
+Expires: February 3, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 28, 2024.
+   This Internet-Draft will expire on February 3, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc sourcecode tests</td>
-<td class="right">July 2023</td>
+<td class="right">August 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires January 28, 2024</td>
+<td class="center">Expires February 3, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-07-27" class="published">July 27, 2023</time>
+<time datetime="2023-08-02" class="published">August 2, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-01-28">January 28, 2024</time></dd>
+<dd class="expires"><time datetime="2024-02-03">February 3, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on January 28, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on February 3, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -720,10 +720,11 @@ def main():
             if not filename:
                 filename = basename + '.txt'
                 options.output_filename = filename
-            v2v3 = xml2rfc.V2v3XmlWriter(xmlrfc, options=options, date=options.date)
-            xmlrfc.tree = v2v3.convert2to3()
-            prep = xml2rfc.PrepToolWriter(xmlrfc, options=options, date=options.date, liberal=True, keep_pis=[xml2rfc.V3_PI_TARGET])
-            xmlrfc.tree = prep.prep()
+            if not xmlrfc.tree.getroot().get('prepTime'):
+                v2v3 = xml2rfc.V2v3XmlWriter(xmlrfc, options=options, date=options.date)
+                xmlrfc.tree = v2v3.convert2to3()
+                prep = xml2rfc.PrepToolWriter(xmlrfc, options=options, date=options.date, liberal=True, keep_pis=[xml2rfc.V3_PI_TARGET])
+                xmlrfc.tree = prep.prep()
             if xmlrfc.tree:
                 writer = xml2rfc.TextWriter(xmlrfc, options=options, date=options.date)
                 writer.write(filename)
@@ -735,10 +736,11 @@ def main():
             if not filename:
                 filename = basename + '.html'
                 options.output_filename = filename
-            v2v3 = xml2rfc.V2v3XmlWriter(xmlrfc, options=options, date=options.date)
-            xmlrfc.tree = v2v3.convert2to3()
-            prep = xml2rfc.PrepToolWriter(xmlrfc, options=options, date=options.date, liberal=True, keep_pis=[xml2rfc.V3_PI_TARGET])
-            xmlrfc.tree = prep.prep()
+            if not xmlrfc.tree.getroot().get('prepTime'):
+                v2v3 = xml2rfc.V2v3XmlWriter(xmlrfc, options=options, date=options.date)
+                xmlrfc.tree = v2v3.convert2to3()
+                prep = xml2rfc.PrepToolWriter(xmlrfc, options=options, date=options.date, liberal=True, keep_pis=[xml2rfc.V3_PI_TARGET])
+                xmlrfc.tree = prep.prep()
             if xmlrfc.tree:
                 writer = xml2rfc.HtmlWriter(xmlrfc, options=options, date=options.date)
                 writer.write(filename)
@@ -750,10 +752,11 @@ def main():
             if not filename:
                 filename = basename + '.pdf'
                 options.output_filename = filename
-            v2v3 = xml2rfc.V2v3XmlWriter(xmlrfc, options=options, date=options.date)
-            xmlrfc.tree = v2v3.convert2to3()
-            prep = xml2rfc.PrepToolWriter(xmlrfc, options=options, date=options.date, liberal=True, keep_pis=[xml2rfc.V3_PI_TARGET])
-            xmlrfc.tree = prep.prep()
+            if not xmlrfc.tree.getroot().get('prepTime'):
+                v2v3 = xml2rfc.V2v3XmlWriter(xmlrfc, options=options, date=options.date)
+                xmlrfc.tree = v2v3.convert2to3()
+                prep = xml2rfc.PrepToolWriter(xmlrfc, options=options, date=options.date, liberal=True, keep_pis=[xml2rfc.V3_PI_TARGET])
+                xmlrfc.tree = prep.prep()
             if xmlrfc.tree:
                 writer = xml2rfc.PdfWriter(xmlrfc, options=options, date=options.date)
                 writer.write(filename)


### PR DESCRIPTION
Fixes #1013

This fix prevents `xml2rfc` from running v2v3 conversion and preptool stages on prepped documents.
Prepped documents are identified by the `prepTime` attribute in the `rfc` element.
This fix gains a considerable performance gain.

#### xml2rfc 3.17.4 (without fix)
```
root@8bc787553164:~/xml2rfc# time xml2rfc --html --text --pdf rfc9427.xml
 Created file rfc9427.txt
 Created file rfc9427.html
 Created file rfc9427.pdf

real	2m16.207s
user	2m14.799s
sys	0m0.572s
root@8bc787553164:~/xml2rfc# time xml2rfc --html --text --pdf rfc9427.notprepped.xml
 Created file rfc9427.notprepped.txt
 Created file rfc9427.notprepped.html
 Created file rfc9427.notprepped.pdf

real	0m3.785s
user	0m2.611s
sys	0m0.337s
```
#### xml2rfc (with the fix)
```
root@8bc787553164:~/xml2rfc# time xml2rfc --html --text --pdf rfc9427.xml
 Created file rfc9427.txt
 Created file rfc9427.html
 Created file rfc9427.pdf

real	0m2.756s
user	0m1.730s
sys	0m0.208s
root@8bc787553164:~/xml2rfc# time xml2rfc --html --text --pdf rfc9427.notprepped.xml
 Created file rfc9427.notprepped.txt
 Created file rfc9427.notprepped.html
 Created file rfc9427.notprepped.pdf

real	0m3.529s
user	0m2.533s
sys	0m0.194s
root@8bc787553164:
```
