### PR TITLE
fix(pdf): Fix line height issue with superscripts

### DIFF
--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -166,6 +166,9 @@ page_css_template = """
   tt, code, pre {{
     font-family: {mono-fonts};
   }}
+  sup {{
+    line-height: 0;
+  }}
   @page {{
     size: A4;
     font-size: 12px; /* needed for the page header and footer text */


### PR DESCRIPTION
Fixes #1160

Suggested by @liZe. [^1]

This fixes the line height issue documented wide.

Screenshots:

RFC 9421:
<img width="851" alt="Screenshot 2024-11-07 at 11 31 08" src="https://github.com/user-attachments/assets/76ba6300-c2b8-4ef2-a55d-ab6899d3dc3c">

RFC 9591:
<img width="852" alt="Screenshot 2024-11-07 at 11 32 26" src="https://github.com/user-attachments/assets/e60909f4-ee3c-486c-a176-a6aec1f98fd3">

[^1]: https://github.com/Kozea/WeasyPrint/issues/2253#issuecomment-2353951920