### PR TITLE
chore: Restrict WeasyPrint version 60.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,7 +90,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,<60.0"
         
     - name: Generate Valid Tests
       run: |
@@ -151,7 +151,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,<60.0"
         
     - name: Generate Valid Tests
       run: |
@@ -201,7 +201,7 @@ jobs:
 #         echo "Installing pip + wheel..."
 #         python -m pip install --upgrade pip wheel
 #         echo "Installing requirements.txt + test dependencies..."
-#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0"
+#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,<60.0"
 #     - name: Generate Valid Tests
 #       run: |
 #         make yestests || true

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -59,7 +59,7 @@ RUN pip3 install --upgrade \
 
 # Install Python dependencies
 RUN pip3 install -r requirements.txt \
-    "weasyprint>=53.0" \
+    "weasyprint>=53.0,<60.0" \
     decorator \
     dict2xml \
     "pypdf>=3.2.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ console_scripts =
 	xml2rfc = xml2rfc.run:main
 
 [options.extras_require]
-pdf = weasyprint>=53.0,!=57.0
+pdf = weasyprint>=53.0,!=57.0,<60.0
 
 [bdist_wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ deps =
     decorator
     dict2xml
     pypdf>=3.2.1
-    weasyprint>=53.0,!=57.0
+    weasyprint>=53.0,!=57.0,<60.0

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -87,7 +87,7 @@ def get_pdf_help(missing_libs=""):
 
     2. Next, install weasyprint python modules using pip.
 
-        pip install 'weasyprint>=53.0'
+        pip install 'weasyprint>=53.0,<60.0'
 
 
     3. Finally, install the full Noto Font and Roboto Mono packages:


### PR DESCRIPTION
WeasyPrint==60.0 is breaking tests for some Python versions.
Until we figure out the issues restrict WeasyPrint==60.0.