### PR TITLE
feat: Allow Unicode characters everywhere 

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.17.4</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.17.5</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.17.4" name="generator">
-<meta content="xml2rfc-docs-3.17.4" name="ietf.draft">
+<meta content="xml2rfc 3.17.5" name="generator">
+<meta content="xml2rfc-docs-3.17.5" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-07-26" class="published">26 July 2023</time>
+<time datetime="2023-07-27" class="published">27 July 2023</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
@@ -49,7 +49,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.17.4</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.17.5</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -371,7 +371,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://ietf-tools.github.io/xml2rfc/">https://ietf-tools.github.io/xml2rfc/</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.17.4.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.17.5.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6366,7 +6366,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.17.4:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.17.5:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.17.4" name="generator">
+<meta content="xml2rfc 3.17.5" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -26,7 +26,7 @@
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.17.4
+  xml2rfc 3.17.5
     Python 3.10.6
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -11,11 +11,11 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.17.4" name="generator">
+<meta content="xml2rfc 3.17.5" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.17.4
+  xml2rfc 3.17.5
     Python 3.10.6
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/elements.bom.text
+++ b/tests/valid/elements.bom.text
@@ -1301,8 +1301,8 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
    2.   Item 2
 
-   *    Indent="5".  "The heaviest penalty for declining to rule is to
-        be ruled by someone inferior to yourself." Πολιτεία
+   *    Indent="5".  “The heaviest penalty for declining to rule is to
+        be ruled by someone inferior to yourself.” Πολιτεία
 
                      Ich weiß nicht, was soll es bedeuten,
                      Daß ich so traurig bin;
@@ -1423,7 +1423,7 @@ Other References
    [GEDICHTE] Heine, H., "Dreiunddreißig Gedichte", 1824.
 
    [NO-DATE]  Mae, N., "Document — with no date", Advances in Cryptology
-              - AACC Edition pp. 235-265.
+              – AACC Edition pp. 235-265.
 
    [REPUBLIC] Πλάτων (Plato), "Πολιτεία", 375 BC.
 

--- a/tests/valid/elements.pages.text
+++ b/tests/valid/elements.pages.text
@@ -1301,8 +1301,8 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
    2.   Item 2
 
-   *    Indent="5".  "The heaviest penalty for declining to rule is to
-        be ruled by someone inferior to yourself." Πολιτεία
+   *    Indent="5".  “The heaviest penalty for declining to rule is to
+        be ruled by someone inferior to yourself.” Πολιτεία
 
                      Ich weiß nicht, was soll es bedeuten,
                      Daß ich so traurig bin;
@@ -1423,7 +1423,7 @@ Other References
    [GEDICHTE] Heine, H., "Dreiunddreißig Gedichte", 1824.
 
    [NO-DATE]  Mae, N., "Document — with no date", Advances in Cryptology
-              - AACC Edition pp. 235-265.
+              – AACC Edition pp. 235-265.
 
    [REPUBLIC] Πλάτων (Plato), "Πολιτεία", 375 BC.
 

--- a/tests/valid/elements.prepped.xml
+++ b/tests/valid/elements.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" submissionType="independent" ipr="trust200902" docName="elements-00" category="info" obsoletes="1234,5678,9012,3456,7890" sortRefs="true" indexInclude="false" prepTime="2023-07-26T21:45:51" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" submissionType="independent" ipr="trust200902" docName="elements-00" category="info" obsoletes="1234,5678,9012,3456,7890" sortRefs="true" indexInclude="false" prepTime="2023-07-27T20:11:18" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   
    
    
@@ -1546,7 +1546,7 @@ for opt, value in opts:
       </ol>
       <ul indent="5" bare="false" empty="false" spacing="normal" pn="section-17-4">
         <li pn="section-17-4.1"> Indent="5".  
-               "The heaviest penalty for declining to rule is to be ruled by someone inferior to yourself." 
+               “The heaviest penalty for declining to rule is to be ruled by someone inferior to yourself.” 
                <xref target="REPUBLIC" format="title" sectionFormat="of" derivedContent="Πολιτεία"/>
         </li>
         <li pn="section-17-4.2">
@@ -1823,7 +1823,7 @@ for opt, value in opts:
               <author fullname="No Mae"/>
               <date/>
             </front>
-            <seriesInfo name="Advances in Cryptology - AACC Edition" value="pp. 235-265"/>
+            <seriesInfo name="Advances in Cryptology – AACC Edition" value="pp. 235-265"/>
           </reference>
           <reference anchor="REPUBLIC" quoteTitle="true" derivedAnchor="REPUBLIC">
             <front>

--- a/tests/valid/elements.text
+++ b/tests/valid/elements.text
@@ -1089,8 +1089,8 @@ Unnumbered section
 
    2.   Item 2
 
-   *    Indent="5".  "The heaviest penalty for declining to rule is to
-        be ruled by someone inferior to yourself." Πολιτεία
+   *    Indent="5".  “The heaviest penalty for declining to rule is to
+        be ruled by someone inferior to yourself.” Πολιτεία
 
                      Ich weiß nicht, was soll es bedeuten,
                      Daß ich so traurig bin;
@@ -1195,7 +1195,7 @@ Other References
    [GEDICHTE] Heine, H., "Dreiunddreißig Gedichte", 1824.
 
    [NO-DATE]  Mae, N., "Document — with no date", Advances in Cryptology
-              - AACC Edition pp. 235-265.
+              – AACC Edition pp. 235-265.
 
    [REPUBLIC] Πλάτων (Plato), "Πολιτεία", 375 BC.
 

--- a/tests/valid/elements.v3.html
+++ b/tests/valid/elements.v3.html
@@ -15,7 +15,7 @@
 <meta content="
        This is the abstract. 
     " name="description">
-<meta content="xml2rfc 3.15.3" name="generator">
+<meta content="xml2rfc 3.17.5" name="generator">
 <meta content="elements-00" name="ietf.draft">
 <link href="tests/input/elements.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -1726,7 +1726,7 @@ for opt, value in opts:
       </ol>
 <ul class="normal">
 <li style="margin-left: 0.5em;" class="normal" id="section-17-4.1"> Indent="5".  
-               "The heaviest penalty for declining to rule is to be ruled by someone inferior to yourself." 
+               “The heaviest penalty for declining to rule is to be ruled by someone inferior to yourself.” 
                <a href="#REPUBLIC" class="internal xref">Πολιτεία</a><a href="#section-17-4.1" class="pilcrow">¶</a>
 </li>
         <li style="margin-left: 0.5em;" class="normal" id="section-17-4.2">
@@ -1778,7 +1778,7 @@ for opt, value in opts:
 <dl class="references">
 <dt id="I-D.levkowetz-xml2rfc-v3-implementation-notes">[I-D.levkowetz-xml2rfc-v3-implementation-notes]</dt>
           <dd>
-<span class="refAuthor">Levkowetz, H.</span>, <span class="refTitle">"Implementation notes for RFC7991,"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-levkowetz-xml2rfc-v3-implementation-notes-13</span>, <time datetime="2021-09-16" class="refDate">September 16, 2021</time>, <span>&lt;<a href="https://www.ietf.org/archive/id/draft-levkowetz-xml2rfc-v3-implementation-notes-13.txt">https://www.ietf.org/archive/id/draft-levkowetz-xml2rfc-v3-implementation-notes-13.txt</a>&gt;</span>. </dd>
+<span class="refAuthor">Levkowetz, H.</span>, <span class="refTitle">"Implementation notes for RFC7991,"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-levkowetz-xml2rfc-v3-implementation-notes-13</span>, <time datetime="2021-09-16" class="refDate">September 16, 2021</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-levkowetz-xml2rfc-v3-implementation-notes-13">https://datatracker.ietf.org/doc/html/draft-levkowetz-xml2rfc-v3-implementation-notes-13</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC5083">[RFC5083]</dt>
           <dd>
@@ -1864,7 +1864,7 @@ for opt, value in opts:
 <dd class="break"></dd>
 <dt id="NO-DATE">[NO-DATE]</dt>
           <dd>
-<span class="refAuthor">Mae, N.</span>, <span class="refTitle">"Document — with no date"</span>, <span class="seriesInfo">Advances in Cryptology - AACC Edition pp. 235-265</span>. </dd>
+<span class="refAuthor">Mae, N.</span>, <span class="refTitle">"Document — with no date"</span>, <span class="seriesInfo">Advances in Cryptology – AACC Edition pp. 235-265</span>. </dd>
 <dd class="break"></dd>
 <dt id="REPUBLIC">[REPUBLIC]</dt>
           <dd>

--- a/tests/valid/elements.wip.text
+++ b/tests/valid/elements.wip.text
@@ -1301,8 +1301,8 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
    2.   Item 2
 
-   *    Indent="5".  "The heaviest penalty for declining to rule is to
-        be ruled by someone inferior to yourself." Πολιτεία
+   *    Indent="5".  “The heaviest penalty for declining to rule is to
+        be ruled by someone inferior to yourself.” Πολιτεία
 
                      Ich weiß nicht, was soll es bedeuten,
                      Daß ich so traurig bin;
@@ -1423,7 +1423,7 @@ Other References
    [GEDICHTE] Heine, H., "Dreiunddreißig Gedichte", 1824.
 
    [NO-DATE]  Mae, N., "Document — with no date", Advances in Cryptology
-              - AACC Edition pp. 235-265.
+              – AACC Edition pp. 235-265.
 
    [REPUBLIC] Πλάτων (Plato), "Πολιτεία", 375 BC.
 

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             July 26, 2023
+Internet-Draft                                             July 27, 2023
 Intended status: Experimental                                           
-Expires: January 27, 2024
+Expires: January 28, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 27, 2024.
+   This Internet-Draft will expire on January 28, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires January 27, 2024                [Page 1]
+Person                  Expires January 28, 2024                [Page 1]
 
 Internet-Draft             xml2rfc index tests                 July 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires January 27, 2024                [Page 2]
+Person                  Expires January 28, 2024                [Page 2]
 
 Internet-Draft             xml2rfc index tests                 July 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires January 27, 2024                [Page 3]
+Person                  Expires January 28, 2024                [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-07-26T21:45:56" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.17.4 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-07-27T20:05:08" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.17.5 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="26" month="07" year="2023"/>
+    <date day="27" month="07" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 27 January 2024.
+        This Internet-Draft will expire on 28 January 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             July 26, 2023
+Internet-Draft                                             July 27, 2023
 Intended status: Experimental                                           
-Expires: January 27, 2024
+Expires: January 28, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 27, 2024.
+   This Internet-Draft will expire on January 28, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.17.4" name="generator">
+<meta content="xml2rfc 3.17.5" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires January 27, 2024</td>
+<td class="center">Expires January 28, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-07-26" class="published">July 26, 2023</time>
+<time datetime="2023-07-27" class="published">July 27, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-01-27">January 27, 2024</time></dd>
+<dd class="expires"><time datetime="2024-01-28">January 28, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on January 27, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on January 28, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                            26 July 2023
+                                                            27 July 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.17.4
-                          xml2rfc-docs-3.17.4
+                         xml2rfc release 3.17.5
+                          xml2rfc-docs-3.17.5
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://ietf-tools.github.io/xml2rfc/.
 
-   This documentation applies to xml2rfc version 3.17.4.
+   This documentation applies to xml2rfc version 3.17.5.
 
 2.  Schema Version 3 Elements
 
@@ -4319,7 +4319,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.17.4:
+   Jinja2 template, as of xml2rfc version 3.17.5:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -16,10 +16,10 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.17.4" name="generator">
+<meta content="xml2rfc 3.17.5" name="generator">
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.17.4
+  xml2rfc 3.17.5
     Python 3.10.6
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             July 26, 2023
+Internet-Draft                                             July 27, 2023
 Intended status: Experimental                                           
-Expires: January 27, 2024
+Expires: January 28, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 27, 2024.
+   This Internet-Draft will expire on January 28, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires January 27, 2024                [Page 1]
+Person                  Expires January 28, 2024                [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests               July 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests               July 2023
 
 
 
-Person                  Expires January 27, 2024                [Page 2]
+Person                  Expires January 28, 2024                [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests               July 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests               July 2023
 
 
 
-Person                  Expires January 27, 2024                [Page 3]
+Person                  Expires January 28, 2024                [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests               July 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires January 27, 2024                [Page 4]
+Person                  Expires January 28, 2024                [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-07-26T21:46:04" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.17.4 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-07-27T20:05:16" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.17.5 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="26" month="07" year="2023"/>
+    <date day="27" month="07" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 27 January 2024.
+        This Internet-Draft will expire on 28 January 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                             July 26, 2023
+Internet-Draft                                             July 27, 2023
 Intended status: Experimental                                           
-Expires: January 27, 2024
+Expires: January 28, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 27, 2024.
+   This Internet-Draft will expire on January 28, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.17.4" name="generator">
+<meta content="xml2rfc 3.17.5" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires January 27, 2024</td>
+<td class="center">Expires January 28, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-07-26" class="published">July 26, 2023</time>
+<time datetime="2023-07-27" class="published">July 27, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-01-27">January 27, 2024</time></dd>
+<dd class="expires"><time datetime="2024-01-28">January 28, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on January 27, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on January 28, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/util/unicode.py
+++ b/xml2rfc/util/unicode.py
@@ -35,7 +35,6 @@ unicode_content_tags = set([
     'street',
     'title',
     'u',
-    't',
 ])
 
 # Attribute values should not contain unicode, with some exceptions
@@ -84,10 +83,6 @@ bare_latin_tags = set([
     'street',
     'title',
     ])
-
-bare_unicode_tags_with_notice = set([
-    't',
-])
 
 def is_svg(e):
     '''

--- a/xml2rfc/writers/preptool.py
+++ b/xml2rfc/writers/preptool.py
@@ -41,9 +41,8 @@ from xml2rfc.util.date import get_expiry_date, format_date, normalize_month
 from xml2rfc.util.name import full_author_name_expansion
 from xml2rfc.util.num import ol_style_formatter
 from xml2rfc.util.unicode import (
-        unicode_content_tags, unicode_attributes, bare_unicode_tags,
-        bare_unicode_tags_with_notice, expand_unicode_element, isascii,
-        downcode, latinscript_attributes, is_svg)
+        unicode_content_tags, unicode_attributes, expand_unicode_element,
+        isascii, latinscript_attributes, is_svg)
 from xml2rfc.utils import build_dataurl, namespaces, sdict, clean_text
 from xml2rfc.writers.base import default_options, BaseV3Writer, RfcWriterError
 
@@ -503,33 +502,13 @@ class PrepToolWriter(BaseV3Writer):
         #
 
     def check_ascii_text(self, e, p):
-        self.downcode_punctuation()
         for c in self.root.iter():
             if is_svg(c):
                 continue
-            p = c.getparent()
-            if c.text and not isascii(c.text):
+            if c.text and not isascii(c.text) and c.tag not in unicode_content_tags:
                 show = c.text.encode('ascii', errors='replace')
-                if c.tag in unicode_content_tags:
-                    if c.tag in bare_unicode_tags_with_notice:
-                        if self.options.warn_bare_unicode:
-                            self.warn(c, 'Found non-ascii characters in an element that should be inspected to ensure they are intentional, in <%s>: %s' % (c.tag, show))
-                    elif not c.get('ascii') and not c.tag in bare_unicode_tags and not is_script(c.text, 'Latin'):
-                        self.err(c, 'Found non-ascii content without matching ascii attribute in <%s>: %s' % (c.tag, show))
-                else:
-                    self.err(c, 'Found non-ascii characters outside of elements that can have non-ascii content, in <%s>: %s' % (c.tag, show))
-                    c.text = downcode(c.text)
-            if c.tail and not isascii(c.tail):
-                show = c.tail.encode('ascii', errors='replace')
-                if p.tag in unicode_content_tags:
-                    if p.tag in bare_unicode_tags_with_notice:
-                        if self.options.warn_bare_unicode:
-                            self.warn(p, 'Found non-ascii characters in an element that should be inspected to ensure they are intentional, in <%s>: %s' % (p.tag, show))
-                    elif not p.get('ascii') and not p.tag in bare_unicode_tags:
-                        self.err(p, 'Found non-unicode content without matching ascii attribute in <%s>: %s' % (p.tag, show))
-                else:
-                    self.err(p, 'Found non-ascii characters outside of elements that can have non-ascii content, in <%s>: %s' % (p.tag, show))
-                    c.tail = downcode(c.tail)
+                if self.options.warn_bare_unicode:
+                    self.warn(c, 'Found non-ascii characters in an element that should be inspected to ensure they are intentional, in <%s>: %s' % (c.tag, show))
 
     def normalize_text_items(self, e, p):
         """

--- a/xml2rfc/writers/v2v3.py
+++ b/xml2rfc/writers/v2v3.py
@@ -13,7 +13,6 @@ from lxml.etree import Element, Comment, CDATA
 
 import xml2rfc
 from xml2rfc import log
-from xml2rfc.util.unicode import unicode_content_tags, unicode_replacements, isascii, is_svg
 from xml2rfc.utils import hastext, isempty, sdict, slugify, iscomment
 from xml2rfc.writers.base import default_options, BaseV3Writer
 
@@ -316,7 +315,6 @@ class V2v3XmlWriter(BaseV3Writer):
             './/*[self::artwork or self::dl or self::figure or self::ol or self::sourcecode or self::t or self::ul]',
             '//*[@*="yes" or @*="no"]',      # convert old attribute false/true
             '.;pretty_print_prep()',
-            '.;wrap_non_ascii()',
         ]
 
         # Remove any DOCTYPE declaration
@@ -1148,55 +1146,3 @@ class V2v3XmlWriter(BaseV3Writer):
 #             if c.tail != None:
 #                 if c.tail.strip() == '':
 #                     c.tail = None
-
-    def wrap_non_ascii(self, e, p):
-        self.downcode(replacements=unicode_replacements)
-        self.downcode_punctuation()
-        for e in self.tree.iter():
-            if is_svg(e):
-                continue
-            def uwrap(text, line): 
-                words = []
-                elements = []
-                ascii = None
-                for word in re.split('(\s+)', text, flags=re.U):
-                    if isascii(word):
-                        words.append(word)
-                    else:
-                        u = self.element('u', line=line)
-                        u.text = word
-                        if ascii is None:
-                            ascii = ''.join(words)
-                            words = []
-                            elements.append(u)
-                        else:
-                            elements[-1].tail = ''.join(words)
-                            words = []
-                            elements.append(u)
-                if words:
-                    if ascii is None:
-                        ascii = ''.join(words)
-                    else:
-                        elements[-1].tail = ''.join(words)
-                return ascii, elements
-            if e.text and e.tag not in unicode_content_tags:
-                    try:
-                        e.text.encode('ascii')
-                    except UnicodeEncodeError:
-                        e.text, elements = uwrap(e.text, e.sourceline)
-                        if len(e):
-                            c = e[0]
-                            for u in elements:
-                                c.addprevious(u)
-                        else:
-                            for u in elements:
-                                e.append(u)
-            if e.tail and e.getparent().tag not in unicode_content_tags:
-                    try:
-                        e.tail.encode('ascii')
-                    except UnicodeEncodeError:
-                        e.tail, elements = uwrap(e.tail, e.sourceline)
-                        for u in elements:
-                            e.addnext(u)
-                            e = u
-                                


### PR DESCRIPTION
This PR that does the following:
* Remove guards for non-ASCII & non-Latin characters.
* Removes automatic downcoding of non-ASCII characters.
* Allows Unicode characters in all elements.
* With the `--warn-bare-unicode` command line option, `xml2rfc` will warn if Unicode characters are present in any element that traditionally Unicode content is not allowed.

Traditionally, Unicode content is allowed in the following elements: `artwork`, `city`, `city`, `cityarea`, `cityarea`, `code`, `code`, `country`, `country`, `email`, `email`, `extaddr`, `extaddr`, `organization`, `organization`, `p`.
With #895 bare use of Unicode characters is added to the `t` element. But it's implemented in such a way that `--warn-bare-unicode` warns about it. This PR will keep that warning.

Fixes #960.
 