### PR TITLE
revert: Lighter styling on internal iref links

### DIFF
--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -220,8 +220,7 @@ a[href]:hover {
   background-color: #f2f2f2;
 }
 figcaption a[href],
-a[href].selfRef,
-.iref + a[href].internal {
+a[href].selfRef {
   color: #222;
 }
 /* XXX probably not this:


### PR DESCRIPTION
This reverts: "feat: Lighter styling on internal iref links (#963)" See https://mailarchive.ietf.org/arch/msg/rsab/F9QOvdVX2amsX1bgR4DGVTzQat8/

This reverts commit dbdda51a16083da0762355ebe0902c3bc2a78a39.

Fixes #1058