### PR TITLE
chore: List required dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Update setup.cfg as well
 platformdirs>=3.6.0
 configargparse>=1.2.3
 google-i18n-address>=3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,20 @@ classifiers =
 packages = xml2rfc, xml2rfc/writers, xml2rfc/util, xml2rfc/uniscripts, xml2rfc/data, xml2rfc/templates
 zip_safe = False
 include_package_data = True
-install_requires = file: requirements.txt
+# install_requires = file: requirements.txt
+# this is a temporary measure to make install work with Ubuntu Jammy
+install_requires = platformdirs>=3.6.0
+    configargparse>=1.2.3
+    google-i18n-address>=3.0.0
+    intervaltree>=3.1.0
+    jinja2>=3.1.2
+    lxml>=4.9.0
+    pycountry>=22.3.5
+    pyyaml>=5.3.1
+    requests>=2.5.0
+    setuptools>=24.2.0
+    six>=1.4.1
+    wcwidth>=0.2.5
 
 [options.package_data]
 * = 


### PR DESCRIPTION
`file: requirements.txt` is only supported by setuptools>=62.6.

Fixes #1049