### PR TITLE
feat: Update subseries presentation

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.19.3</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.19.4</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.19.3" name="generator">
-<meta content="xml2rfc-docs-3.19.3" name="ietf.draft">
+<meta content="xml2rfc 3.19.4" name="generator">
+<meta content="xml2rfc-docs-3.19.4" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-02-06" class="published">6 February 2024</time>
+<time datetime="2024-02-19" class="published">19 February 2024</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
@@ -49,7 +49,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.19.3</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.19.4</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -371,7 +371,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://ietf-tools.github.io/xml2rfc/">https://ietf-tools.github.io/xml2rfc/</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.19.3.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.19.4.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6366,7 +6366,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.19.3:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.19.4:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4225,11 +4225,12 @@ src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww..."&gt;
 <dl class="references">
 <dt id="BCP14">[BCP14]</dt>
       <dd>
+<div class="refInstance">Best Current Practice 14, <span>&lt;<a href="https://www.rfc-editor.org/bcp/bcp14.txt">https://www.rfc-editor.org/bcp/bcp14.txt</a>&gt;</span>.<br><span>At the time of writing, this BCP comprises the following:</span>
+</div>
 <div class="refInstance" id="RFC2119">
-          <span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>. </div>
+          <span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </div>
 <div class="refInstance" id="RFC8174">
-          <span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>. </div>
-<span>&lt;<a href="https://www.rfc-editor.org/bcp/bcp14.txt">https://www.rfc-editor.org/bcp/bcp14.txt</a>&gt;</span>
+          <span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </div>
 </dd>
 <dd class="break"></dd>
 <dt id="IDGUIDE">[IDGUIDE]</dt>

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.19.3" name="generator">
+<meta content="xml2rfc 3.19.4" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -26,7 +26,7 @@
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.19.3
+  xml2rfc 3.19.4
     Python 3.11.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -470,6 +470,10 @@ nav.toc li {
   margin-bottom: 1.25em;
 }
 
+.refSubseries {
+  margin-bottom: 1.25em;
+}
+
 .references .ascii {
   margin-bottom: 0.25em;
 }

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -459,6 +459,10 @@ nav.toc li {
   margin-bottom: 1.25em;
 }
 
+.refSubseries {
+  margin-bottom: 1.25em;
+}
+
 .references .ascii {
   margin-bottom: 0.25em;
 }

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -11,11 +11,11 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.19.3" name="generator">
+<meta content="xml2rfc 3.19.4" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.19.3
+  xml2rfc 3.19.4
     Python 3.11.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/draft-v3-features.text
+++ b/tests/valid/draft-v3-features.text
@@ -1360,10 +1360,13 @@ Table of Contents
               _here_, November 2014.  Due to a <displayreference>
               element, this should be listed as "[0REFTEST]".
 
-   [BCP45]    Eggert, L. and S. Harris, "IETF Discussion List Charter",
-              BCP 45, RFC 9245, June 2022.
+   [BCP45]    Best Current Practice 45,
+              <https://www.rfc-editor.org/info/bcp45>.
+              At the time of writing, this BCP comprises the following:
 
-              <https://www.rfc-editor.org/info/bcp45>
+              Eggert, L. and S. Harris, "IETF Discussion List Charter",
+              BCP 45, RFC 9245, DOI 10.17487/RFC9245, June 2022,
+              <https://www.rfc-editor.org/info/rfc9245>.
 
    [DUP]      Reschke, J., "Reference Duplicate Test", July 2016.
 
@@ -1385,23 +1388,29 @@ Table of Contents
               RFC 7996, DOI 10.17487/RFC7996, December 2016,
               <https://www.rfc-editor.org/info/rfc7996>.
 
-   [STD78]    Schoenwaelder, J., "Simple Network Management Protocol
+   [STD78]    Internet Standard 78,
+              <https://www.rfc-editor.org/info/std78>.
+              At the time of writing, this STD comprises the following:
+
+              Schoenwaelder, J., "Simple Network Management Protocol
               (SNMP) Context EngineID Discovery", STD 78, RFC 5343,
-              September 2008.
+              DOI 10.17487/RFC5343, September 2008,
+              <https://www.rfc-editor.org/info/rfc5343>.
 
               Harrington, D. and J. Schoenwaelder, "Transport Subsystem
               for the Simple Network Management Protocol (SNMP)",
-              STD 78, RFC 5590, June 2009.
+              STD 78, RFC 5590, DOI 10.17487/RFC5590, June 2009,
+              <https://www.rfc-editor.org/info/rfc5590>.
 
               Harrington, D. and W. Hardaker, "Transport Security Model
               for the Simple Network Management Protocol (SNMP)",
-              STD 78, RFC 5591, June 2009.
+              STD 78, RFC 5591, DOI 10.17487/RFC5591, June 2009,
+              <https://www.rfc-editor.org/info/rfc5591>.
 
               Hardaker, W., "Transport Layer Security (TLS) Transport
               Model for the Simple Network Management Protocol (SNMP)",
-              STD 78, RFC 6353, July 2011.
-
-              <https://www.rfc-editor.org/info/std78>
+              STD 78, RFC 6353, DOI 10.17487/RFC6353, July 2011,
+              <https://www.rfc-editor.org/info/rfc6353>.
 
    [STPETER]  ᏚᎢᎵᎬᎢᎬᏒ Inc. (STPETER Inc.), "ᏚᎢᎵᎬᎢᎬᏒ's document".  A
               document where the author element specifies just an

--- a/tests/valid/draft-v3-features.v3.html
+++ b/tests/valid/draft-v3-features.v3.html
@@ -13,7 +13,7 @@
         This document tests features introduced in xml2rfc v3 vocabulary.
        
     " name="description">
-<meta content="xml2rfc 3.19.3" name="generator">
+<meta content="xml2rfc 3.19.4" name="generator">
 <meta content="draft-v3-features" name="ietf.draft">
 <link href="tests/input/draft-v3-features.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -4969,9 +4969,10 @@ foo = bar
 <dd class="break"></dd>
 <dt id="BCP45">[BCP45]</dt>
       <dd>
+<div class="refInstance">Best Current Practice 45, <span>&lt;<a href="https://www.rfc-editor.org/info/bcp45">https://www.rfc-editor.org/info/bcp45</a>&gt;</span>.<br><span>At the time of writing, this BCP comprises the following:</span>
+</div>
 <div class="refInstance" id="RFC9245">
-          <span class="refAuthor">Eggert, L.</span> and <span class="refAuthor">S. Harris</span>, <span class="refTitle">"IETF Discussion List Charter"</span>, <span class="seriesInfo">BCP 45</span>, <span class="seriesInfo">RFC 9245</span>, <time datetime="2022-06" class="refDate">June 2022</time>. </div>
-<span>&lt;<a href="https://www.rfc-editor.org/info/bcp45">https://www.rfc-editor.org/info/bcp45</a>&gt;</span>
+          <span class="refAuthor">Eggert, L.</span> and <span class="refAuthor">S. Harris</span>, <span class="refTitle">"IETF Discussion List Charter"</span>, <span class="seriesInfo">BCP 45</span>, <span class="seriesInfo">RFC 9245</span>, <span class="seriesInfo">DOI 10.17487/RFC9245</span>, <time datetime="2022-06" class="refDate">June 2022</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9245">https://www.rfc-editor.org/info/rfc9245</a>&gt;</span>. </div>
 </dd>
 <dd class="break"></dd>
 <dt id="DUP">[DUP]</dt>
@@ -4998,15 +4999,16 @@ foo = bar
 <dd class="break"></dd>
 <dt id="STD78">[STD78]</dt>
       <dd>
+<div class="refInstance">Internet Standard 78, <span>&lt;<a href="https://www.rfc-editor.org/info/std78">https://www.rfc-editor.org/info/std78</a>&gt;</span>.<br><span>At the time of writing, this STD comprises the following:</span>
+</div>
 <div class="refInstance" id="RFC5343">
-          <span class="refAuthor">Schoenwaelder, J.</span>, <span class="refTitle">"Simple Network Management Protocol (SNMP) Context EngineID Discovery"</span>, <span class="seriesInfo">STD 78</span>, <span class="seriesInfo">RFC 5343</span>, <time datetime="2008-09" class="refDate">September 2008</time>. </div>
+          <span class="refAuthor">Schoenwaelder, J.</span>, <span class="refTitle">"Simple Network Management Protocol (SNMP) Context EngineID Discovery"</span>, <span class="seriesInfo">STD 78</span>, <span class="seriesInfo">RFC 5343</span>, <span class="seriesInfo">DOI 10.17487/RFC5343</span>, <time datetime="2008-09" class="refDate">September 2008</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5343">https://www.rfc-editor.org/info/rfc5343</a>&gt;</span>. </div>
 <div class="refInstance" id="RFC5590">
-          <span class="refAuthor">Harrington, D.</span> and <span class="refAuthor">J. Schoenwaelder</span>, <span class="refTitle">"Transport Subsystem for the Simple Network Management Protocol (SNMP)"</span>, <span class="seriesInfo">STD 78</span>, <span class="seriesInfo">RFC 5590</span>, <time datetime="2009-06" class="refDate">June 2009</time>. </div>
+          <span class="refAuthor">Harrington, D.</span> and <span class="refAuthor">J. Schoenwaelder</span>, <span class="refTitle">"Transport Subsystem for the Simple Network Management Protocol (SNMP)"</span>, <span class="seriesInfo">STD 78</span>, <span class="seriesInfo">RFC 5590</span>, <span class="seriesInfo">DOI 10.17487/RFC5590</span>, <time datetime="2009-06" class="refDate">June 2009</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5590">https://www.rfc-editor.org/info/rfc5590</a>&gt;</span>. </div>
 <div class="refInstance" id="RFC5591">
-          <span class="refAuthor">Harrington, D.</span> and <span class="refAuthor">W. Hardaker</span>, <span class="refTitle">"Transport Security Model for the Simple Network Management Protocol (SNMP)"</span>, <span class="seriesInfo">STD 78</span>, <span class="seriesInfo">RFC 5591</span>, <time datetime="2009-06" class="refDate">June 2009</time>. </div>
+          <span class="refAuthor">Harrington, D.</span> and <span class="refAuthor">W. Hardaker</span>, <span class="refTitle">"Transport Security Model for the Simple Network Management Protocol (SNMP)"</span>, <span class="seriesInfo">STD 78</span>, <span class="seriesInfo">RFC 5591</span>, <span class="seriesInfo">DOI 10.17487/RFC5591</span>, <time datetime="2009-06" class="refDate">June 2009</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5591">https://www.rfc-editor.org/info/rfc5591</a>&gt;</span>. </div>
 <div class="refInstance" id="RFC6353">
-          <span class="refAuthor">Hardaker, W.</span>, <span class="refTitle">"Transport Layer Security (TLS) Transport Model for the Simple Network Management Protocol (SNMP)"</span>, <span class="seriesInfo">STD 78</span>, <span class="seriesInfo">RFC 6353</span>, <time datetime="2011-07" class="refDate">July 2011</time>. </div>
-<span>&lt;<a href="https://www.rfc-editor.org/info/std78">https://www.rfc-editor.org/info/std78</a>&gt;</span>
+          <span class="refAuthor">Hardaker, W.</span>, <span class="refTitle">"Transport Layer Security (TLS) Transport Model for the Simple Network Management Protocol (SNMP)"</span>, <span class="seriesInfo">STD 78</span>, <span class="seriesInfo">RFC 6353</span>, <span class="seriesInfo">DOI 10.17487/RFC6353</span>, <time datetime="2011-07" class="refDate">July 2011</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6353">https://www.rfc-editor.org/info/rfc6353</a>&gt;</span>. </div>
 </dd>
 <dd class="break"></dd>
 <dt id="STPETER">[STPETER]</dt>

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          February 6, 2024
+Internet-Draft                                         February 19, 2024
 Intended status: Experimental                                           
-Expires: August 9, 2024
+Expires: August 22, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 9, 2024.
+   This Internet-Draft will expire on August 22, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                   Expires August 9, 2024                 [Page 1]
+Person                   Expires August 22, 2024                [Page 1]
 
 Internet-Draft             xml2rfc index tests             February 2024
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                   Expires August 9, 2024                 [Page 2]
+Person                   Expires August 22, 2024                [Page 2]
 
 Internet-Draft             xml2rfc index tests             February 2024
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                   Expires August 9, 2024                 [Page 3]
+Person                   Expires August 22, 2024                [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2024-02-06T20:51:50" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.19.3 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2024-02-19T00:20:48" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.19.4 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="06" month="02" year="2024"/>
+    <date day="19" month="02" year="2024"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 9 August 2024.
+        This Internet-Draft will expire on 22 August 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          February 6, 2024
+Internet-Draft                                         February 19, 2024
 Intended status: Experimental                                           
-Expires: August 9, 2024
+Expires: August 22, 2024
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 9, 2024.
+   This Internet-Draft will expire on August 22, 2024.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.19.3" name="generator">
+<meta content="xml2rfc 3.19.4" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires August 9, 2024</td>
+<td class="center">Expires August 22, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-02-06" class="published">February 6, 2024</time>
+<time datetime="2024-02-19" class="published">February 19, 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-08-09">August 9, 2024</time></dd>
+<dd class="expires"><time datetime="2024-08-22">August 22, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on August 9, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on August 22, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                         6 February 2024
+                                                        19 February 2024
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.19.3
-                          xml2rfc-docs-3.19.3
+                         xml2rfc release 3.19.4
+                          xml2rfc-docs-3.19.4
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://ietf-tools.github.io/xml2rfc/.
 
-   This documentation applies to xml2rfc version 3.19.3.
+   This documentation applies to xml2rfc version 3.19.4.
 
 2.  Schema Version 3 Elements
 
@@ -4319,7 +4319,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.19.3:
+   Jinja2 template, as of xml2rfc version 3.19.4:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -2642,13 +2642,18 @@ Table of Contents
 
 4.  References
 
-   [BCP14]    Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119, March 1997.
+   [BCP14]    Best Current Practice 14,
+              <https://www.rfc-editor.org/bcp/bcp14.txt>.
+              At the time of writing, this BCP comprises the following:
+
+              Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
               Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
-              2119 Key Words", BCP 14, RFC 8174, May 2017.
-
-              <https://www.rfc-editor.org/bcp/bcp14.txt>
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
    [IDGUIDE]  Housley, R., "Guidelines to Authors of Internet-Drafts",
               December 2010,

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -16,10 +16,10 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.19.3" name="generator">
+<meta content="xml2rfc 3.19.4" name="generator">
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.19.3
+  xml2rfc 3.19.4
     Python 3.11.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.0

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -463,6 +463,10 @@ nav.toc li {
   margin-bottom: 1.25em;
 }
 
+.refSubseries {
+  margin-bottom: 1.25em;
+}
+
 .references .ascii {
   margin-bottom: 0.25em;
 }

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          February 6, 2024
+Internet-Draft                                         February 19, 2024
 Intended status: Experimental                                           
-Expires: August 9, 2024
+Expires: August 22, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 9, 2024.
+   This Internet-Draft will expire on August 22, 2024.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                   Expires August 9, 2024                 [Page 1]
+Person                   Expires August 22, 2024                [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests           February 2024
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests           February 2024
 
 
 
-Person                   Expires August 9, 2024                 [Page 2]
+Person                   Expires August 22, 2024                [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests           February 2024
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests           February 2024
 
 
 
-Person                   Expires August 9, 2024                 [Page 3]
+Person                   Expires August 22, 2024                [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests           February 2024
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                   Expires August 9, 2024                 [Page 4]
+Person                   Expires August 22, 2024                [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2024-02-06T20:51:57" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.19.3 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2024-02-19T00:20:55" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.19.4 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="06" month="02" year="2024"/>
+    <date day="19" month="02" year="2024"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 9 August 2024.
+        This Internet-Draft will expire on 22 August 2024.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          February 6, 2024
+Internet-Draft                                         February 19, 2024
 Intended status: Experimental                                           
-Expires: August 9, 2024
+Expires: August 22, 2024
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 9, 2024.
+   This Internet-Draft will expire on August 22, 2024.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.19.3" name="generator">
+<meta content="xml2rfc 3.19.4" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires August 9, 2024</td>
+<td class="center">Expires August 22, 2024</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-02-06" class="published">February 6, 2024</time>
+<time datetime="2024-02-19" class="published">February 19, 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2024-08-09">August 9, 2024</time></dd>
+<dd class="expires"><time datetime="2024-08-22">August 22, 2024</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on August 9, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on August 22, 2024.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -424,6 +424,10 @@ nav.toc li {
   margin-bottom: 1.25em;
 }
 
+.refSubseries {
+  margin-bottom: 1.25em;
+}
+
 .references .ascii {
   margin-bottom: 0.25em;
 }

--- a/xml2rfc/writers/base.py
+++ b/xml2rfc/writers/base.py
@@ -79,6 +79,7 @@ default_options.__dict__ = {
         'image_svg': False,
         'indent': 2,
         'info': False,
+        'info_base_url': 'https://www.rfc-editor.org/info/',
         'inline_version_info': True,
         'legacy': False,
         'legacy_date_format': False,

--- a/xml2rfc/writers/base.py
+++ b/xml2rfc/writers/base.py
@@ -31,6 +31,12 @@ from xml2rfc.util.unicode import is_svg
 from xml2rfc.utils import namespaces, find_duplicate_ids, slugify
 
 
+SUBSERIES = {
+        'STD': 'Internet Standard',
+        'BCP': 'Best Current Practice',
+        'FYI': 'For Your Information',
+}
+
 DEADLY_ERRORS = [
     'Element svg has extra content: script',
     'Did not expect element script there',

--- a/xml2rfc/writers/preptool.py
+++ b/xml2rfc/writers/preptool.py
@@ -263,6 +263,7 @@ class PrepToolWriter(BaseV3Writer):
         './/boilerplate;insert_copyright_notice()', # 5.4.2.3.  "Copyright Notice" Insertion
         './/boilerplate//section',          # 5.2.7.  Section "toc" attribute
         './/reference;insert_target()',     # 5.4.3.  <reference> "target" Insertion
+        './/referencegroup;insert_target()',        # <referencegroup> "target" Insertion
         './/reference;insert_work_in_progress()',
         './/reference;sort_series_info()',  #         <reference> sort <seriesInfo>
         './/name;insert_slugified_name()',  # 5.4.4.  <name> Slugification
@@ -1215,6 +1216,24 @@ class PrepToolWriter(BaseV3Writer):
         for s in series_info:
             front.insert(pos, s)
             pos += 1
+
+    def referencegroup_insert_target(self, e, p):
+        target_pattern = {
+            "BCP": os.path.join(self.options.info_base_url, 'bcp{value}'),
+            "STD": os.path.join(self.options.info_base_url, 'std{value}'),
+            "FYI": os.path.join(self.options.info_base_url, 'fyi{value}'),
+        }
+
+        if not e.get('target'):
+            for c in e.xpath('.//seriesInfo'):
+                series_name = c.get('name')
+                if series_name in target_pattern.keys():
+                    series_value=c.get('value')
+                    if series_value:
+                        e.set('target', target_pattern[series_name].format(value=series_value))
+                        break
+                    else:
+                        self.err(c, 'Expected a value= attribute value for <seriesInfo name="%s">, but found none' % (series_name, ))
 
     # 
     # 5.4.4.  <name> Slugification


### PR DESCRIPTION
Fixes #1100

With https://github.com/ietf-tools/xml2rfc/pull/1102/commits/205c09c84fb4f204d727ae64c56dab70d61fe768, `xml2rfc` tries to add the correct target for subseries when `referencegroup`'s `target` attribute is missing.

Updated examples:
| Format | Example |
| --- | --- |
| XML | [draft-foobar-00.xml](https://t4.fq.nz/subseries-reference-targets/draft-foobar-00.xml) |
| Text | [draft-foobar-00.txt](https://t4.fq.nz/subseries-reference-targets/draft-foobar-00.txt) |
| HTML | [draft-foobar-00.html](https://t4.fq.nz/subseries-reference-targets/draft-foobar-00.html) |
| PDF | [draft-foobar-00.pdf](https://t4.fq.nz/subseries-reference-targets/draft-foobar-00.pdf) |