### PR TITLE
build: Update pydyf version requirement

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -83,7 +83,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==61.2" "pydyf<0.11.0"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==61.2" "pydyf<0.10.0"
         
     - name: Generate Valid Tests
       run: |
@@ -135,7 +135,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing requirements.txt + test dependencies..."
-        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==61.2" "pydyf<0.11.0"
+        python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==61.2" "pydyf<0.10.0"
         
     - name: Generate Valid Tests
       run: |
@@ -185,7 +185,7 @@ jobs:
 #         echo "Installing pip + wheel..."
 #         python -m pip install --upgrade pip wheel
 #         echo "Installing requirements.txt + test dependencies..."
-#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==61.2" "pydyf<0.11.0"
+#         python -m pip install -r requirements.txt tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==61.2" "pydyf<0.10.0"
 #     - name: Generate Valid Tests
 #       run: |
 #         make yestests || true

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ console_scripts =
 
 [options.extras_require]
 pdf = weasyprint==61.2
-      pydyf<0.11.0
+      pydyf<0.10.0
 
 [bdist_wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,4 @@ deps =
     dict2xml
     pypdf>=4.1.0
     weasyprint==61.2
-    pydyf<0.11.0
+    pydyf<0.10.0


### PR DESCRIPTION
Weasyprint `61.2` requires `pydyf >= 0.8.0`.
Since `pydyf < 0.10.0` is best suited for us right now.