### PR TITLE
fix: Follow HTML presentational hints in PDF

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">October 2023</td>
+<td class="right">November 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-10-26" class="published">26 October 2023</time>
+<time datetime="2023-11-16" class="published">16 November 2023</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -33,7 +33,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.11.0
+    platformdirs 3.10.0
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -22,7 +22,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.11.0
+    platformdirs 3.10.0
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 26, 2023
+Internet-Draft                                         November 16, 2023
 Intended status: Experimental                                           
-Expires: April 28, 2024
+Expires: May 19, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 28, 2024.
+   This Internet-Draft will expire on May 19, 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                   Expires April 28, 2024                 [Page 1]
+Person                    Expires May 19, 2024                  [Page 1]
 
-Internet-Draft             xml2rfc index tests              October 2023
+Internet-Draft             xml2rfc index tests             November 2023
 
 
    This is another section!
@@ -109,9 +109,9 @@ Index
 
 
 
-Person                   Expires April 28, 2024                 [Page 2]
+Person                    Expires May 19, 2024                  [Page 2]
 
-Internet-Draft             xml2rfc index tests              October 2023
+Internet-Draft             xml2rfc index tests             November 2023
 
 
       E
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                   Expires April 28, 2024                 [Page 3]
+Person                    Expires May 19, 2024                  [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-10-26T16:43:20" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2023-11-16T22:23:11" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.2 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="26" month="10" year="2023"/>
+    <date day="16" month="11" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 28 April 2024.
+        This Internet-Draft will expire on 19 May 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 26, 2023
+Internet-Draft                                         November 16, 2023
 Intended status: Experimental                                           
-Expires: April 28, 2024
+Expires: May 19, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 28, 2024.
+   This Internet-Draft will expire on May 19, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">October 2023</td>
+<td class="right">November 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires April 28, 2024</td>
+<td class="center">Expires May 19, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-10-26" class="published">October 26, 2023</time>
+<time datetime="2023-11-16" class="published">November 16, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-04-28">April 28, 2024</time></dd>
+<dd class="expires"><time datetime="2024-05-19">May 19, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on April 28, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on May 19, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                         26 October 2023
+                                                        16 November 2023
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -26,7 +26,7 @@
     intervaltree 3.1.0
     Jinja2 3.1.2
     lxml 4.9.3
-    platformdirs 3.11.0
+    platformdirs 3.10.0
     pycountry 22.3.5
     PyYAML 6.0.1
     requests 2.31.0

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 26, 2023
+Internet-Draft                                         November 16, 2023
 Intended status: Experimental                                           
-Expires: April 28, 2024
+Expires: May 19, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 28, 2024.
+   This Internet-Draft will expire on May 19, 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                   Expires April 28, 2024                 [Page 1]
+Person                    Expires May 19, 2024                  [Page 1]
 
-Internet-Draft          xml2rfc sourcecode tests            October 2023
+Internet-Draft          xml2rfc sourcecode tests           November 2023
 
 
    print("01")
@@ -109,9 +109,9 @@ Internet-Draft          xml2rfc sourcecode tests            October 2023
 
 
 
-Person                   Expires April 28, 2024                 [Page 2]
+Person                    Expires May 19, 2024                  [Page 2]
 
-Internet-Draft          xml2rfc sourcecode tests            October 2023
+Internet-Draft          xml2rfc sourcecode tests           November 2023
 
 
    print("49")
@@ -165,9 +165,9 @@ Internet-Draft          xml2rfc sourcecode tests            October 2023
 
 
 
-Person                   Expires April 28, 2024                 [Page 3]
+Person                    Expires May 19, 2024                  [Page 3]
 
-Internet-Draft          xml2rfc sourcecode tests            October 2023
+Internet-Draft          xml2rfc sourcecode tests           November 2023
 
 
    print("47")
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                   Expires April 28, 2024                 [Page 4]
+Person                    Expires May 19, 2024                  [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-10-26T16:43:27" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2023-11-16T22:23:19" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.18.2 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="26" month="10" year="2023"/>
+    <date day="16" month="11" year="2023"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 28 April 2024.
+        This Internet-Draft will expire on 19 May 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          October 26, 2023
+Internet-Draft                                         November 16, 2023
 Intended status: Experimental                                           
-Expires: April 28, 2024
+Expires: May 19, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 28, 2024.
+   This Internet-Draft will expire on May 19, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc sourcecode tests</td>
-<td class="right">October 2023</td>
+<td class="right">November 2023</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires April 28, 2024</td>
+<td class="center">Expires May 19, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-10-26" class="published">October 26, 2023</time>
+<time datetime="2023-11-16" class="published">November 16, 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-04-28">April 28, 2024</time></dd>
+<dd class="expires"><time datetime="2024-05-19">May 19, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on April 28, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on May 19, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -104,7 +104,7 @@ class PdfWriter(BaseV3Writer):
         page_css_text = page_css_template.format(**page_info)
         page_css = weasyprint.CSS(string=page_css_text)
 
-        pdf = writer.write_pdf(None, stylesheets=[ css, page_css ])
+        pdf = writer.write_pdf(None, stylesheets=[ css, page_css ], presentational_hints=True)
 
         return pdf
 


### PR DESCRIPTION
Set `presentational_hints` option in WeasyPrint so that HTML
presentational hints are respected.

See https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#supported-html-tags

Fixes #1054