### PR TITLE
chore: Allow WeasyPrint v60.1

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,7 +90,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,<60.0"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,!=60.0"
         
     - name: Generate Valid Tests
       run: |
@@ -151,7 +151,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,<60.0"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,!=60.0"
         
     - name: Generate Valid Tests
       run: |
@@ -201,7 +201,7 @@ jobs:
 #         echo "Installing pip + wheel..."
 #         python -m pip install --upgrade pip wheel
 #         echo "Installing requirements.txt + test dependencies..."
-#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,<60.0"
+#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=3.2.1" "weasyprint>=53.0,!=57.0,!=60.0"
 #     - name: Generate Valid Tests
 #       run: |
 #         make yestests || true

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -59,7 +59,7 @@ RUN pip3 install --upgrade \
 
 # Install Python dependencies
 RUN pip3 install -r requirements.txt \
-    "weasyprint>=53.0,<60.0" \
+    "weasyprint>=53.0,!=57.0,!=60.0" \
     decorator \
     dict2xml \
     "pypdf>=3.2.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ console_scripts =
 	xml2rfc = xml2rfc.run:main
 
 [options.extras_require]
-pdf = weasyprint>=53.0,!=57.0,<60.0
+pdf = weasyprint>=53.0,!=57.0,!=60.0
 
 [bdist_wheel]
 universal = 1

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -27,7 +27,7 @@
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
   xml2rfc 3.18.0
-    Python 3.10.6
+    Python 3.10.12
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
     intervaltree 3.1.0
@@ -37,10 +37,10 @@
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0
-    setuptools 67.4.0
+    setuptools 68.2.0
     six 1.16.0
-    wcwidth 0.2.6
-    weasyprint 59.0
+    wcwidth 0.2.7
+    weasyprint 60.1
 -->
 <link href="tests/input/draft-miek-test.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -16,7 +16,7 @@
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
   xml2rfc 3.18.0
-    Python 3.10.6
+    Python 3.10.12
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
     intervaltree 3.1.0
@@ -26,10 +26,10 @@
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0
-    setuptools 67.4.0
+    setuptools 68.2.0
     six 1.16.0
-    wcwidth 0.2.6
-    weasyprint 59.0
+    wcwidth 0.2.7
+    weasyprint 60.1
 -->
 <link href="tests/input/draft-template.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                        September 27, 2023
+Internet-Draft                                        September 29, 2023
 Intended status: Experimental                                           
-Expires: March 30, 2024
+Expires: April 1, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 30, 2024.
+   This Internet-Draft will expire on April 1, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                   Expires March 30, 2024                 [Page 1]
+Person                    Expires April 1, 2024                 [Page 1]
 
 Internet-Draft             xml2rfc index tests            September 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                   Expires March 30, 2024                 [Page 2]
+Person                    Expires April 1, 2024                 [Page 2]
 
 Internet-Draft             xml2rfc index tests            September 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                   Expires March 30, 2024                 [Page 3]
+Person                    Expires April 1, 2024                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-09-27T02:01:34" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-09-29T09:36:20" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="27" month="09" year="2023"/>
+    <date day="29" month="09" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 30 March 2024.
+        This Internet-Draft will expire on 1 April 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                        September 27, 2023
+Internet-Draft                                        September 29, 2023
 Intended status: Experimental                                           
-Expires: March 30, 2024
+Expires: April 1, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 30, 2024.
+   This Internet-Draft will expire on April 1, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires March 30, 2024</td>
+<td class="center">Expires April 1, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-09-27" class="published">September 27, 2023</time>
+<time datetime="2023-09-29" class="published">September 29, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-03-30">March 30, 2024</time></dd>
+<dd class="expires"><time datetime="2024-04-01">April 1, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on March 30, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on April 1, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                       27 September 2023
+                                                       29 September 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -20,7 +20,7 @@
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
   xml2rfc 3.18.0
-    Python 3.10.6
+    Python 3.10.12
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
     intervaltree 3.1.0
@@ -30,10 +30,10 @@
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0
-    setuptools 67.4.0
+    setuptools 68.2.0
     six 1.16.0
-    wcwidth 0.2.6
-    weasyprint 59.0
+    wcwidth 0.2.7
+    weasyprint 60.1
 -->
 <link href="tests/input/rfc7911.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                        September 27, 2023
+Internet-Draft                                        September 29, 2023
 Intended status: Experimental                                           
-Expires: March 30, 2024
+Expires: April 1, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 30, 2024.
+   This Internet-Draft will expire on April 1, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                   Expires March 30, 2024                 [Page 1]
+Person                    Expires April 1, 2024                 [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests          September 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests          September 2023
 
 
 
-Person                   Expires March 30, 2024                 [Page 2]
+Person                    Expires April 1, 2024                 [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests          September 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests          September 2023
 
 
 
-Person                   Expires March 30, 2024                 [Page 3]
+Person                    Expires April 1, 2024                 [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests          September 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                   Expires March 30, 2024                 [Page 4]
+Person                    Expires April 1, 2024                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-09-27T02:01:42" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-09-29T09:36:28" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="27" month="09" year="2023"/>
+    <date day="29" month="09" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 30 March 2024.
+        This Internet-Draft will expire on 1 April 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                        September 27, 2023
+Internet-Draft                                        September 29, 2023
 Intended status: Experimental                                           
-Expires: March 30, 2024
+Expires: April 1, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 30, 2024.
+   This Internet-Draft will expire on April 1, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires March 30, 2024</td>
+<td class="center">Expires April 1, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-09-27" class="published">September 27, 2023</time>
+<time datetime="2023-09-29" class="published">September 29, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-03-30">March 30, 2024</time></dd>
+<dd class="expires"><time datetime="2024-04-01">April 1, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on March 30, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on April 1, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ deps =
     decorator
     dict2xml
     pypdf>=3.2.1
-    weasyprint>=53.0,!=57.0,<60.0
+    weasyprint>=53.0,!=57.0,!=60.0

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -87,7 +87,7 @@ def get_pdf_help(missing_libs=""):
 
     2. Next, install weasyprint python modules using pip.
 
-        pip install 'weasyprint>=53.0,<60.0'
+        pip install 'weasyprint>=53.0,!=57.0,!=60.0'
 
 
     3. Finally, install the full Noto Font and Roboto Mono packages:


### PR DESCRIPTION
 WeasyPrint 60.1 has fixed the crash caused by the wrong UTF-8 indices.
 Allow installing v60.1 and above while avoiding v60.0.