### PR TITLE
fix(text): Render list items correctly

### DIFF
--- a/tests/input/elements.xml
+++ b/tests/input/elements.xml
@@ -1362,6 +1362,26 @@ for opt, value in opts:
                </artwork>
                <t><xref target="GEDICHTE" format="title"/></t>
             </li>
+            <li>
+              <t>ul with no bullets</t>
+              <ul empty="true">
+                <li>
+                  <ul>
+                    <li>Must not have an empty line with bullet above this line.</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+            <li>
+              <t>ul with bullets</t>
+              <ul>
+                <li>
+                  <ul>
+                    <li>Must have an empty line with bullet above this line.</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
          </ul>
       </section>
    </middle>

--- a/tests/valid/elements.bom.text
+++ b/tests/valid/elements.bom.text
@@ -93,9 +93,9 @@ Table of Contents
        CMS References  . . . . . . . . . . . . . . . . . . . . . . .  25
        ESS References  . . . . . . . . . . . . . . . . . . . . . . .  26
        MIME-SPEC References  . . . . . . . . . . . . . . . . . . . .  26
-       Other References  . . . . . . . . . . . . . . . . . . . . . .  26
+       Other References  . . . . . . . . . . . . . . . . . . . . . .  27
    Appendix A.  Some Back Matter . . . . . . . . . . . . . . . . . .  27
-     A.1.  Contributors  . . . . . . . . . . . . . . . . . . . . . .  27
+     A.1.  Contributors  . . . . . . . . . . . . . . . . . . . . . .  28
      A.2.  Arbitrary^superscript in section _title_  . . . . . . . .  28
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
 
@@ -450,6 +450,7 @@ Author, et al.           Expires 13 January 2019                [Page 8]
 Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
+   4.
        4.1  Sublist with '%p' parent counter element in the list
             counter, item one
 
@@ -497,7 +498,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
       1.  Definition list, third bullet, fifth element: Ordered list,
           element li.  Text only.
-
 
 
 
@@ -1351,12 +1351,22 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    *    Indent="5".  “The heaviest penalty for declining to rule is to
         be ruled by someone inferior to yourself.” Πολιτεία
 
+   *
                      Ich weiß nicht, was soll es bedeuten,
                      Daß ich so traurig bin;
                      Ein Mährchen aus alten Zeiten,
                      Das kommt mir nicht aus dem Sinn.
 
         Dreiunddreißig Gedichte
+
+   *    ul with no bullets
+
+           o  Must not have an empty line with bullet above this line.
+
+   *    ul with bullets
+
+        -
+           o  Must have an empty line with bullet above this line.
 
 References
 
@@ -1379,6 +1389,19 @@ Informative References
 
 CMS References
 
+
+
+
+
+
+
+
+
+Author, et al.           Expires 13 January 2019               [Page 25]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
    [I-D.levkowetz-xml2rfc-v3-implementation-notes]
               Levkowetz, H., "Implementation notes for RFC7991,", Work
               in Progress, Internet-Draft, draft-levkowetz-xml2rfc-v3-
@@ -1394,13 +1417,6 @@ CMS References
    [RFC5652]  Housley, R., "Cryptographic Message Syntax (CMS)", STD 70,
               RFC 5652, DOI 10.17487/RFC5652, September 2009,
               <https://www.rfc-editor.org/info/rfc5652>.
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 25]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
 ESS References
 
@@ -1435,6 +1451,13 @@ MIME-SPEC References
               Examples", RFC 2049, DOI 10.17487/RFC2049, November 1996,
               <https://www.rfc-editor.org/info/rfc2049>.
 
+
+
+Author, et al.           Expires 13 January 2019               [Page 26]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
    [RFC4289]  Freed, N. and J. Klensin, "Multipurpose Internet Mail
               Extensions (MIME) Part Four: Registration Procedures",
               BCP 13, RFC 4289, DOI 10.17487/RFC4289, December 2005,
@@ -1446,17 +1469,6 @@ MIME-SPEC References
               <https://www.rfc-editor.org/info/rfc6838>.
 
 Other References
-
-
-
-
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 26]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
    [AUTHORS]  Πυθαγόρας ὁ Σάμιος (Samos, P. O.), Doe, J., Bergström, A.,
               and J. Doe, "Lots of authors", RFC 7539,
@@ -1493,6 +1505,15 @@ Appendix A.  Some Back Matter
    // This is a long comment line which extends well beyond the
    // 72-character page width.
 
+
+
+
+
+Author, et al.           Expires 13 January 2019               [Page 27]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
 A.1.  Contributors
 
    We'd like to thank these contributors:
@@ -1504,15 +1525,6 @@ A.1.  Contributors
    Israel
 
    Additional contact information:
-
-
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 27]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
       רוני אבן
       וואווי
@@ -1547,6 +1559,17 @@ Authors' Addresses
 
    Additional contact information:
 
+
+
+
+
+
+
+Author, et al.           Expires 13 January 2019               [Page 28]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       רוני אבן
       וואווי
       דוד המלך 14
@@ -1562,13 +1585,6 @@ Authors' Addresses
    Email: hanako.tanaka@nihon.example
 
    Additional contact information:
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 28]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
       田中花子 様
       日本
@@ -1600,22 +1616,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    Sevedstorp 125
    Mariannelund
    Sweden
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/tests/valid/elements.pages.text
+++ b/tests/valid/elements.pages.text
@@ -93,9 +93,9 @@ Table of Contents
        CMS References  . . . . . . . . . . . . . . . . . . . . . . .  25
        ESS References  . . . . . . . . . . . . . . . . . . . . . . .  26
        MIME-SPEC References  . . . . . . . . . . . . . . . . . . . .  26
-       Other References  . . . . . . . . . . . . . . . . . . . . . .  26
+       Other References  . . . . . . . . . . . . . . . . . . . . . .  27
    Appendix A.  Some Back Matter . . . . . . . . . . . . . . . . . .  27
-     A.1.  Contributors  . . . . . . . . . . . . . . . . . . . . . .  27
+     A.1.  Contributors  . . . . . . . . . . . . . . . . . . . . . .  28
      A.2.  Arbitrary^superscript in section _title_  . . . . . . . .  28
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
 
@@ -450,6 +450,7 @@ Author, et al.          Expires January 13, 2019                [Page 8]
 Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
+   4.
        4.1  Sublist with '%p' parent counter element in the list
             counter, item one
 
@@ -497,7 +498,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
       1.  Definition list, third bullet, fifth element: Ordered list,
           element li.  Text only.
-
 
 
 
@@ -1351,12 +1351,22 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    *    Indent="5".  “The heaviest penalty for declining to rule is to
         be ruled by someone inferior to yourself.” Πολιτεία
 
+   *
                      Ich weiß nicht, was soll es bedeuten,
                      Daß ich so traurig bin;
                      Ein Mährchen aus alten Zeiten,
                      Das kommt mir nicht aus dem Sinn.
 
         Dreiunddreißig Gedichte
+
+   *    ul with no bullets
+
+           o  Must not have an empty line with bullet above this line.
+
+   *    ul with bullets
+
+        -
+           o  Must have an empty line with bullet above this line.
 
 References
 
@@ -1379,6 +1389,19 @@ Informative References
 
 CMS References
 
+
+
+
+
+
+
+
+
+Author, et al.          Expires January 13, 2019               [Page 25]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
    [I-D.levkowetz-xml2rfc-v3-implementation-notes]
               Levkowetz, H., "Implementation notes for RFC7991,", Work
               in Progress, Internet-Draft, draft-levkowetz-xml2rfc-v3-
@@ -1394,13 +1417,6 @@ CMS References
    [RFC5652]  Housley, R., "Cryptographic Message Syntax (CMS)", STD 70,
               RFC 5652, DOI 10.17487/RFC5652, September 2009,
               <https://www.rfc-editor.org/info/rfc5652>.
-
-
-
-Author, et al.          Expires January 13, 2019               [Page 25]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
 ESS References
 
@@ -1435,6 +1451,13 @@ MIME-SPEC References
               Examples", RFC 2049, DOI 10.17487/RFC2049, November 1996,
               <https://www.rfc-editor.org/info/rfc2049>.
 
+
+
+Author, et al.          Expires January 13, 2019               [Page 26]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
    [RFC4289]  Freed, N. and J. Klensin, "Multipurpose Internet Mail
               Extensions (MIME) Part Four: Registration Procedures",
               BCP 13, RFC 4289, DOI 10.17487/RFC4289, December 2005,
@@ -1446,17 +1469,6 @@ MIME-SPEC References
               <https://www.rfc-editor.org/info/rfc6838>.
 
 Other References
-
-
-
-
-
-
-
-Author, et al.          Expires January 13, 2019               [Page 26]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
    [AUTHORS]  Πυθαγόρας ὁ Σάμιος (Samos, P. O.), Doe, J., Bergström, A.,
               and J. Doe, "Lots of authors", RFC 7539,
@@ -1493,6 +1505,15 @@ Appendix A.  Some Back Matter
    // This is a long comment line which extends well beyond the
    // 72-character page width.
 
+
+
+
+
+Author, et al.          Expires January 13, 2019               [Page 27]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
 A.1.  Contributors
 
    We'd like to thank these contributors:
@@ -1504,15 +1525,6 @@ A.1.  Contributors
    Israel
 
    Additional contact information:
-
-
-
-
-
-Author, et al.          Expires January 13, 2019               [Page 27]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
       רוני אבן
       וואווי
@@ -1547,6 +1559,17 @@ Authors' Addresses
 
    Additional contact information:
 
+
+
+
+
+
+
+Author, et al.          Expires January 13, 2019               [Page 28]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       רוני אבן
       וואווי
       דוד המלך 14
@@ -1562,13 +1585,6 @@ Authors' Addresses
    Email: hanako.tanaka@nihon.example
 
    Additional contact information:
-
-
-
-Author, et al.          Expires January 13, 2019               [Page 28]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
       田中花子 様
       日本
@@ -1600,22 +1616,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    Sevedstorp 125
    Mariannelund
    Sweden
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/tests/valid/elements.prepped.xml
+++ b/tests/valid/elements.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" submissionType="independent" ipr="trust200902" docName="elements-00" category="info" obsoletes="1234,5678,9012,3456,7890" sortRefs="true" indexInclude="false" prepTime="2024-10-22T23:07:12" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" submissionType="independent" ipr="trust200902" docName="elements-00" category="info" obsoletes="1234,5678,9012,3456,7890" sortRefs="true" indexInclude="false" prepTime="2025-01-12T22:15:49" scripts="Cherokee,Common,Greek,Han,Hebrew,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   
    
    
@@ -1582,6 +1582,26 @@ for opt, value in opts:
                Das kommt mir nicht aus dem Sinn.    
                </artwork>
           <t indent="0" pn="section-17-4.2.2"><xref target="GEDICHTE" format="title" sectionFormat="of" derivedContent="Dreiunddreißig Gedichte"/></t>
+        </li>
+        <li pn="section-17-4.3">
+          <t indent="0" pn="section-17-4.3.1">ul with no bullets</t>
+          <ul empty="true" bare="false" indent="3" spacing="normal" pn="section-17-4.3.2">
+            <li pn="section-17-4.3.2.1">
+              <ul bare="false" empty="false" indent="3" spacing="normal" pn="section-17-4.3.2.1.1">
+                <li pn="section-17-4.3.2.1.1.1">Must not have an empty line with bullet above this line.</li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li pn="section-17-4.4">
+          <t indent="0" pn="section-17-4.4.1">ul with bullets</t>
+          <ul bare="false" empty="false" indent="3" spacing="normal" pn="section-17-4.4.2">
+            <li pn="section-17-4.4.2.1">
+              <ul bare="false" empty="false" indent="3" spacing="normal" pn="section-17-4.4.2.1.1">
+                <li pn="section-17-4.4.2.1.1.1">Must have an empty line with bullet above this line.</li>
+              </ul>
+            </li>
+          </ul>
         </li>
       </ul>
     </section>

--- a/tests/valid/elements.text
+++ b/tests/valid/elements.text
@@ -377,6 +377,7 @@ Table of Contents
           Case Ambiguity [RFC8174], Appendix A.1 / Key Words Case
           Ambiguity [RFC8174] (Appendix A.1).
 
+   4.
        4.1  Sublist with '%p' parent counter element in the list
             counter, item one
 
@@ -1115,12 +1116,22 @@ Unnumbered section
    *    Indent="5".  “The heaviest penalty for declining to rule is to
         be ruled by someone inferior to yourself.” Πολιτεία
 
+   *
                      Ich weiß nicht, was soll es bedeuten,
                      Daß ich so traurig bin;
                      Ein Mährchen aus alten Zeiten,
                      Das kommt mir nicht aus dem Sinn.
 
         Dreiunddreißig Gedichte
+
+   *    ul with no bullets
+
+           o  Must not have an empty line with bullet above this line.
+
+   *    ul with bullets
+
+        -
+           o  Must have an empty line with bullet above this line.
 
 References
 

--- a/tests/valid/elements.v3.html
+++ b/tests/valid/elements.v3.html
@@ -1775,6 +1775,28 @@ for opt, value in opts:
 </div>
 <p id="section-17-4.2.2"><a href="#GEDICHTE" class="internal xref">Dreiunddreißig Gedichte</a><a href="#section-17-4.2.2" class="pilcrow">¶</a></p>
 </li>
+        <li style="margin-left: 0.5em;" class="normal" id="section-17-4.3">
+          <p id="section-17-4.3.1">ul with no bullets<a href="#section-17-4.3.1" class="pilcrow">¶</a></p>
+<ul class="normal ulEmpty">
+<li class="normal ulEmpty" id="section-17-4.3.2.1">
+              <ul class="normal">
+<li class="normal" id="section-17-4.3.2.1.1.1">Must not have an empty line with bullet above this line.<a href="#section-17-4.3.2.1.1.1" class="pilcrow">¶</a>
+</li>
+              </ul>
+</li>
+          </ul>
+</li>
+        <li style="margin-left: 0.5em;" class="normal" id="section-17-4.4">
+          <p id="section-17-4.4.1">ul with bullets<a href="#section-17-4.4.1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-17-4.4.2.1">
+              <ul class="normal">
+<li class="normal" id="section-17-4.4.2.1.1.1">Must have an empty line with bullet above this line.<a href="#section-17-4.4.2.1.1.1" class="pilcrow">¶</a>
+</li>
+              </ul>
+</li>
+          </ul>
+</li>
       </ul>
 </section>
 <div id="references-section">

--- a/tests/valid/elements.wip.text
+++ b/tests/valid/elements.wip.text
@@ -93,9 +93,9 @@ Table of Contents
        CMS References  . . . . . . . . . . . . . . . . . . . . . . .  25
        ESS References  . . . . . . . . . . . . . . . . . . . . . . .  26
        MIME-SPEC References  . . . . . . . . . . . . . . . . . . . .  26
-       Other References  . . . . . . . . . . . . . . . . . . . . . .  26
+       Other References  . . . . . . . . . . . . . . . . . . . . . .  27
    Appendix A.  Some Back Matter . . . . . . . . . . . . . . . . . .  27
-     A.1.  Contributors  . . . . . . . . . . . . . . . . . . . . . .  27
+     A.1.  Contributors  . . . . . . . . . . . . . . . . . . . . . .  28
      A.2.  Arbitrary^superscript in section _title_  . . . . . . . .  28
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
 
@@ -450,6 +450,7 @@ Author, et al.           Expires 13 January 2019                [Page 8]
 Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
 
+   4.
        4.1  Sublist with '%p' parent counter element in the list
             counter, item one
 
@@ -497,7 +498,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
 
       1.  Definition list, third bullet, fifth element: Ordered list,
           element li.  Text only.
-
 
 
 
@@ -1351,12 +1351,22 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    *    Indent="5".  “The heaviest penalty for declining to rule is to
         be ruled by someone inferior to yourself.” Πολιτεία
 
+   *
                      Ich weiß nicht, was soll es bedeuten,
                      Daß ich so traurig bin;
                      Ein Mährchen aus alten Zeiten,
                      Das kommt mir nicht aus dem Sinn.
 
         Dreiunddreißig Gedichte
+
+   *    ul with no bullets
+
+           o  Must not have an empty line with bullet above this line.
+
+   *    ul with bullets
+
+        -
+           o  Must have an empty line with bullet above this line.
 
 References
 
@@ -1379,6 +1389,19 @@ Informative References
 
 CMS References
 
+
+
+
+
+
+
+
+
+Author, et al.           Expires 13 January 2019               [Page 25]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
    [I-D.levkowetz-xml2rfc-v3-implementation-notes]
               Levkowetz, H., "Implementation notes for RFC7991,", Work
               in Progress, Internet-Draft, draft-levkowetz-xml2rfc-v3-
@@ -1394,13 +1417,6 @@ CMS References
    [RFC5652]  Housley, R., "Cryptographic Message Syntax (CMS)", STD 70,
               RFC 5652, DOI 10.17487/RFC5652, September 2009,
               <https://www.rfc-editor.org/info/rfc5652>.
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 25]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
 ESS References
 
@@ -1435,6 +1451,13 @@ MIME-SPEC References
               Examples", RFC 2049, DOI 10.17487/RFC2049, November 1996,
               <https://www.rfc-editor.org/info/rfc2049>.
 
+
+
+Author, et al.           Expires 13 January 2019               [Page 26]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
    [RFC4289]  Freed, N. and J. Klensin, "Multipurpose Internet Mail
               Extensions (MIME) Part Four: Registration Procedures",
               BCP 13, RFC 4289, DOI 10.17487/RFC4289, December 2005,
@@ -1446,17 +1469,6 @@ MIME-SPEC References
               <https://www.rfc-editor.org/info/rfc6838>.
 
 Other References
-
-
-
-
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 26]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
    [AUTHORS]  Πυθαγόρας ὁ Σάμιος (Samos, P. O.), Doe, J., Bergström, A.,
               and J. Doe, "Lots of authors", RFC 7539,
@@ -1493,6 +1505,15 @@ Appendix A.  Some Back Matter
    // This is a long comment line which extends well beyond the
    // 72-character page width.
 
+
+
+
+
+Author, et al.           Expires 13 January 2019               [Page 27]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
 A.1.  Contributors
 
    We'd like to thank these contributors:
@@ -1504,15 +1525,6 @@ A.1.  Contributors
    Israel
 
    Additional contact information:
-
-
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 27]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
       רוני אבן
       וואווי
@@ -1547,6 +1559,17 @@ Authors' Addresses
 
    Additional contact information:
 
+
+
+
+
+
+
+Author, et al.           Expires 13 January 2019               [Page 28]
+
+Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
+
+
       רוני אבן
       וואווי
       דוד המלך 14
@@ -1562,13 +1585,6 @@ Authors' Addresses
    Email: hanako.tanaka@nihon.example
 
    Additional contact information:
-
-
-
-Author, et al.           Expires 13 January 2019               [Page 28]
-
-Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
-
 
       田中花子 様
       日本
@@ -1600,22 +1616,6 @@ Internet-Draft       Xml2rfc Vocabulary V3 Elements            July 2018
    Sevedstorp 125
    Mariannelund
    Sweden
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          January 10, 2025
+Internet-Draft                                          January 12, 2025
 Intended status: Experimental                                           
-Expires: July 14, 2025
+Expires: July 16, 2025
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 14, 2025.
+   This Internet-Draft will expire on July 16, 2025.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                    Expires July 14, 2025                 [Page 1]
+Person                    Expires July 16, 2025                 [Page 1]
 
 Internet-Draft             xml2rfc index tests              January 2025
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                    Expires July 14, 2025                 [Page 2]
+Person                    Expires July 16, 2025                 [Page 2]
 
 Internet-Draft             xml2rfc index tests              January 2025
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                    Expires July 14, 2025                 [Page 3]
+Person                    Expires July 16, 2025                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2025-01-10T04:34:27" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2025-01-12T22:11:58" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.25.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="10" month="01" year="2025"/>
+    <date day="12" month="01" year="2025"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 14 July 2025.
+        This Internet-Draft will expire on 16 July 2025.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          January 10, 2025
+Internet-Draft                                          January 12, 2025
 Intended status: Experimental                                           
-Expires: July 14, 2025
+Expires: July 16, 2025
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 14, 2025.
+   This Internet-Draft will expire on July 16, 2025.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires July 14, 2025</td>
+<td class="center">Expires July 16, 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2025-01-10" class="published">January 10, 2025</time>
+<time datetime="2025-01-12" class="published">January 12, 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-07-14">July 14, 2025</time></dd>
+<dd class="expires"><time datetime="2025-07-16">July 16, 2025</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on July 14, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on July 16, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                         10 January 2025
+                                                         12 January 2025
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          January 10, 2025
+Internet-Draft                                          January 12, 2025
 Intended status: Experimental                                           
-Expires: July 14, 2025
+Expires: July 16, 2025
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 14, 2025.
+   This Internet-Draft will expire on July 16, 2025.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                    Expires July 14, 2025                 [Page 1]
+Person                    Expires July 16, 2025                 [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2025
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests            January 2025
 
 
 
-Person                    Expires July 14, 2025                 [Page 2]
+Person                    Expires July 16, 2025                 [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2025
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests            January 2025
 
 
 
-Person                    Expires July 14, 2025                 [Page 3]
+Person                    Expires July 16, 2025                 [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2025
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                    Expires July 14, 2025                 [Page 4]
+Person                    Expires July 16, 2025                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2025-01-10T04:34:37" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2025-01-12T22:12:08" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.25.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="10" month="01" year="2025"/>
+    <date day="12" month="01" year="2025"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 14 July 2025.
+        This Internet-Draft will expire on 16 July 2025.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          January 10, 2025
+Internet-Draft                                          January 12, 2025
 Intended status: Experimental                                           
-Expires: July 14, 2025
+Expires: July 16, 2025
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 14, 2025.
+   This Internet-Draft will expire on July 16, 2025.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires July 14, 2025</td>
+<td class="center">Expires July 16, 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2025-01-10" class="published">January 10, 2025</time>
+<time datetime="2025-01-12" class="published">January 12, 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-07-14">July 14, 2025</time></dd>
+<dd class="expires"><time datetime="2025-07-16">July 16, 2025</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on July 14, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on July 16, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/writers/text.py
+++ b/xml2rfc/writers/text.py
@@ -2152,12 +2152,21 @@ class TextWriter(BaseV3Writer):
         tt, __ = self.text_or_block_renderer(e, width, **kwargs)
         if isinstance(tt, list):
             lines = stripl(tt)
+            children = e.getchildren()
             if (
-                lines
-                and lines[0].elem.tag not in ["artwork", "figure", "sourcecode"]
-                and not (p.tag == "ul" and lines[0].elem.tag == "li")
+                children
+                and children[0].tag in ["artwork", "figure", "sourcecode", "ol", "ul"]
+                and not (p.tag == "ul" and p.get("empty", "false").lower() == "true")
             ):
-                lines[0].text = text + lines[0].text.lstrip(stripspace)
+                 lines.insert(0, Line(text.rstrip(stripspace), e))
+            else:
+                if lines and lines[0].elem.tag not in [
+                    "artwork",
+                    "figure",
+                    "sourcecode",
+                    "li",
+                ]:
+                    lines[0].text = text + lines[0].text.lstrip(stripspace)
         else:
             text += tt.lstrip(stripspace)
             lines = mklines(text, e)

--- a/xml2rfc/writers/text.py
+++ b/xml2rfc/writers/text.py
@@ -2152,7 +2152,11 @@ class TextWriter(BaseV3Writer):
         tt, __ = self.text_or_block_renderer(e, width, **kwargs)
         if isinstance(tt, list):
             lines = stripl(tt)
-            if lines and lines[0].elem.tag not in ['artwork', 'figure', 'sourcecode', 'li', ]:
+            if (
+                lines
+                and lines[0].elem.tag not in ["artwork", "figure", "sourcecode"]
+                and not (p.tag == "ul" and lines[0].elem.tag == "li")
+            ):
                 lines[0].text = text + lines[0].text.lstrip(stripspace)
         else:
             text += tt.lstrip(stripspace)


### PR DESCRIPTION
Fixes #1135
Fixes #1138 

See changes made in https://github.com/ietf-tools/xml2rfc/commit/3712523cb325bb43b1b164e833dd436c1c62a295 for context.

This change can affect if `ol` is used inside a `li` as the first element and the `li` element is inside another `ol` element. 

I could not find any published RFCs with XML that match the above condition.

These are the RFCs that I found that use `ol` as the first element in `li`:
 * RFC8679
 * RFC8687

I didn't notice any changes in text output due to this change. But there are a few minor changes (with spacing) due to changes over the years.

