### PR TITLE
ci: Update CodeQL Action to v2

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,12 +21,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: python
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
   tests-linux:
     name: Unit Tests (Linux)


### PR DESCRIPTION
CodeQL Action v1 is deprecated.
See https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/