### PR TITLE
fix: Deduplicate index entries

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.18.1</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.18.2</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.18.1" name="generator">
-<meta content="xml2rfc-docs-3.18.1" name="ietf.draft">
+<meta content="xml2rfc 3.18.2" name="generator">
+<meta content="xml2rfc-docs-3.18.2" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-10-11" class="published">11 October 2023</time>
+<time datetime="2023-10-26" class="published">26 October 2023</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
@@ -49,7 +49,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.18.1</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.18.2</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -371,7 +371,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://ietf-tools.github.io/xml2rfc/">https://ietf-tools.github.io/xml2rfc/</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.18.1.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.18.2.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6366,7 +6366,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.18.1:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.18.2:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.18.1" name="generator">
+<meta content="xml2rfc 3.18.2" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -26,7 +26,7 @@
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.18.1
+  xml2rfc 3.18.2
     Python 3.10.12
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -11,11 +11,11 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.18.1" name="generator">
+<meta content="xml2rfc 3.18.2" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.18.1
+  xml2rfc 3.18.2
     Python 3.10.12
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
@@ -2104,7 +2104,7 @@ main(int argc, char *argv[])
 <dl class="references">
 <dt id="DOI_10.1145_2975159">[DOI_10.1145_2975159]</dt>
         <dd>
-<span class="refAuthor">Singh, A.</span>, <span class="refAuthor">Ong, J.</span>, <span class="refAuthor">Agarwal, A.</span>, <span class="refAuthor">Anderson, G.</span>, <span class="refAuthor">Armistead, A.</span>, <span class="refAuthor">Bannon, R.</span>, <span class="refAuthor">Boving, S.</span>, <span class="refAuthor">Desai, G.</span>, <span class="refAuthor">Felderman, B.</span>, <span class="refAuthor">Germano, P.</span>, <span class="refAuthor">Kanagala, A.</span>, <span class="refAuthor">Liu, H.</span>, <span class="refAuthor">Provost, J.</span>, <span class="refAuthor">Simmons, J.</span>, <span class="refAuthor">Tanda, E.</span>, <span class="refAuthor">Wanderer, J.</span>, <span class="refAuthor">Hölzle, U.</span>, <span class="refAuthor">Stuart, S.</span>, <span class="refAuthor">Vahdat, A.</span>, and <span class="refAuthor">Association for Computing Machinery (ACM)</span>, <span class="refTitle">"Jupiter rising"</span>, <span class="refContent">Communications of the ACM, vol. 59, no. 9, pp. 88-97</span>, <span class="seriesInfo">DOI 10.1145/2975159</span>, <time datetime="2016-08-24" class="refDate">24 August 2016</time>, <span>&lt;<a href="http://dx.doi.org/10.1145/2975159">http://dx.doi.org/10.1145/2975159</a>&gt;</span>. </dd>
+<span class="refAuthor">Singh, A.</span>, <span class="refAuthor">Ong, J.</span>, <span class="refAuthor">Agarwal, A.</span>, <span class="refAuthor">Anderson, G.</span>, <span class="refAuthor">Armistead, A.</span>, <span class="refAuthor">Bannon, R.</span>, <span class="refAuthor">Boving, S.</span>, <span class="refAuthor">Desai, G.</span>, <span class="refAuthor">Felderman, B.</span>, <span class="refAuthor">Germano, P.</span>, <span class="refAuthor">Kanagala, A.</span>, <span class="refAuthor">Liu, H.</span>, <span class="refAuthor">Provost, J.</span>, <span class="refAuthor">Simmons, J.</span>, <span class="refAuthor">Tanda, E.</span>, <span class="refAuthor">Wanderer, J.</span>, <span class="refAuthor">Hölzle, U.</span>, <span class="refAuthor">Stuart, S.</span>, <span class="refAuthor">Vahdat, A.</span>, and <span class="refAuthor">Association for Computing Machinery (ACM)</span>, <span class="refTitle">"Jupiter rising"</span>, <span class="refContent">Communications of the ACM, vol. 59, no. 9, pp. 88-97</span>, <span class="seriesInfo">DOI 10.1145/2975159</span>, <time datetime="2016-08-24" class="refDate">24 August 2016</time>, <span>&lt;<a href="https://doi.org/10.1145/2975159">https://doi.org/10.1145/2975159</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="DOMINATION">[DOMINATION]</dt>
         <dd>

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 11, 2023
+Internet-Draft                                          October 26, 2023
 Intended status: Experimental                                           
-Expires: April 13, 2024
+Expires: April 28, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 13, 2024.
+   This Internet-Draft will expire on April 28, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                   Expires April 13, 2024                 [Page 1]
+Person                   Expires April 28, 2024                 [Page 1]
 
 Internet-Draft             xml2rfc index tests              October 2023
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                   Expires April 13, 2024                 [Page 2]
+Person                   Expires April 28, 2024                 [Page 2]
 
 Internet-Draft             xml2rfc index tests              October 2023
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                   Expires April 13, 2024                 [Page 3]
+Person                   Expires April 28, 2024                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-10-11T00:11:48" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.18.1 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-10-26T16:43:20" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.18.2 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="11" month="10" year="2023"/>
+    <date day="26" month="10" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 13 April 2024.
+        This Internet-Draft will expire on 28 April 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 11, 2023
+Internet-Draft                                          October 26, 2023
 Intended status: Experimental                                           
-Expires: April 13, 2024
+Expires: April 28, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 13, 2024.
+   This Internet-Draft will expire on April 28, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.18.1" name="generator">
+<meta content="xml2rfc 3.18.2" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires April 13, 2024</td>
+<td class="center">Expires April 28, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-10-11" class="published">October 11, 2023</time>
+<time datetime="2023-10-26" class="published">October 26, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-04-13">April 13, 2024</time></dd>
+<dd class="expires"><time datetime="2024-04-28">April 28, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on April 13, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on April 28, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                         11 October 2023
+                                                         26 October 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.18.1
-                          xml2rfc-docs-3.18.1
+                         xml2rfc release 3.18.2
+                          xml2rfc-docs-3.18.2
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://ietf-tools.github.io/xml2rfc/.
 
-   This documentation applies to xml2rfc version 3.18.1.
+   This documentation applies to xml2rfc version 3.18.2.
 
 2.  Schema Version 3 Elements
 
@@ -4319,7 +4319,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.18.1:
+   Jinja2 template, as of xml2rfc version 3.18.2:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -16,10 +16,10 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.18.1" name="generator">
+<meta content="xml2rfc 3.18.2" name="generator">
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.18.1
+  xml2rfc 3.18.2
     Python 3.10.12
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 11, 2023
+Internet-Draft                                          October 26, 2023
 Intended status: Experimental                                           
-Expires: April 13, 2024
+Expires: April 28, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 13, 2024.
+   This Internet-Draft will expire on April 28, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                   Expires April 13, 2024                 [Page 1]
+Person                   Expires April 28, 2024                 [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests            October 2023
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests            October 2023
 
 
 
-Person                   Expires April 13, 2024                 [Page 2]
+Person                   Expires April 28, 2024                 [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests            October 2023
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests            October 2023
 
 
 
-Person                   Expires April 13, 2024                 [Page 3]
+Person                   Expires April 28, 2024                 [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests            October 2023
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                   Expires April 13, 2024                 [Page 4]
+Person                   Expires April 28, 2024                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-10-11T00:11:56" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.18.1 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-10-26T16:43:27" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.18.2 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="11" month="10" year="2023"/>
+    <date day="26" month="10" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 13 April 2024.
+        This Internet-Draft will expire on 28 April 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 11, 2023
+Internet-Draft                                          October 26, 2023
 Intended status: Experimental                                           
-Expires: April 13, 2024
+Expires: April 28, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 13, 2024.
+   This Internet-Draft will expire on April 28, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.18.1" name="generator">
+<meta content="xml2rfc 3.18.2" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires April 13, 2024</td>
+<td class="center">Expires April 28, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-10-11" class="published">October 11, 2023</time>
+<time datetime="2023-10-26" class="published">October 26, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-04-13">April 13, 2024</time></dd>
+<dd class="expires"><time datetime="2024-04-28">April 28, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on April 13, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on April 28, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/writers/preptool.py
+++ b/xml2rfc/writers/preptool.py
@@ -2221,6 +2221,13 @@ class PrepToolWriter(BaseV3Writer):
 
         # done defining helpers, resume back_insert_index() flow
         if self.index_entries and self.root.get('indexInclude') == 'true':
+            # remove duplicate entries
+            entries = {}
+            for entry in self.index_entries:
+                uniq_key = (entry.item, entry.anchor)
+                entries.setdefault(uniq_key, entry)  # keeps only the first for each key
+            self.index_entries = list(entries.values())
+            #
             index = self.element('section', numbered='false', toc='include')
             name = self.element('name')
             name.text = 'Index'

--- a/xml2rfc/writers/preptool.py
+++ b/xml2rfc/writers/preptool.py
@@ -63,6 +63,8 @@ pnprefix = {
 
 index_item = namedtuple('index_item', ['item', 'sub', 'anchor', 'anchor_tag', 'iref', ])
 
+re_spaces = re.compile(r'\s+')
+
 def uniq(l):
     seen = set()
     ll = []
@@ -1428,7 +1430,7 @@ class PrepToolWriter(BaseV3Writer):
             if not anchor:
                 self.err(e, "Did not find an anchor to use for <iref item='%s'> in <%s>" % (item, p.tag))
             else:
-                self.index_entries.append(index_item(item, sub, anchor, anchor_tag, e))
+                self.index_entries.append(index_item(re_spaces.sub(' ', item), sub, anchor, anchor_tag, e))
 
     def ol_add_counter(self, e, p):
         start = e.get('start')


### PR DESCRIPTION
This PR addresses two issues:
* Duplicate entries per term in the index.
* Duplicate terms in the index.

Fixes #988 