### PR TITLE
fix: Use importlib.metadata

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.19.0</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.19.1</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.19.0" name="generator">
-<meta content="xml2rfc-docs-3.19.0" name="ietf.draft">
+<meta content="xml2rfc 3.19.1" name="generator">
+<meta content="xml2rfc-docs-3.19.1" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-01-08" class="published">8 January 2024</time>
+<time datetime="2024-01-16" class="published">16 January 2024</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
@@ -49,7 +49,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.19.0</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.19.1</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -371,7 +371,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://ietf-tools.github.io/xml2rfc/">https://ietf-tools.github.io/xml2rfc/</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.19.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.19.1.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6366,7 +6366,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.19.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.19.1:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.19.0" name="generator">
+<meta content="xml2rfc 3.19.1" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -26,12 +26,12 @@
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.19.0
-    Python 3.10.12
+  xml2rfc 3.19.1
+    Python 3.11.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
     intervaltree 3.1.0
-    Jinja2 3.1.2
+    Jinja2 3.1.3
     lxml 4.9.4
     platformdirs 4.1.0
     pycountry 23.12.11

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -11,16 +11,16 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.19.0" name="generator">
+<meta content="xml2rfc 3.19.1" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.19.0
-    Python 3.10.12
+  xml2rfc 3.19.1
+    Python 3.11.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
     intervaltree 3.1.0
-    Jinja2 3.1.2
+    Jinja2 3.1.3
     lxml 4.9.4
     platformdirs 4.1.0
     pycountry 23.12.11

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           January 8, 2024
+Internet-Draft                                          January 16, 2024
 Intended status: Experimental                                           
-Expires: July 11, 2024
+Expires: July 19, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 11, 2024.
+   This Internet-Draft will expire on July 19, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                    Expires July 11, 2024                 [Page 1]
+Person                    Expires July 19, 2024                 [Page 1]
 
 Internet-Draft             xml2rfc index tests              January 2024
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                    Expires July 11, 2024                 [Page 2]
+Person                    Expires July 19, 2024                 [Page 2]
 
 Internet-Draft             xml2rfc index tests              January 2024
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                    Expires July 11, 2024                 [Page 3]
+Person                    Expires July 19, 2024                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2024-01-08T21:32:09" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.19.0 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2024-01-16T00:03:26" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.19.1 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="08" month="01" year="2024"/>
+    <date day="16" month="01" year="2024"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 11 July 2024.
+        This Internet-Draft will expire on 19 July 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           January 8, 2024
+Internet-Draft                                          January 16, 2024
 Intended status: Experimental                                           
-Expires: July 11, 2024
+Expires: July 19, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 11, 2024.
+   This Internet-Draft will expire on July 19, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.19.0" name="generator">
+<meta content="xml2rfc 3.19.1" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires July 11, 2024</td>
+<td class="center">Expires July 19, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-01-08" class="published">January 8, 2024</time>
+<time datetime="2024-01-16" class="published">January 16, 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-07-11">July 11, 2024</time></dd>
+<dd class="expires"><time datetime="2024-07-19">July 19, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on July 11, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on July 19, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                          8 January 2024
+                                                         16 January 2024
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.19.0
-                          xml2rfc-docs-3.19.0
+                         xml2rfc release 3.19.1
+                          xml2rfc-docs-3.19.1
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://ietf-tools.github.io/xml2rfc/.
 
-   This documentation applies to xml2rfc version 3.19.0.
+   This documentation applies to xml2rfc version 3.19.1.
 
 2.  Schema Version 3 Elements
 
@@ -4319,7 +4319,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.19.0:
+   Jinja2 template, as of xml2rfc version 3.19.1:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -16,15 +16,15 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.19.0" name="generator">
+<meta content="xml2rfc 3.19.1" name="generator">
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.19.0
-    Python 3.10.12
+  xml2rfc 3.19.1
+    Python 3.11.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.0
     intervaltree 3.1.0
-    Jinja2 3.1.2
+    Jinja2 3.1.3
     lxml 4.9.4
     platformdirs 4.1.0
     pycountry 23.12.11

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           January 8, 2024
+Internet-Draft                                          January 16, 2024
 Intended status: Experimental                                           
-Expires: July 11, 2024
+Expires: July 19, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 11, 2024.
+   This Internet-Draft will expire on July 19, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                    Expires July 11, 2024                 [Page 1]
+Person                    Expires July 19, 2024                 [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2024
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests            January 2024
 
 
 
-Person                    Expires July 11, 2024                 [Page 2]
+Person                    Expires July 19, 2024                 [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2024
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests            January 2024
 
 
 
-Person                    Expires July 11, 2024                 [Page 3]
+Person                    Expires July 19, 2024                 [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2024
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                    Expires July 11, 2024                 [Page 4]
+Person                    Expires July 19, 2024                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2024-01-08T21:32:17" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.19.0 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2024-01-16T00:03:34" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.19.1 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="08" month="01" year="2024"/>
+    <date day="16" month="01" year="2024"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 11 July 2024.
+        This Internet-Draft will expire on 19 July 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                           January 8, 2024
+Internet-Draft                                          January 16, 2024
 Intended status: Experimental                                           
-Expires: July 11, 2024
+Expires: July 19, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 11, 2024.
+   This Internet-Draft will expire on July 19, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.19.0" name="generator">
+<meta content="xml2rfc 3.19.1" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires July 11, 2024</td>
+<td class="center">Expires July 19, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-01-08" class="published">January 8, 2024</time>
+<time datetime="2024-01-16" class="published">January 16, 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-07-11">July 11, 2024</time></dd>
+<dd class="expires"><time datetime="2024-07-19">July 19, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on July 11, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on July 19, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/__init__.py
+++ b/xml2rfc/__init__.py
@@ -46,24 +46,15 @@ except (ImportError, OSError, AttributeError):
 def get_versions():
     import sys
     versions = []
-    extras = set(['weasyprint'])
     try:
-        import pkg_resources
-        this = pkg_resources.working_set.by_key[NAME]
-        for p in this.requires():
-            if p.key in extras:
-                extras -= p.key
+        from importlib import metadata
+        this = metadata.distribution(NAME)
+        for p in [x.split()[0] for x in this.requires]:
             try:
-                dist = pkg_resources.get_distribution(p.key)
-                versions.append((dist.project_name, dist.version))
+                dist = metadata.distribution(p)
+                versions.append((dist.metadata['name'], dist.metadata['version']))
             except Exception as e:
                 print(e)
-                pass
-        for key in extras:
-            try:
-                dist = pkg_resources.get_distribution(key)
-                versions.append((dist.project_name, dist.version))
-            except:
                 pass
     except:
         pass


### PR DESCRIPTION
Use `importlib.metadata` instead of `pkg_resources` from `setuptools` since `pkg_resources` is deprecated.

Fixes #1072