### PR TITLE
fix(text): Preserve NBSP in dd

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.17.5</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.18.0</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.17.5" name="generator">
-<meta content="xml2rfc-docs-3.17.5" name="ietf.draft">
+<meta content="xml2rfc 3.18.0" name="generator">
+<meta content="xml2rfc-docs-3.18.0" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-02" class="published">2 August 2023</time>
+<time datetime="2023-08-21" class="published">21 August 2023</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
@@ -49,7 +49,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.17.5</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.18.0</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -371,7 +371,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://ietf-tools.github.io/xml2rfc/">https://ietf-tools.github.io/xml2rfc/</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.17.5.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.18.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6366,7 +6366,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.17.5:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.18.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.17.5" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -26,7 +26,7 @@
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.17.5
+  xml2rfc 3.18.0
     Python 3.10.6
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -11,11 +11,11 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.17.5" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.17.5
+  xml2rfc 3.18.0
     Python 3.10.6
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/draft-v3-features.text
+++ b/tests/valid/draft-v3-features.text
@@ -210,11 +210,13 @@ Table of Contents
 
    newline=default/spacing=default
 
-   Term1  Description1.  Description1.  Description1.  Description1.
+   Term1
+      Description1.  Description1.  Description1.  Description1.
       Description1.  Description1.  Description1.  Description1.
       Description1.  Description1.  Description1.  Description1.
 
-   Term2  Description2.  Description2.  Description2.  Description2.
+   Term2
+      Description2.  Description2.  Description2.  Description2.
       Description2.  Description2.  Description2.  Description2.
       Description2.  Description2.  Description2.  Description2.
 
@@ -232,29 +234,35 @@ Table of Contents
 
    newline=false/spacing=default
 
-   Term1  Description1.  Description1.  Description1.  Description1.
+   Term1
+      Description1.  Description1.  Description1.  Description1.
       Description1.  Description1.  Description1.  Description1.
       Description1.  Description1.  Description1.  Description1.
 
-   Term2  Description2.  Description2.  Description2.  Description2.
+   Term2
+      Description2.  Description2.  Description2.  Description2.
       Description2.  Description2.  Description2.  Description2.
       Description2.  Description2.  Description2.  Description2.
 
    newline=default/spacing=compact
 
-   Term1  Description1.  Description1.  Description1.  Description1.
+   Term1
       Description1.  Description1.  Description1.  Description1.
       Description1.  Description1.  Description1.  Description1.
-   Term2  Description2.  Description2.  Description2.  Description2.
+      Description1.  Description1.  Description1.  Description1.
+   Term2
+      Description2.  Description2.  Description2.  Description2.
       Description2.  Description2.  Description2.  Description2.
       Description2.  Description2.  Description2.  Description2.
 
    newline=false/spacing=compact
 
-   Term1  Description1.  Description1.  Description1.  Description1.
+   Term1
       Description1.  Description1.  Description1.  Description1.
       Description1.  Description1.  Description1.  Description1.
-   Term2  Description2.  Description2.  Description2.  Description2.
+      Description1.  Description1.  Description1.  Description1.
+   Term2
+      Description2.  Description2.  Description2.  Description2.
       Description2.  Description2.  Description2.  Description2.
       Description2.  Description2.  Description2.  Description2.
 

--- a/tests/valid/elements.bom.text
+++ b/tests/valid/elements.bom.text
@@ -461,13 +461,14 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
    Term 1  Definition list, first bullet.
 
-   Term 2  Definition list, second bullet.  Text only.  Octavio fuit,
-      cum illam severitatem in eo non arbitrantur. erunt etiam, et ii
-      quidem eruditi Graecis litteris, contemnentes Latinas, qui se
-      plane Graecum dici velit, ut a Scaevola est praetore salutatus
-      Athenis Albucius.  In physicis plurimum posuit. ea scientia et
-      verborum vis et natura orationis et consequentium repugnantiumve
-      ratio potest perspici.
+   Term 2
+      Definition list, second bullet.  Text only.  Octavio fuit, cum
+      illam severitatem in eo non arbitrantur. erunt etiam, et ii quidem
+      eruditi Graecis litteris, contemnentes Latinas, qui se plane
+      Graecum dici velit, ut a Scaevola est praetore salutatus Athenis
+      Albucius.  In physicis plurimum posuit. ea scientia et verborum
+      vis et natura orationis et consequentium repugnantiumve ratio
+      potest perspici.
 
    Term 3  Definition list, third bullet, element t.  Quid? si nos non
       interpretum fungimur munere, sed tuemur ea, quae audiebamus,
@@ -497,7 +498,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
       1.  Definition list, third bullet, fifth element: Ordered list,
           element li.  Text only.
-
 
 
 

--- a/tests/valid/elements.pages.text
+++ b/tests/valid/elements.pages.text
@@ -461,13 +461,14 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
    Term 1  Definition list, first bullet.
 
-   Term 2  Definition list, second bullet.  Text only.  Octavio fuit,
-      cum illam severitatem in eo non arbitrantur. erunt etiam, et ii
-      quidem eruditi Graecis litteris, contemnentes Latinas, qui se
-      plane Graecum dici velit, ut a Scaevola est praetore salutatus
-      Athenis Albucius.  In physicis plurimum posuit. ea scientia et
-      verborum vis et natura orationis et consequentium repugnantiumve
-      ratio potest perspici.
+   Term 2
+      Definition list, second bullet.  Text only.  Octavio fuit, cum
+      illam severitatem in eo non arbitrantur. erunt etiam, et ii quidem
+      eruditi Graecis litteris, contemnentes Latinas, qui se plane
+      Graecum dici velit, ut a Scaevola est praetore salutatus Athenis
+      Albucius.  In physicis plurimum posuit. ea scientia et verborum
+      vis et natura orationis et consequentium repugnantiumve ratio
+      potest perspici.
 
    Term 3  Definition list, third bullet, element t.  Quid? si nos non
       interpretum fungimur munere, sed tuemur ea, quae audiebamus,
@@ -497,7 +498,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
       1.  Definition list, third bullet, fifth element: Ordered list,
           element li.  Text only.
-
 
 
 

--- a/tests/valid/elements.text
+++ b/tests/valid/elements.text
@@ -388,13 +388,14 @@ Table of Contents
 
    Term 1  Definition list, first bullet.
 
-   Term 2  Definition list, second bullet.  Text only.  Octavio fuit,
-      cum illam severitatem in eo non arbitrantur. erunt etiam, et ii
-      quidem eruditi Graecis litteris, contemnentes Latinas, qui se
-      plane Graecum dici velit, ut a Scaevola est praetore salutatus
-      Athenis Albucius.  In physicis plurimum posuit. ea scientia et
-      verborum vis et natura orationis et consequentium repugnantiumve
-      ratio potest perspici.
+   Term 2
+      Definition list, second bullet.  Text only.  Octavio fuit, cum
+      illam severitatem in eo non arbitrantur. erunt etiam, et ii quidem
+      eruditi Graecis litteris, contemnentes Latinas, qui se plane
+      Graecum dici velit, ut a Scaevola est praetore salutatus Athenis
+      Albucius.  In physicis plurimum posuit. ea scientia et verborum
+      vis et natura orationis et consequentium repugnantiumve ratio
+      potest perspici.
 
    Term 3  Definition list, third bullet, element t.  Quid? si nos non
       interpretum fungimur munere, sed tuemur ea, quae audiebamus,

--- a/tests/valid/elements.wip.text
+++ b/tests/valid/elements.wip.text
@@ -461,13 +461,14 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
    Term 1  Definition list, first bullet.
 
-   Term 2  Definition list, second bullet.  Text only.  Octavio fuit,
-      cum illam severitatem in eo non arbitrantur. erunt etiam, et ii
-      quidem eruditi Graecis litteris, contemnentes Latinas, qui se
-      plane Graecum dici velit, ut a Scaevola est praetore salutatus
-      Athenis Albucius.  In physicis plurimum posuit. ea scientia et
-      verborum vis et natura orationis et consequentium repugnantiumve
-      ratio potest perspici.
+   Term 2
+      Definition list, second bullet.  Text only.  Octavio fuit, cum
+      illam severitatem in eo non arbitrantur. erunt etiam, et ii quidem
+      eruditi Graecis litteris, contemnentes Latinas, qui se plane
+      Graecum dici velit, ut a Scaevola est praetore salutatus Athenis
+      Albucius.  In physicis plurimum posuit. ea scientia et verborum
+      vis et natura orationis et consequentium repugnantiumve ratio
+      potest perspici.
 
    Term 3  Definition list, third bullet, element t.  Quid? si nos non
       interpretum fungimur munere, sed tuemur ea, quae audiebamus,
@@ -497,7 +498,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
       1.  Definition list, third bullet, fifth element: Ordered list,
           element li.  Text only.
-
 
 
 

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 3, 2023
+Internet-Draft                                           August 21, 2023
 Intended status: Experimental                                           
-Expires: February 4, 2024
+Expires: February 22, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 4, 2024.
+   This Internet-Draft will expire on February 22, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires February 4, 2024                [Page 1]
+Person                  Expires February 22, 2024               [Page 1]
 
 Internet-Draft             xml2rfc index tests               August 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires February 4, 2024                [Page 2]
+Person                  Expires February 22, 2024               [Page 2]
 
 Internet-Draft             xml2rfc index tests               August 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires February 4, 2024                [Page 3]
+Person                  Expires February 22, 2024               [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-08-03T23:01:04" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.17.5 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-08-21T04:28:58" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="03" month="08" year="2023"/>
+    <date day="21" month="08" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 4 February 2024.
+        This Internet-Draft will expire on 22 February 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 3, 2023
+Internet-Draft                                           August 21, 2023
 Intended status: Experimental                                           
-Expires: February 4, 2024
+Expires: February 22, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 4, 2024.
+   This Internet-Draft will expire on February 22, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.17.5" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires February 4, 2024</td>
+<td class="center">Expires February 22, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-03" class="published">August 3, 2023</time>
+<time datetime="2023-08-21" class="published">August 21, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-02-04">February 4, 2024</time></dd>
+<dd class="expires"><time datetime="2024-02-22">February 22, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on February 4, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on February 22, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                           3 August 2023
+                                                          21 August 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.17.5
-                          xml2rfc-docs-3.17.5
+                         xml2rfc release 3.18.0
+                          xml2rfc-docs-3.18.0
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://ietf-tools.github.io/xml2rfc/.
 
-   This documentation applies to xml2rfc version 3.17.5.
+   This documentation applies to xml2rfc version 3.18.0.
 
 2.  Schema Version 3 Elements
 
@@ -4319,7 +4319,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.17.5:
+   Jinja2 template, as of xml2rfc version 3.18.0:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -16,10 +16,10 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.17.5" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.17.5
+  xml2rfc 3.18.0
     Python 3.10.6
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 3, 2023
+Internet-Draft                                           August 21, 2023
 Intended status: Experimental                                           
-Expires: February 4, 2024
+Expires: February 22, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 4, 2024.
+   This Internet-Draft will expire on February 22, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires February 4, 2024                [Page 1]
+Person                  Expires February 22, 2024               [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
 
-Person                  Expires February 4, 2024                [Page 2]
+Person                  Expires February 22, 2024               [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
 
-Person                  Expires February 4, 2024                [Page 3]
+Person                  Expires February 22, 2024               [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests             August 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                  Expires February 4, 2024                [Page 4]
+Person                  Expires February 22, 2024               [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-08-03T23:01:12" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.17.5 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-08-21T04:29:06" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="03" month="08" year="2023"/>
+    <date day="21" month="08" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 4 February 2024.
+        This Internet-Draft will expire on 22 February 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            August 3, 2023
+Internet-Draft                                           August 21, 2023
 Intended status: Experimental                                           
-Expires: February 4, 2024
+Expires: February 22, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 4, 2024.
+   This Internet-Draft will expire on February 22, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.17.5" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires February 4, 2024</td>
+<td class="center">Expires February 22, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-03" class="published">August 3, 2023</time>
+<time datetime="2023-08-21" class="published">August 21, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-02-04">February 4, 2024</time></dd>
+<dd class="expires"><time datetime="2024-02-22">February 22, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on February 4, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on February 22, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/writers/text.py
+++ b/xml2rfc/writers/text.py
@@ -1511,7 +1511,7 @@ class TextWriter(BaseV3Writer):
         dtwidth = indent
         for c in e.getchildren():
             if ((not newline and c.tag == 'dd' and c.text and c.text.strip(stripspace)
-                 and (width - len('  ') - len(text)) < len(c.text.split(None, 1)[0]))
+                 and (width - len('  ') - len(text)) < len(c.text.split(stripspace, 1)[0]))
                 or (len(c) and c[0].tag in newline_tags)):
                 # Add a newline if first word of dd text won't fit to the right of dt
                 kwargs['joiners']['dd'] = nljoin


### PR DESCRIPTION
This change preserves `&nbsp;` in `dd` elements in the text output.

Fixes #1022