### PR TITLE
fix: Break word when line overflows

### DIFF
--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -87,6 +87,7 @@ body {
   font-family: var(--font-sans);
   line-height: 1.6;
   scroll-behavior: smooth;
+  overflow-wrap: break-word;
 }
 .ears {
   display: none;
@@ -655,7 +656,6 @@ hr.addr {
 /* pagination */
 @media print {
   body {
-
     width: 100%;
   }
   p {

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -76,6 +76,7 @@ body {
   font-family: var(--font-sans);
   line-height: 1.6;
   scroll-behavior: smooth;
+  overflow-wrap: break-word;
 }
 .ears {
   display: none;
@@ -644,7 +645,6 @@ hr.addr {
 /* pagination */
 @media print {
   body {
-
     width: 100%;
   }
   p {

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 2, 2023
+Internet-Draft                                            August 3, 2023
 Intended status: Experimental                                           
-Expires: February 3, 2024
+Expires: February 4, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 3, 2024.
+   This Internet-Draft will expire on February 4, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires February 3, 2024                [Page 1]
+Person                  Expires February 4, 2024                [Page 1]
 
 Internet-Draft             xml2rfc index tests               August 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires February 3, 2024                [Page 2]
+Person                  Expires February 4, 2024                [Page 2]
 
 Internet-Draft             xml2rfc index tests               August 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires February 3, 2024                [Page 3]
+Person                  Expires February 4, 2024                [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-08-02T00:11:46" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-08-03T23:01:04" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.17.5 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="02" month="08" year="2023"/>
+    <date day="03" month="08" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 3 February 2024.
+        This Internet-Draft will expire on 4 February 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 2, 2023
+Internet-Draft                                            August 3, 2023
 Intended status: Experimental                                           
-Expires: February 3, 2024
+Expires: February 4, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 3, 2024.
+   This Internet-Draft will expire on February 4, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires February 3, 2024</td>
+<td class="center">Expires February 4, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-02" class="published">August 2, 2023</time>
+<time datetime="2023-08-03" class="published">August 3, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-02-03">February 3, 2024</time></dd>
+<dd class="expires"><time datetime="2024-02-04">February 4, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on February 3, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on February 4, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                           2 August 2023
+                                                           3 August 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -80,6 +80,7 @@ body {
   font-family: var(--font-sans);
   line-height: 1.6;
   scroll-behavior: smooth;
+  overflow-wrap: break-word;
 }
 .ears {
   display: none;
@@ -648,7 +649,6 @@ hr.addr {
 /* pagination */
 @media print {
   body {
-
     width: 100%;
   }
   p {

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 2, 2023
+Internet-Draft                                            August 3, 2023
 Intended status: Experimental                                           
-Expires: February 3, 2024
+Expires: February 4, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 3, 2024.
+   This Internet-Draft will expire on February 4, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires February 3, 2024                [Page 1]
+Person                  Expires February 4, 2024                [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
 
-Person                  Expires February 3, 2024                [Page 2]
+Person                  Expires February 4, 2024                [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
 
-Person                  Expires February 3, 2024                [Page 3]
+Person                  Expires February 4, 2024                [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires February 3, 2024                [Page 4]
+Person                  Expires February 4, 2024                [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-08-02T00:11:54" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-08-03T23:01:12" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.17.5 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="02" month="08" year="2023"/>
+    <date day="03" month="08" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 3 February 2024.
+        This Internet-Draft will expire on 4 February 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 2, 2023
+Internet-Draft                                            August 3, 2023
 Intended status: Experimental                                           
-Expires: February 3, 2024
+Expires: February 4, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 3, 2024.
+   This Internet-Draft will expire on February 4, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires February 3, 2024</td>
+<td class="center">Expires February 4, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-02" class="published">August 2, 2023</time>
+<time datetime="2023-08-03" class="published">August 3, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-02-03">February 3, 2024</time></dd>
+<dd class="expires"><time datetime="2024-02-04">February 4, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on February 3, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on February 4, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -41,6 +41,7 @@ body {
   font-family: var(--font-sans);
   line-height: 1.6;
   scroll-behavior: smooth;
+  overflow-wrap: break-word;
 }
 .ears {
   display: none;
@@ -609,7 +610,6 @@ hr.addr {
 /* pagination */
 @media print {
   body {
-
     width: 100%;
   }
   p {


### PR DESCRIPTION
When a word is too big to fit in a line in HTML and PDF outputs, break the word.

Fixes #687