### PR TITLE
fix: Silently pass when weasyprint is not installed

### DIFF
--- a/xml2rfc/__init__.py
+++ b/xml2rfc/__init__.py
@@ -54,8 +54,7 @@ def get_versions():
             try:
                 dist = metadata.distribution(p)
                 versions.append((dist.metadata['name'], dist.metadata['version']))
-            except Exception as e:
-                print(e)
+            except:
                 pass
     except:
         pass


### PR DESCRIPTION
Fixes #1091