### PR TITLE
fix: Allow non-ASCII values in all attributes

### DIFF
--- a/xml2rfc/writers/preptool.py
+++ b/xml2rfc/writers/preptool.py
@@ -439,9 +439,9 @@ class PrepToolWriter(BaseV3Writer):
                     if (c.tag, a) in latinscript_attributes:
                         if not is_script(v, 'Latin'):
                             self.err(c, 'Found non-Latin-script content in <%s> attribute value %s="%s"' % (c.tag, a, v))
-                    else:
+                    if self.options.warn_bare_unicode:
                         if not isascii(v):
-                            self.err(c, 'Found non-ASCII content in <%s> attribute value %s="%s"' % (c.tag, a, v))
+                            self.warn(c, f'Found non-ASCII content in {c.tag} attribute value {a}="{v}" that should be inspected to ensure it is intentional.')
                 if not (c.tag, a) in space_attributes:
                     vv = v.strip()
                     if vv != v:


### PR DESCRIPTION
PR #1017 allowed Unicord characters everywhere.
This fixes a bug that xml2rfc was guarding against non-ASCII characters in attribute values.
With `--warn-bare-unicode`, xml2rfc will warn if non-ASCII characters are present in attribute values.

Fixes #1105