### PR TITLE
fix: Remove emphasis from xref in headings and fix xrefs in headings 

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">November 2023</td>
+<td class="right">December 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-11-16" class="published">16 November 2023</time>
+<time datetime="2023-12-17" class="published">17 December 2023</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -33,14 +33,14 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.10.0
-    pycountry 22.3.5
+    platformdirs 4.1.0
+    pycountry 23.12.11
     PyYAML 6.0.1
     requests 2.31.0
-    setuptools 68.2.0
+    setuptools 68.2.2
     six 1.16.0
-    wcwidth 0.2.8
-    weasyprint 60.1
+    wcwidth 0.2.12
+    weasyprint 60.2
 -->
 <link href="tests/input/draft-miek-test.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -266,8 +266,7 @@ a[href]:hover {
   background-color: #f2f2f2;
 }
 figcaption a[href],
-a[href].selfRef,
-.iref + a[href].internal {
+a[href].selfRef {
   color: #222;
 }
 /* XXX probably not this:

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -22,14 +22,14 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.10.0
-    pycountry 22.3.5
+    platformdirs 4.1.0
+    pycountry 23.12.11
     PyYAML 6.0.1
     requests 2.31.0
-    setuptools 68.2.0
+    setuptools 68.2.2
     six 1.16.0
-    wcwidth 0.2.8
-    weasyprint 60.1
+    wcwidth 0.2.12
+    weasyprint 60.2
 -->
 <link href="tests/input/draft-template.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -255,8 +255,7 @@ a[href]:hover {
   background-color: #f2f2f2;
 }
 figcaption a[href],
-a[href].selfRef,
-.iref + a[href].internal {
+a[href].selfRef {
   color: #222;
 }
 /* XXX probably not this:

--- a/tests/valid/draft-v3-features.v3.html
+++ b/tests/valid/draft-v3-features.v3.html
@@ -13,7 +13,7 @@
         This document tests features introduced in xml2rfc v3 vocabulary.
        
     " name="description">
-<meta content="xml2rfc 3.15.3" name="generator">
+<meta content="xml2rfc 3.18.2" name="generator">
 <meta content="draft-v3-features" name="ietf.draft">
 <link href="tests/input/draft-v3-features.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -446,7 +446,7 @@
 <div id="titlexref">
 <section id="section-2.2">
         <h3 id="name-title-with-xref">
-<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-title-with-xref" class="section-name selfRef">Title with <code>xref</code>: <em class="cite xref">[Section 2.2]</em></a>
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-title-with-xref" class="section-name selfRef">Title with <code>xref</code>: <span class="cite xref">Section 2.2</span></a>
         </h3>
 <p id="section-2.2-1">
           Test.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
@@ -1003,7 +1003,7 @@ foo = bar
 </div>
 </div>
 <figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
-<a href="#name-references-of" class="selfRef">References of <em class="cite xref">[RFC7991]</em></a>
+<a href="#name-references-of" class="selfRef">References of <span class="cite xref">[RFC7991]</span></a>
           </figcaption></figure>
 <div id="node1">
 <p id="section-8.5-2">

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                         November 16, 2023
+Internet-Draft                                         December 17, 2023
 Intended status: Experimental                                           
-Expires: May 19, 2024
+Expires: June 19, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 19, 2024.
+   This Internet-Draft will expire on June 19, 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                    Expires May 19, 2024                  [Page 1]
+Person                    Expires June 19, 2024                 [Page 1]
 
-Internet-Draft             xml2rfc index tests             November 2023
+Internet-Draft             xml2rfc index tests             December 2023
 
 
    This is another section!
@@ -109,9 +109,9 @@ Index
 
 
 
-Person                    Expires May 19, 2024                  [Page 2]
+Person                    Expires June 19, 2024                 [Page 2]
 
-Internet-Draft             xml2rfc index tests             November 2023
+Internet-Draft             xml2rfc index tests             December 2023
 
 
       E
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                    Expires May 19, 2024                  [Page 3]
+Person                    Expires June 19, 2024                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-11-16T22:23:11" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-12-17T22:39:31" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.2 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="16" month="11" year="2023"/>
+    <date day="17" month="12" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 19 May 2024.
+        This Internet-Draft will expire on 19 June 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                         November 16, 2023
+Internet-Draft                                         December 17, 2023
 Intended status: Experimental                                           
-Expires: May 19, 2024
+Expires: June 19, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 19, 2024.
+   This Internet-Draft will expire on June 19, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">November 2023</td>
+<td class="right">December 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires May 19, 2024</td>
+<td class="center">Expires June 19, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-11-16" class="published">November 16, 2023</time>
+<time datetime="2023-12-17" class="published">December 17, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-05-19">May 19, 2024</time></dd>
+<dd class="expires"><time datetime="2024-06-19">June 19, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on May 19, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on June 19, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                        16 November 2023
+                                                        17 December 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -26,14 +26,14 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.10.0
-    pycountry 22.3.5
+    platformdirs 4.1.0
+    pycountry 23.12.11
     PyYAML 6.0.1
     requests 2.31.0
-    setuptools 68.2.0
+    setuptools 68.2.2
     six 1.16.0
-    wcwidth 0.2.8
-    weasyprint 60.1
+    wcwidth 0.2.12
+    weasyprint 60.2
 -->
 <link href="tests/input/rfc7911.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -259,8 +259,7 @@ a[href]:hover {
   background-color: #f2f2f2;
 }
 figcaption a[href],
-a[href].selfRef,
-.iref + a[href].internal {
+a[href].selfRef {
   color: #222;
 }
 /* XXX probably not this:

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                         November 16, 2023
+Internet-Draft                                         December 17, 2023
 Intended status: Experimental                                           
-Expires: May 19, 2024
+Expires: June 19, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 19, 2024.
+   This Internet-Draft will expire on June 19, 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                    Expires May 19, 2024                  [Page 1]
+Person                    Expires June 19, 2024                 [Page 1]
 
-Internet-Draft          xml2rfc sourcecode tests           November 2023
+Internet-Draft          xml2rfc sourcecode tests           December 2023
 
 
    print("01")
@@ -109,9 +109,9 @@ Internet-Draft          xml2rfc sourcecode tests           November 2023
 
 
 
-Person                    Expires May 19, 2024                  [Page 2]
+Person                    Expires June 19, 2024                 [Page 2]
 
-Internet-Draft          xml2rfc sourcecode tests           November 2023
+Internet-Draft          xml2rfc sourcecode tests           December 2023
 
 
    print("49")
@@ -165,9 +165,9 @@ Internet-Draft          xml2rfc sourcecode tests           November 2023
 
 
 
-Person                    Expires May 19, 2024                  [Page 3]
+Person                    Expires June 19, 2024                 [Page 3]
 
-Internet-Draft          xml2rfc sourcecode tests           November 2023
+Internet-Draft          xml2rfc sourcecode tests           December 2023
 
 
    print("47")
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                    Expires May 19, 2024                  [Page 4]
+Person                    Expires June 19, 2024                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-11-16T22:23:19" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-12-17T22:39:39" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.2 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="16" month="11" year="2023"/>
+    <date day="17" month="12" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 19 May 2024.
+        This Internet-Draft will expire on 19 June 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                         November 16, 2023
+Internet-Draft                                         December 17, 2023
 Intended status: Experimental                                           
-Expires: May 19, 2024
+Expires: June 19, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 19, 2024.
+   This Internet-Draft will expire on June 19, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc sourcecode tests</td>
-<td class="right">November 2023</td>
+<td class="right">December 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires May 19, 2024</td>
+<td class="center">Expires June 19, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-11-16" class="published">November 16, 2023</time>
+<time datetime="2023-12-17" class="published">December 17, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-05-19">May 19, 2024</time></dd>
+<dd class="expires"><time datetime="2024-06-19">June 19, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on May 19, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on June 19, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -2847,8 +2847,16 @@ class HtmlWriter(BaseV3Writer):
                 if format == 'none':
                     reftext = content
                     hh = build.span(reftext, classes='xref cite')
+                elif target in self.refname_mapping and format != 'title':
+                    if content:
+                        hh = build.span(content, ' ', '[', reftext, ']', classes='xref cite')
+                    else:
+                        hh = build.span('[', reftext, ']', classes='xref cite')
                 else:
-                    hh = build.span('[', reftext, ']', classes='xref cite')
+                    if content:
+                        hh = build.span(content, ' ', '(', reftext, ')', classes='xref cite')
+                    else:
+                        hh = build.span(reftext, classes='xref cite')
             else:
                 srefclass = 'xref internal'
                 if not content and format != 'title':

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -2844,7 +2844,11 @@ class HtmlWriter(BaseV3Writer):
                 target = id_for_pn(target)
             # plain xref
             if in_name:
-                hh = build.em('[', reftext, ']', classes='xref cite')
+                if format == 'none':
+                    reftext = content
+                    hh = build.span(reftext, classes='xref cite')
+                else:
+                    hh = build.span('[', reftext, ']', classes='xref cite')
             else:
                 srefclass = 'xref internal'
                 if not content and format != 'title':


### PR DESCRIPTION
* This change removes emphasis on xref content in headings.
* This change also adds `xref` content to `name` when the `format="none"` in the `xref` element.
* When `xref` is in `title`, if `xref` has a target to a `reference` use
square brackets (`[ <target text> ]`).
* If the `xref` target is not a reference don't use brackets or parenthesis.
* If the `xref` element has text content:
For `reference` targets:
    `<text content> [<target>]`
For other targets:
    `<text content> (<target>)`

Fixes #683