### PR TITLE
fix(html): Use basename for alternative link

### DIFF
--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">December 2024</td>
+<td class="right">January 2025</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -39,7 +39,7 @@
 <dd class="workgroup">xml2rfc(1)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-12-04" class="published">4 December 2024</time>
+<time datetime="2025-01-10" class="published">10 January 2025</time>
     </dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">

--- a/tests/valid/docfile.html
+++ b/tests/valid/docfile.html
@@ -13,7 +13,7 @@
     " name="description">
 <meta content="xml2rfc 3.25.0" name="generator">
 <meta content="xml2rfc-docs-3.25.0" name="ietf.draft">
-<link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
+<link href="docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/draft-miek-test.html
+++ b/tests/valid/draft-miek-test.html
@@ -42,7 +42,7 @@
     wcwidth 0.2.13
     weasyprint 61.2
 -->
-<link href="tests/input/draft-miek-test.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-miek-test.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 

--- a/tests/valid/draft-miek-test.v3.html
+++ b/tests/valid/draft-miek-test.v3.html
@@ -16,7 +16,7 @@
             This version is adapted to work with "xml2rfc" version 2.x.  
        
     ' name="description">
-<meta content="xml2rfc 3.18.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="RFC" name="keyword">
 <meta content="Request for Comments" name="keyword">
 <meta content="I-D" name="keyword">
@@ -25,7 +25,7 @@
 <meta content="Pandoc" name="keyword">
 <meta content="Extensible Markup Language" name="keyword">
 <meta content="draft-gieben-writing-rfcs-pandoc-02" name="ietf.draft">
-<link href="tests/input/draft-miek-test.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-miek-test.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/draft-template.html
+++ b/tests/valid/draft-template.html
@@ -31,7 +31,7 @@
     wcwidth 0.2.13
     weasyprint 61.2
 -->
-<link href="tests/input/draft-template.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-template.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 

--- a/tests/valid/draft-template.v3.html
+++ b/tests/valid/draft-template.v3.html
@@ -11,10 +11,10 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.18.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
-<link href="tests/input/draft-template.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-template.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">
@@ -921,7 +921,7 @@ main(int argc, char *argv[])
 <dl class="references">
 <dt id="DOI_10.1145_2975159">[DOI_10.1145_2975159]</dt>
         <dd>
-<span class="refAuthor">Singh, A.</span>, <span class="refAuthor">Ong, J.</span>, <span class="refAuthor">Agarwal, A.</span>, <span class="refAuthor">Anderson, G.</span>, <span class="refAuthor">Armistead, A.</span>, <span class="refAuthor">Bannon, R.</span>, <span class="refAuthor">Boving, S.</span>, <span class="refAuthor">Desai, G.</span>, <span class="refAuthor">Felderman, B.</span>, <span class="refAuthor">Germano, P.</span>, <span class="refAuthor">Kanagala, A.</span>, <span class="refAuthor">Liu, H.</span>, <span class="refAuthor">Provost, J.</span>, <span class="refAuthor">Simmons, J.</span>, <span class="refAuthor">Tanda, E.</span>, <span class="refAuthor">Wanderer, J.</span>, <span class="refAuthor">Hölzle, U.</span>, <span class="refAuthor">Stuart, S.</span>, <span class="refAuthor">Vahdat, A.</span>, and <span class="refAuthor">Association for Computing Machinery (ACM)</span>, <span class="refTitle">"Jupiter rising"</span>, <span class="refContent">Communications of the ACM, vol. 59, no. 9, pp. 88-97</span>, <span class="seriesInfo">DOI 10.1145/2975159</span>, <time datetime="2016-08-24" class="refDate">August 24, 2016</time>, <span>&lt;<a href="http://dx.doi.org/10.1145/2975159">http://dx.doi.org/10.1145/2975159</a>&gt;</span>. </dd>
+<span class="refAuthor">Singh, A.</span>, <span class="refAuthor">Ong, J.</span>, <span class="refAuthor">Agarwal, A.</span>, <span class="refAuthor">Anderson, G.</span>, <span class="refAuthor">Armistead, A.</span>, <span class="refAuthor">Bannon, R.</span>, <span class="refAuthor">Boving, S.</span>, <span class="refAuthor">Desai, G.</span>, <span class="refAuthor">Felderman, B.</span>, <span class="refAuthor">Germano, P.</span>, <span class="refAuthor">Kanagala, A.</span>, <span class="refAuthor">Liu, H.</span>, <span class="refAuthor">Provost, J.</span>, <span class="refAuthor">Simmons, J.</span>, <span class="refAuthor">Tanda, E.</span>, <span class="refAuthor">Wanderer, J.</span>, <span class="refAuthor">Hölzle, U.</span>, <span class="refAuthor">Stuart, S.</span>, <span class="refAuthor">Vahdat, A.</span>, and <span class="refAuthor">Association for Computing Machinery (ACM)</span>, <span class="refTitle">"Jupiter rising"</span>, <span class="refContent">Communications of the ACM, vol. 59, no. 9, pp. 88-97</span>, <span class="seriesInfo">DOI 10.1145/2975159</span>, <time datetime="2016-08-24" class="refDate">August 24, 2016</time>, <span>&lt;<a href="https://doi.org/10.1145/2975159">https://doi.org/10.1145/2975159</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="DOMINATION">[DOMINATION]</dt>
         <dd>

--- a/tests/valid/draft-v3-features.v3.html
+++ b/tests/valid/draft-v3-features.v3.html
@@ -13,9 +13,9 @@
         This document tests features introduced in xml2rfc v3 vocabulary.
        
     " name="description">
-<meta content="xml2rfc 3.19.4" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="draft-v3-features" name="ietf.draft">
-<link href="tests/input/draft-v3-features.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-v3-features.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/elements.v3.html
+++ b/tests/valid/elements.v3.html
@@ -15,9 +15,9 @@
 <meta content="
        This is the abstract. 
     " name="description">
-<meta content="xml2rfc 3.22.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="elements-00" name="ietf.draft">
-<link href="tests/input/elements.xml" rel="alternate" type="application/rfc+xml">
+<link href="elements.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          December 4, 2024
+Internet-Draft                                          January 10, 2025
 Intended status: Experimental                                           
-Expires: June 7, 2025
+Expires: July 14, 2025
 
 
                           xml2rfc index tests
@@ -26,11 +26,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 7, 2025.
+   This Internet-Draft will expire on July 14, 2025.
 
 Copyright Notice
 
-   Copyright (c) 2024 IETF Trust and the persons identified as the
+   Copyright (c) 2025 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                    Expires June 7, 2025                  [Page 1]
+Person                    Expires July 14, 2025                 [Page 1]
 
-Internet-Draft             xml2rfc index tests             December 2024
+Internet-Draft             xml2rfc index tests              January 2025
 
 
    This is another section!
@@ -109,9 +109,9 @@ Index
 
 
 
-Person                    Expires June 7, 2025                  [Page 2]
+Person                    Expires July 14, 2025                 [Page 2]
 
-Internet-Draft             xml2rfc index tests             December 2024
+Internet-Draft             xml2rfc index tests              January 2025
 
 
       E
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                    Expires June 7, 2025                  [Page 3]
+Person                    Expires July 14, 2025                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2024-12-04T00:11:42" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2025-01-10T04:34:27" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.25.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="04" month="12" year="2024"/>
+    <date day="10" month="01" year="2025"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,13 +41,13 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 7 June 2025.
+        This Internet-Draft will expire on 14 July 2025.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">
         <name slugifiedName="name-copyright-notice">Copyright Notice</name>
         <t indent="0" pn="section-boilerplate.2-1">
-            Copyright (c) 2024 IETF Trust and the persons identified as the
+            Copyright (c) 2025 IETF Trust and the persons identified as the
             document authors. All rights reserved.
         </t>
         <t indent="0" pn="section-boilerplate.2-2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          December 4, 2024
+Internet-Draft                                          January 10, 2025
 Intended status: Experimental                                           
-Expires: June 7, 2025
+Expires: July 14, 2025
 
 
                           xml2rfc index tests
@@ -26,11 +26,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 7, 2025.
+   This Internet-Draft will expire on July 14, 2025.
 
 Copyright Notice
 
-   Copyright (c) 2024 IETF Trust and the persons identified as the
+   Copyright (c) 2025 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">December 2024</td>
+<td class="right">January 2025</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires June 7, 2025</td>
+<td class="center">Expires July 14, 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-12-04" class="published">December 4, 2024</time>
+<time datetime="2025-01-10" class="published">January 10, 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-06-07">June 7, 2025</time></dd>
+<dd class="expires"><time datetime="2025-07-14">July 14, 2025</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on June 7, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on July 14, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -80,7 +80,7 @@
 <a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
-            Copyright (c) 2024 IETF Trust and the persons identified as the
+            Copyright (c) 2025 IETF Trust and the persons identified as the
             document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.2-2">
             This document is subject to BCP 78 and the IETF Trust's Legal

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -8,7 +8,7 @@
 <meta content="Human Person" name="author">
 <meta content="xml2rfc 3.25.0" name="generator">
 <meta content="indexes-00" name="ietf.draft">
-<link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
+<link href="indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                         4 December 2024
+                                                         10 January 2025
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/no-toc.v3.html
+++ b/tests/valid/no-toc.v3.html
@@ -9,9 +9,9 @@
 <meta content="
        Test no ToC 
     " name="description">
-<meta content="xml2rfc 3.13.1" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="draft-no-toc-test-00" name="ietf.draft">
-<link href="tests/input/no-toc.xml" rel="alternate" type="application/rfc+xml">
+<link href="no-toc.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/rfc7911.html
+++ b/tests/valid/rfc7911.html
@@ -35,7 +35,7 @@
     wcwidth 0.2.13
     weasyprint 61.2
 -->
-<link href="tests/input/rfc7911.xml" rel="alternate" type="application/rfc+xml">
+<link href="rfc7911.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 

--- a/tests/valid/rfc7911.v3.html
+++ b/tests/valid/rfc7911.v3.html
@@ -16,9 +16,9 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.18.0" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="7911" name="rfc.number">
-<link href="tests/input/rfc7911.xml" rel="alternate" type="application/rfc+xml">
+<link href="rfc7911.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/rfc9001.canonical.html
+++ b/tests/valid/rfc9001.canonical.html
@@ -11,12 +11,12 @@
        This document describes how Transport Layer Security (TLS) is used to secure
 QUIC. 
     " name="description">
-<meta content="xml2rfc 3.15.2" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="crypto" name="keyword">
 <meta content="opportunistic encryption" name="keyword">
 <meta content="plaintext quic" name="keyword">
 <meta content="9001" name="rfc.number">
-<link href="tests/input/rfc9001.canonical.xml" rel="alternate" type="application/rfc+xml">
+<link href="rfc9001.canonical.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/rfc99999.html
+++ b/tests/valid/rfc99999.html
@@ -28,7 +28,7 @@
     wcwidth 0.2.13
     weasyprint 61.2
 -->
-<link href="tests/input/rfc99999.xml" rel="alternate" type="application/rfc+xml">
+<link href="rfc99999.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 

--- a/tests/valid/rfc99999.v3.html
+++ b/tests/valid/rfc99999.v3.html
@@ -9,9 +9,9 @@
 <meta content="
        This is not a real RFC. 
     " name="description">
-<meta content="xml2rfc 3.23.2" name="generator">
+<meta content="xml2rfc 3.25.0" name="generator">
 <meta content="99999" name="rfc.number">
-<link href="tests/input/rfc99999.xml" rel="alternate" type="application/rfc+xml">
+<link href="rfc99999.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          December 4, 2024
+Internet-Draft                                          January 10, 2025
 Intended status: Experimental                                           
-Expires: June 7, 2025
+Expires: July 14, 2025
 
 
                         xml2rfc sourcecode tests
@@ -26,11 +26,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 7, 2025.
+   This Internet-Draft will expire on July 14, 2025.
 
 Copyright Notice
 
-   Copyright (c) 2024 IETF Trust and the persons identified as the
+   Copyright (c) 2025 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                    Expires June 7, 2025                  [Page 1]
+Person                    Expires July 14, 2025                 [Page 1]
 
-Internet-Draft          xml2rfc sourcecode tests           December 2024
+Internet-Draft          xml2rfc sourcecode tests            January 2025
 
 
    print("01")
@@ -109,9 +109,9 @@ Internet-Draft          xml2rfc sourcecode tests           December 2024
 
 
 
-Person                    Expires June 7, 2025                  [Page 2]
+Person                    Expires July 14, 2025                 [Page 2]
 
-Internet-Draft          xml2rfc sourcecode tests           December 2024
+Internet-Draft          xml2rfc sourcecode tests            January 2025
 
 
    print("49")
@@ -165,9 +165,9 @@ Internet-Draft          xml2rfc sourcecode tests           December 2024
 
 
 
-Person                    Expires June 7, 2025                  [Page 3]
+Person                    Expires July 14, 2025                 [Page 3]
 
-Internet-Draft          xml2rfc sourcecode tests           December 2024
+Internet-Draft          xml2rfc sourcecode tests            January 2025
 
 
    print("47")
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                    Expires June 7, 2025                  [Page 4]
+Person                    Expires July 14, 2025                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2024-12-04T00:11:52" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2025-01-10T04:34:37" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.25.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="04" month="12" year="2024"/>
+    <date day="10" month="01" year="2025"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,13 +41,13 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 7 June 2025.
+        This Internet-Draft will expire on 14 July 2025.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">
         <name slugifiedName="name-copyright-notice">Copyright Notice</name>
         <t indent="0" pn="section-boilerplate.2-1">
-            Copyright (c) 2024 IETF Trust and the persons identified as the
+            Copyright (c) 2025 IETF Trust and the persons identified as the
             document authors. All rights reserved.
         </t>
         <t indent="0" pn="section-boilerplate.2-2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          December 4, 2024
+Internet-Draft                                          January 10, 2025
 Intended status: Experimental                                           
-Expires: June 7, 2025
+Expires: July 14, 2025
 
 
                         xml2rfc sourcecode tests
@@ -26,11 +26,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 7, 2025.
+   This Internet-Draft will expire on July 14, 2025.
 
 Copyright Notice
 
-   Copyright (c) 2024 IETF Trust and the persons identified as the
+   Copyright (c) 2025 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc sourcecode tests</td>
-<td class="right">December 2024</td>
+<td class="right">January 2025</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires June 7, 2025</td>
+<td class="center">Expires July 14, 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-12-04" class="published">December 4, 2024</time>
+<time datetime="2025-01-10" class="published">January 10, 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-06-07">June 7, 2025</time></dd>
+<dd class="expires"><time datetime="2025-07-14">July 14, 2025</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on June 7, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on July 14, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -80,7 +80,7 @@
 <a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
-            Copyright (c) 2024 IETF Trust and the persons identified as the
+            Copyright (c) 2025 IETF Trust and the persons identified as the
             document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.2-2">
             This document is subject to BCP 78 and the IETF Trust's Legal

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -8,7 +8,7 @@
 <meta content="Human Person" name="author">
 <meta content="xml2rfc 3.25.0" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
-<link href="tests/input/sourcecode.xml" rel="alternate" type="application/rfc+xml">
+<link href="sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
 <link href="rfc-local.css" rel="stylesheet" type="text/css">

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -507,7 +507,7 @@ class HtmlWriter(BaseV3Writer):
     # 
     #    <link rel="alternate" type="application/rfc+xml" href="source.xml">
 
-        add.link(head, None, href=self.xmlrfc.source, rel='alternate', type='application/rfc+xml')
+        add.link(head, None, href=os.path.basename(self.xmlrfc.source), rel='alternate', type='application/rfc+xml')
 
     # 6.3.5.  Link to License
     # 


### PR DESCRIPTION
This removes path from the alternate link.

Fixes #1068