### PR TITLE
fix: Render child elements in the xref element

### DIFF
--- a/tests/input/elements.xml
+++ b/tests/input/elements.xml
@@ -181,7 +181,8 @@
             <li>
                Text and format="default": Sections
                <xref target="RFC7997" format="default" sectionFormat="bare" section="3.2">Person Names</xref> and 
-               <xref target="RFC7997" format="default" sectionFormat="bare" section="3.3">Company Names</xref> of
+               <xref target="RFC7997" format="default" sectionFormat="bare" section="3.3">Company Names</xref> and
+               <xref target="RFC7997" format="default" sectionFormat="bare" section="3.3">a <em>lot</em> <strong>more</strong> information</xref> of
                <xref target="RFC7997" format="default"/>.
 
             </li>

--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">August 2023</td>
+<td class="right">September 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-21" class="published">21 August 2023</time>
+<time datetime="2023-09-27" class="published">27 September 2023</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -33,7 +33,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.9.1
+    platformdirs 3.10.0
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -22,7 +22,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.9.1
+    platformdirs 3.10.0
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0

--- a/tests/valid/elements.bom.text
+++ b/tests/valid/elements.bom.text
@@ -160,7 +160,7 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    sectionFormat="bare":
 
    *  Text and format="default": Sections 3.2 (Person Names) and 3.3
-      (Company Names) of [RFC7997].
+      (Company Names) and 3.3 (a _lot_ *more* information) of [RFC7997].
 
 
 

--- a/tests/valid/elements.pages.text
+++ b/tests/valid/elements.pages.text
@@ -160,7 +160,7 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    sectionFormat="bare":
 
    *  Text and format="default": Sections 3.2 (Person Names) and 3.3
-      (Company Names) of [RFC7997].
+      (Company Names) and 3.3 (a _lot_ *more* information) of [RFC7997].
 
 
 

--- a/tests/valid/elements.prepped.xml
+++ b/tests/valid/elements.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" submissionType="independent" ipr="trust200902" docName="elements-00" category="info" obsoletes="1234,5678,9012,3456,7890" sortRefs="true" indexInclude="false" prepTime="2023-08-02T01:35:51" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" submissionType="independent" ipr="trust200902" docName="elements-00" category="info" obsoletes="1234,5678,9012,3456,7890" sortRefs="true" indexInclude="false" prepTime="2023-09-27T20:11:31" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   
    
    
@@ -333,7 +333,8 @@
         <li pn="section-2-9.1">
                Text and format="default": Sections
                <xref target="RFC7997" format="default" sectionFormat="bare" section="3.2" derivedLink="https://rfc-editor.org/rfc/rfc7997#section-3.2" derivedContent="RFC7997">Person Names</xref> and 
-               <xref target="RFC7997" format="default" sectionFormat="bare" section="3.3" derivedLink="https://rfc-editor.org/rfc/rfc7997#section-3.3" derivedContent="RFC7997">Company Names</xref> of
+               <xref target="RFC7997" format="default" sectionFormat="bare" section="3.3" derivedLink="https://rfc-editor.org/rfc/rfc7997#section-3.3" derivedContent="RFC7997">Company Names</xref> and
+               <xref target="RFC7997" format="default" sectionFormat="bare" section="3.3" derivedLink="https://rfc-editor.org/rfc/rfc7997#section-3.3" derivedContent="RFC7997">a <em>lot</em> <strong>more</strong> information</xref> of
                <xref target="RFC7997" format="default" sectionFormat="of" derivedContent="RFC7997"/>.
 
             </li>

--- a/tests/valid/elements.text
+++ b/tests/valid/elements.text
@@ -141,7 +141,7 @@ Table of Contents
    sectionFormat="bare":
 
    *  Text and format="default": Sections 3.2 (Person Names) and 3.3
-      (Company Names) of [RFC7997].
+      (Company Names) and 3.3 (a _lot_ *more* information) of [RFC7997].
 
    *  Text and format="title": Not meaningful
 

--- a/tests/valid/elements.v3.html
+++ b/tests/valid/elements.v3.html
@@ -15,7 +15,7 @@
 <meta content="
        This is the abstract. 
     " name="description">
-<meta content="xml2rfc 3.17.5" name="generator">
+<meta content="xml2rfc 3.18.0" name="generator">
 <meta content="elements-00" name="ietf.draft">
 <link href="tests/input/elements.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -330,7 +330,8 @@
 <li class="normal" id="section-2-9.1">
                Text and format="default": Sections
                <span><a href="https://rfc-editor.org/rfc/rfc7997#section-3.2" class="relref">3.2</a> (<a href="https://rfc-editor.org/rfc/rfc7997#section-3.2" class="relref">Person Names</a>)</span> and 
-               <span><a href="https://rfc-editor.org/rfc/rfc7997#section-3.3" class="relref">3.3</a> (<a href="https://rfc-editor.org/rfc/rfc7997#section-3.3" class="relref">Company Names</a>)</span> of
+               <span><a href="https://rfc-editor.org/rfc/rfc7997#section-3.3" class="relref">3.3</a> (<a href="https://rfc-editor.org/rfc/rfc7997#section-3.3" class="relref">Company Names</a>)</span> and
+               <span><a href="https://rfc-editor.org/rfc/rfc7997#section-3.3" class="relref">3.3</a> (<a href="https://rfc-editor.org/rfc/rfc7997#section-3.3" class="relref">a <em>lot</em> <strong>more</strong> information</a>)</span> of
                <span>[<a href="#RFC7997" class="cite xref">RFC7997</a>]</span>.<a href="#section-2-9.1" class="pilcrow">¶</a>
 </li>
         <li class="normal" id="section-2-9.2">

--- a/tests/valid/elements.wip.text
+++ b/tests/valid/elements.wip.text
@@ -160,7 +160,7 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    sectionFormat="bare":
 
    *  Text and format="default": Sections 3.2 (Person Names) and 3.3
-      (Company Names) of [RFC7997].
+      (Company Names) and 3.3 (a _lot_ *more* information) of [RFC7997].
 
 
 

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           August 30, 2023
+Internet-Draft                                        September 27, 2023
 Intended status: Experimental                                           
-Expires: March 2, 2024
+Expires: March 30, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 2, 2024.
+   This Internet-Draft will expire on March 30, 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                    Expires March 2, 2024                 [Page 1]
+Person                   Expires March 30, 2024                 [Page 1]
 
-Internet-Draft             xml2rfc index tests               August 2023
+Internet-Draft             xml2rfc index tests            September 2023
 
 
    This is another section!
@@ -109,9 +109,9 @@ Index
 
 
 
-Person                    Expires March 2, 2024                 [Page 2]
+Person                   Expires March 30, 2024                 [Page 2]
 
-Internet-Draft             xml2rfc index tests               August 2023
+Internet-Draft             xml2rfc index tests            September 2023
 
 
       E
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                    Expires March 2, 2024                 [Page 3]
+Person                   Expires March 30, 2024                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-08-30T08:01:10" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-09-27T02:01:34" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="30" month="08" year="2023"/>
+    <date day="27" month="09" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 2 March 2024.
+        This Internet-Draft will expire on 30 March 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           August 30, 2023
+Internet-Draft                                        September 27, 2023
 Intended status: Experimental                                           
-Expires: March 2, 2024
+Expires: March 30, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 2, 2024.
+   This Internet-Draft will expire on March 30, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">August 2023</td>
+<td class="right">September 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires March 2, 2024</td>
+<td class="center">Expires March 30, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-30" class="published">August 30, 2023</time>
+<time datetime="2023-09-27" class="published">September 27, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-03-02">March 2, 2024</time></dd>
+<dd class="expires"><time datetime="2024-03-30">March 30, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on March 2, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on March 30, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                          30 August 2023
+                                                       27 September 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -26,7 +26,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.9.1
+    platformdirs 3.10.0
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           August 30, 2023
+Internet-Draft                                        September 27, 2023
 Intended status: Experimental                                           
-Expires: March 2, 2024
+Expires: March 30, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 2, 2024.
+   This Internet-Draft will expire on March 30, 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                    Expires March 2, 2024                 [Page 1]
+Person                   Expires March 30, 2024                 [Page 1]
 
-Internet-Draft          xml2rfc sourcecode tests             August 2023
+Internet-Draft          xml2rfc sourcecode tests          September 2023
 
 
    print("01")
@@ -109,9 +109,9 @@ Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
 
-Person                    Expires March 2, 2024                 [Page 2]
+Person                   Expires March 30, 2024                 [Page 2]
 
-Internet-Draft          xml2rfc sourcecode tests             August 2023
+Internet-Draft          xml2rfc sourcecode tests          September 2023
 
 
    print("49")
@@ -165,9 +165,9 @@ Internet-Draft          xml2rfc sourcecode tests             August 2023
 
 
 
-Person                    Expires March 2, 2024                 [Page 3]
+Person                   Expires March 30, 2024                 [Page 3]
 
-Internet-Draft          xml2rfc sourcecode tests             August 2023
+Internet-Draft          xml2rfc sourcecode tests          September 2023
 
 
    print("47")
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                    Expires March 2, 2024                 [Page 4]
+Person                   Expires March 30, 2024                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-08-30T08:01:18" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-09-27T02:01:42" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="30" month="08" year="2023"/>
+    <date day="27" month="09" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 2 March 2024.
+        This Internet-Draft will expire on 30 March 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           August 30, 2023
+Internet-Draft                                        September 27, 2023
 Intended status: Experimental                                           
-Expires: March 2, 2024
+Expires: March 30, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 2, 2024.
+   This Internet-Draft will expire on March 30, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc sourcecode tests</td>
-<td class="right">August 2023</td>
+<td class="right">September 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires March 2, 2024</td>
+<td class="center">Expires March 30, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-08-30" class="published">August 30, 2023</time>
+<time datetime="2023-09-27" class="published">September 27, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-03-02">March 2, 2024</time></dd>
+<dd class="expires"><time datetime="2024-03-30">March 30, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on March 2, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on March 30, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">


### PR DESCRIPTION
This change fixes a bug where child elements were not rendered in the `xref` element with a `section` attribute.

This change only affects HTML & PDF outputs.

Fixes #1034

# Example outputs

Example XML snippet:
```
<section anchor="introduction"><name>Introduction</name>

 <t>See Section <xref target="RFC8610" section="2" sectionFormat="bare">The <em>Style</em> of Data Structure Specification</xref> of <xref target="RFC8610">CDDL</xref>.</t>
 <t>See <xref target="RFC8610" section="2" sectionFormat="parens">The <em>Style</em> of Data Structure Specification</xref> of <xref target="RFC8610">CDDL</xref>.</t>
 <t>See <xref target="RFC8610" section="2" sectionFormat="comma">The <em>Style</em> of Data Structure Specification</xref> of <xref target="RFC8610">CDDL</xref>.</t>
 <t>See <xref target="RFC8610" section="2" sectionFormat="of">The <em>Style</em> of Data Structure Specification</xref> of <xref target="RFC8610">CDDL</xref>.</t>
 <t>See <xref target="RFC8610" section="2">The <em>Style</em> of Data Structure Specification</xref> of <xref target="RFC8610">CDDL</xref>.</t>

 <t>See <xref target="introduction">The <em>Style</em> of Data Structure Specification</xref></t>

 <t>See <xref target="RFC8610" section="2"/>.</t>
 <t>See <xref target="RFC8610" section="2" sectionFormat="parens"/>.</t>
 <t>See <xref target="RFC8610" section="2" sectionFormat="comma"/>.</t>
 <t>See <xref target="RFC8610" section="2" sectionFormat="of"/>.</t>
 <t>See <xref target="RFC8610" section="2" sectionFormat="bare"/>.</t>

</section>
```

## Sample HTML outputs
### Before proposed changes
<img width="867" alt="Screenshot 2023-09-27 at 9 40 11 PM" src="https://github.com/ietf-tools/xml2rfc/assets/1027692/e5d0dfe5-c78a-4625-862b-13825d12e4ed">

### After the proposed changes
<img width="857" alt="Screenshot 2023-09-27 at 9 42 44 PM" src="https://github.com/ietf-tools/xml2rfc/assets/1027692/45da1e73-6f45-4d7c-ac69-5b0e073d447a">

## Sample PDF outputs
### Before proposed changes
<img width="497" alt="Screenshot 2023-09-27 at 9 40 36 PM" src="https://github.com/ietf-tools/xml2rfc/assets/1027692/a0917017-25bd-4a4a-85e8-d2e9da5f3973">

### After the proposed changes
<img width="495" alt="Screenshot 2023-09-27 at 9 43 53 PM" src="https://github.com/ietf-tools/xml2rfc/assets/1027692/037d60b8-9902-4509-ac60-1b3c2944e2b3">
