### PR TITLE
feat: Add option to update datatracker references

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -5616,7 +5616,7 @@ start |= rfc
         </h3>
 <p id="appendix-B.3-1">
                One or more of the following output formats may be specified. The default is --text. The destination filename will be based on the input filename, unless --out=FILE or --basename=BASE is used.
-               The group has 10 options.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+               The group has 11 options.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-B.3-2">
           <dt id="appendix-B.3-2.1">
 <div id="option--text">
@@ -5673,39 +5673,48 @@ start |= rfc
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.3-2.13">
-<div id="option--v2v3">
-<code>--v2v3</code>                    </div>
+<div id="option--use-bib">
+<code>--use-bib</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.3-2.14">
             <p id="appendix-B.3-2.14.1">
-                          Convert vocabulary version 2 XML to version 3.<a href="#appendix-B.3-2.14.1" class="pilcrow">¶</a></p>
+                          Update all datatracker references with bib.ietf.org.<a href="#appendix-B.3-2.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.3-2.15">
-<div id="option--preptool">
-<code>--preptool</code>                    </div>
+<div id="option--v2v3">
+<code>--v2v3</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.3-2.16">
             <p id="appendix-B.3-2.16.1">
-                          Run preptool on the input.<a href="#appendix-B.3-2.16.1" class="pilcrow">¶</a></p>
+                          Convert vocabulary version 2 XML to version 3.<a href="#appendix-B.3-2.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.3-2.17">
-<div id="option--unprep">
-<code>--unprep</code>                    </div>
+<div id="option--preptool">
+<code>--preptool</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.3-2.18">
             <p id="appendix-B.3-2.18.1">
-                          Reduce prepped xml to unprepped.<a href="#appendix-B.3-2.18.1" class="pilcrow">¶</a></p>
+                          Run preptool on the input.<a href="#appendix-B.3-2.18.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
 <dt id="appendix-B.3-2.19">
-<div id="option--info">
-<code>--info</code>                    </div>
+<div id="option--unprep">
+<code>--unprep</code>                    </div>
           </dt>
 <dd style="margin-left: 1.5em" id="appendix-B.3-2.20">
             <p id="appendix-B.3-2.20.1">
-                          Generate a JSON file with anchor to section lookup information.<a href="#appendix-B.3-2.20.1" class="pilcrow">¶</a></p>
+                          Reduce prepped xml to unprepped.<a href="#appendix-B.3-2.20.1" class="pilcrow">¶</a></p>
+</dd>
+          <dd class="break"></dd>
+<dt id="appendix-B.3-2.21">
+<div id="option--info">
+<code>--info</code>                    </div>
+          </dt>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.22">
+            <p id="appendix-B.3-2.22.1">
+                          Generate a JSON file with anchor to section lookup information.<a href="#appendix-B.3-2.22.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>

--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.24.0</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.25.0</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.24.0" name="generator">
-<meta content="xml2rfc-docs-3.24.0" name="ietf.draft">
+<meta content="xml2rfc 3.25.0" name="generator">
+<meta content="xml2rfc-docs-3.25.0" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">November 2024</td>
+<td class="right">December 2024</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-11-14" class="published">14 November 2024</time>
+<time datetime="2024-12-04" class="published">4 December 2024</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
@@ -49,7 +49,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.24.0</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.25.0</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -371,7 +371,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://ietf-tools.github.io/xml2rfc/">https://ietf-tools.github.io/xml2rfc/</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.24.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.25.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6387,7 +6387,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.24.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.25.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.24.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -26,7 +26,7 @@
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.24.0
+  xml2rfc 3.25.0
     Python 3.12.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.1

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -11,11 +11,11 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.24.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.24.0
+  xml2rfc 3.25.0
     Python 3.12.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.1

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                         November 14, 2024
+Internet-Draft                                          December 4, 2024
 Intended status: Experimental                                           
-Expires: May 18, 2025
+Expires: June 7, 2025
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 18, 2025.
+   This Internet-Draft will expire on June 7, 2025.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                    Expires May 18, 2025                  [Page 1]
+Person                    Expires June 7, 2025                  [Page 1]
 
-Internet-Draft             xml2rfc index tests             November 2024
+Internet-Draft             xml2rfc index tests             December 2024
 
 
    This is another section!
@@ -109,9 +109,9 @@ Index
 
 
 
-Person                    Expires May 18, 2025                  [Page 2]
+Person                    Expires June 7, 2025                  [Page 2]
 
-Internet-Draft             xml2rfc index tests             November 2024
+Internet-Draft             xml2rfc index tests             December 2024
 
 
       E
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                    Expires May 18, 2025                  [Page 3]
+Person                    Expires June 7, 2025                  [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2024-11-14T10:46:57" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.24.0 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2024-12-04T00:11:42" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.25.0 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="14" month="11" year="2024"/>
+    <date day="04" month="12" year="2024"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 18 May 2025.
+        This Internet-Draft will expire on 7 June 2025.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                         November 14, 2024
+Internet-Draft                                          December 4, 2024
 Intended status: Experimental                                           
-Expires: May 18, 2025
+Expires: June 7, 2025
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 18, 2025.
+   This Internet-Draft will expire on June 7, 2025.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.24.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">November 2024</td>
+<td class="right">December 2024</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires May 18, 2025</td>
+<td class="center">Expires June 7, 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-11-14" class="published">November 14, 2024</time>
+<time datetime="2024-12-04" class="published">December 4, 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-05-18">May 18, 2025</time></dd>
+<dd class="expires"><time datetime="2025-06-07">June 7, 2025</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on May 18, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on June 7, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,10 +1,10 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                        14 November 2024
+                                                         4 December 2024
 
 
                   Xml2rfc Vocabulary Version 3 Schema
-                         xml2rfc release 3.24.0
-                          xml2rfc-docs-3.24.0
+                         xml2rfc release 3.25.0
+                          xml2rfc-docs-3.25.0
 
 Abstract
 
@@ -54,7 +54,7 @@ Table of Contents
    The latest version of this documentation is available in HTML form at
    https://ietf-tools.github.io/xml2rfc/.
 
-   This documentation applies to xml2rfc version 3.24.0.
+   This documentation applies to xml2rfc version 3.25.0.
 
 2.  Schema Version 3 Elements
 
@@ -4336,7 +4336,7 @@ Appendix C.  xml2rfc Configuration Files
 Appendix D.  xml2rfc Documentation Template Variables
 
    The following variables are available for use in an xml2rfc manpage
-   Jinja2 template, as of xml2rfc version 3.24.0:
+   Jinja2 template, as of xml2rfc version 3.25.0:
 
    {{ bare_latin_tags }}:
 

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -3985,7 +3985,7 @@ B.3.  Format selection
    One or more of the following output formats may be specified.  The
    default is --text.  The destination filename will be based on the
    input filename, unless --out=FILE or --basename=BASE is used.  The
-   group has 10 options.
+   group has 11 options.
 
    --text
       Outputs formatted text to file, with proper page breaks.
@@ -4004,6 +4004,9 @@ B.3.  Format selection
 
    --expand
       Outputs XML to file with all references expanded.
+
+   --use-bib
+      Update all datatracker references with bib.ietf.org.
 
    --v2v3
       Convert vocabulary version 2 XML to version 3.

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -16,10 +16,10 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.24.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="7911" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.24.0
+  xml2rfc 3.25.0
     Python 3.12.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.1

--- a/tests/valid/rfc99999.html
+++ b/tests/valid/rfc99999.html
@@ -9,10 +9,10 @@
 <meta content="
        This is not a real RFC. 
     " name="description">
-<meta content="xml2rfc 3.24.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="99999" name="rfc.number">
 <!-- Generator version information:
-  xml2rfc 3.24.0
+  xml2rfc 3.25.0
     Python 3.12.7
     ConfigArgParse 1.7
     google-i18n-address 3.1.1

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                         November 14, 2024
+Internet-Draft                                          December 4, 2024
 Intended status: Experimental                                           
-Expires: May 18, 2025
+Expires: June 7, 2025
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 18, 2025.
+   This Internet-Draft will expire on June 7, 2025.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                    Expires May 18, 2025                  [Page 1]
+Person                    Expires June 7, 2025                  [Page 1]
 
-Internet-Draft          xml2rfc sourcecode tests           November 2024
+Internet-Draft          xml2rfc sourcecode tests           December 2024
 
 
    print("01")
@@ -109,9 +109,9 @@ Internet-Draft          xml2rfc sourcecode tests           November 2024
 
 
 
-Person                    Expires May 18, 2025                  [Page 2]
+Person                    Expires June 7, 2025                  [Page 2]
 
-Internet-Draft          xml2rfc sourcecode tests           November 2024
+Internet-Draft          xml2rfc sourcecode tests           December 2024
 
 
    print("49")
@@ -165,9 +165,9 @@ Internet-Draft          xml2rfc sourcecode tests           November 2024
 
 
 
-Person                    Expires May 18, 2025                  [Page 3]
+Person                    Expires June 7, 2025                  [Page 3]
 
-Internet-Draft          xml2rfc sourcecode tests           November 2024
+Internet-Draft          xml2rfc sourcecode tests           December 2024
 
 
    print("47")
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                    Expires May 18, 2025                  [Page 4]
+Person                    Expires June 7, 2025                  [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2024-11-14T10:47:08" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.24.0 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2024-12-04T00:11:52" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.25.0 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="14" month="11" year="2024"/>
+    <date day="04" month="12" year="2024"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 18 May 2025.
+        This Internet-Draft will expire on 7 June 2025.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                         November 14, 2024
+Internet-Draft                                          December 4, 2024
 Intended status: Experimental                                           
-Expires: May 18, 2025
+Expires: June 7, 2025
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 18, 2025.
+   This Internet-Draft will expire on June 7, 2025.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.24.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc sourcecode tests</td>
-<td class="right">November 2024</td>
+<td class="right">December 2024</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires May 18, 2025</td>
+<td class="center">Expires June 7, 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-11-14" class="published">November 14, 2024</time>
+<time datetime="2024-12-04" class="published">December 4, 2024</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-05-18">May 18, 2025</time></dd>
+<dd class="expires"><time datetime="2025-06-07">June 7, 2025</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on May 18, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on June 7, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/__init__.py
+++ b/xml2rfc/__init__.py
@@ -16,7 +16,7 @@ from xml2rfc.parser import  XmlRfcError, CachingResolver, XmlRfcParser, XmlRfc
 from xml2rfc.writers import ( BaseRfcWriter, RawTextRfcWriter, PaginatedTextRfcWriter,
 	 HtmlRfcWriter, NroffRfcWriter, ExpandedXmlWriter, RfcWriterError,
          V2v3XmlWriter, PrepToolWriter, TextWriter, HtmlWriter, PdfWriter,
-         ExpandV3XmlWriter, UnPrepWriter, DocWriter
+         ExpandV3XmlWriter, UnPrepWriter, DocWriter, DatatrackerToBibConverter,
      )
 
 # This defines what 'from xml2rfc import *' actually imports:
@@ -25,7 +25,7 @@ __all__ = ['XmlRfcError', 'CachingResolver', 'XmlRfcParser', 'XmlRfc',
            'HtmlRfcWriter', 'NroffRfcWriter', 'ExpandedXmlWriter',
            'RfcWriterError', 'V2v3XmlWriter', 'PrepToolWriter', 'TextWriter',
            'HtmlWriter', 'PdfWriter', 'ExpandV3XmlWriter', 'UnPrepWriter', 
-           'DocWriter',
+           'DocWriter', 'DatatrackerToBibConverter',
        ]
 
 try:

--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -198,6 +198,8 @@ def main():
                            help='outputs formatted text to file, unpaginated (only v2 input)')
     formatgroup.add_argument('--expand', action='store_true',
                            help='outputs XML to file with all references expanded')
+    formatgroup.add_argument('--use-bib', action='store_true',
+                           help='update all datatracker references with bib.ietf.org')
     formatgroup.add_argument('--v2v3', action='store_true',
                            help='convert vocabulary version 2 XML to version 3')
     formatgroup.add_argument('--preptool', action='store_true',
@@ -456,7 +458,7 @@ def main():
             options.output_path = options.basename
             options.basename = None
     #
-    num_formats = len([ o for o in [options.raw, options.text, options.nroff, options.html, options.expand, options.v2v3, options.preptool, options.info, options.pdf, options.unprep ] if o])
+    num_formats = len([ o for o in [options.raw, options.text, options.nroff, options.html, options.expand, options.use_bib, options.v2v3, options.preptool, options.info, options.pdf, options.unprep ] if o])
     if num_formats > 1 and (options.filename or options.output_filename):
         sys.exit('Cannot use an explicit output filename when generating more than one format, '
                  'use --path instead.')
@@ -662,6 +664,15 @@ def main():
             options.output_filename = None
 
         # --- End of legacy formatter invocations ---
+        if options.use_bib:
+            xmlrfc = parser.parse(remove_comments=False, quiet=True, normalize=False, strip_cdata=False, add_xmlns=True)
+            filename = options.output_filename
+            if not filename:
+                filename = basename + '.bib.xml'
+                options.output_filename = filename
+            expander = xml2rfc.DatatrackerToBibConverter(xmlrfc, options=options, date=options.date)
+            expander.write(filename)
+            options.output_filename = None
 
         if options.expand and not options.legacy:
             xmlrfc = parser.parse(remove_comments=False, quiet=True, normalize=False, strip_cdata=False, add_xmlns=True)

--- a/xml2rfc/writers/__init__.py
+++ b/xml2rfc/writers/__init__.py
@@ -14,11 +14,12 @@ from xml2rfc.writers.expand import ExpandV3XmlWriter
 from xml2rfc.writers.pdf import PdfWriter
 from xml2rfc.writers.unprep import UnPrepWriter
 from xml2rfc.writers.doc import DocWriter
+from xml2rfc.writers.bib import DatatrackerToBibConverter
 
 # This defines what 'from xml2rfc.writers import *' actually imports:
 __all__ = ['BaseRfcWriter', 'RawTextRfcWriter', 'PaginatedTextRfcWriter',
            'HtmlRfcWriter', 'NroffRfcWriter', 'ExpandedXmlWriter',
            'RfcWriterError', 'V2v3XmlWriter', 'PrepToolWriter', 'TextWriter',
            'HtmlWriter', 'PdfWriter', 'ExpandV3XmlWriter', 'UnPrepWriter', 
-           'DocWriter',
+           'DocWriter', 'DatatrackerToBibConverter',
        ]

--- a/xml2rfc/writers/base.py
+++ b/xml2rfc/writers/base.py
@@ -117,6 +117,7 @@ default_options.__dict__ = {
         'template_dir': os.path.join(os.path.dirname(os.path.dirname(__file__)), 'templates'),
         'text': True,
         'unprep': False,
+        'use_bib': False,
         'utf8': False,
         'values': False,
         'verbose': False,

--- a/xml2rfc/writers/bib.py
+++ b/xml2rfc/writers/bib.py
@@ -1,0 +1,43 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, division
+
+from io import open
+from lxml import etree
+from urllib.parse import urlparse
+
+from xml2rfc.writers.preptool import PrepToolWriter
+
+
+class DatatrackerToBibConverter(PrepToolWriter):
+    """Writes a duplicate XML file but with datratracker references replaced with bib.ietf.org"""
+
+    def write(self, filename):
+        """Public method to write the XML document to a file"""
+        self.convert()
+        with open(filename, "w", encoding="utf-8") as file:
+            text = etree.tostring(self.tree, encoding="unicode")
+            file.write("<?xml version='1.0' encoding='utf-8'?>\n")
+            file.write(text)
+            if not self.options.quiet:
+                self.log(" Created file %s" % filename)
+
+    def convert(self):
+        version = self.root.get("version", "3")
+        if version not in [
+            "3",
+        ]:
+            self.die(self.root, 'Expected <rfc> version="3", but found "%s"' % version)
+        self.convert_xincludes()
+
+    def convert_xincludes(self):
+        ns = {"xi": b"http://www.w3.org/2001/XInclude"}
+        xincludes = self.root.xpath("//xi:include", namespaces=ns)
+        for xinclude in xincludes:
+            href = urlparse(xinclude.get("href"))
+
+            if href.netloc == "datatracker.ietf.org":
+                reference_file = href.path.split("/")[-1]
+                xinclude.set(
+                    "href", f"https://bib.ietf.org/public/rfc/bibxml-ids/{reference_file}"
+                )


### PR DESCRIPTION
With the new command line option `--use-bib`, xinclude with `datatracker.ietf.org` is replaced with `bib.ietf.org`.

Fixes #1167