### PR TITLE
fix(text): Improve sentence ending logic

### DIFF
--- a/tests/input/abbreviations.xml
+++ b/tests/input/abbreviations.xml
@@ -1,3 +1,5 @@
 <t>Various abbreviations which aren't end of sentence:
    Jr. AND Sr. AND i.e. AND Mr. AND Mrs. etc. -- done.  Start of next sentence.
+   Sentence with parentheses (a.k.a. Round brackets) -- done.  Start of next sentence.
+   Sentence with brackets [i.e. Square brackets] -- done.  Start of next sentence.
 </t>

--- a/tests/valid/abbreviations.html
+++ b/tests/valid/abbreviations.html
@@ -1,1 +1,1 @@
-<p>Various abbreviations which aren't end of sentence: Jr. AND Sr. AND i.e. AND Mr. AND Mrs. etc. -- done.  Start of next sentence.  </p>
+<p>Various abbreviations which aren't end of sentence: Jr. AND Sr. AND i.e. AND Mr. AND Mrs. etc. -- done.  Start of next sentence.  Sentence with parentheses (a.k.a. Round brackets) -- done.  Start of next sentence.  Sentence with brackets [i.e. Square brackets] -- done.  Start of next sentence.  </p>

--- a/tests/valid/abbreviations.nroff
+++ b/tests/valid/abbreviations.nroff
@@ -2,3 +2,6 @@
 
 Various abbreviations which aren't end of sentence: Jr. AND Sr. AND
 i.e. AND Mr. AND Mrs. etc. \%-- done.  Start of next sentence.
+Sentence with parentheses (a.k.a. Round brackets) \%-- done.  Start of
+next sentence.  Sentence with brackets [i.e. Square brackets] \%--
+done.  Start of next sentence.

--- a/tests/valid/abbreviations.raw.txt
+++ b/tests/valid/abbreviations.raw.txt
@@ -1,2 +1,5 @@
    Various abbreviations which aren't end of sentence: Jr. AND Sr. AND
    i.e. AND Mr. AND Mrs. etc. -- done.  Start of next sentence.
+   Sentence with parentheses (a.k.a. Round brackets) -- done.  Start of
+   next sentence.  Sentence with brackets [i.e. Square brackets] --
+   done.  Start of next sentence.

--- a/tests/valid/abbreviations.txt
+++ b/tests/valid/abbreviations.txt
@@ -1,2 +1,5 @@
    Various abbreviations which aren't end of sentence: Jr. AND Sr. AND
    i.e. AND Mr. AND Mrs. etc. -- done.  Start of next sentence.
+   Sentence with parentheses (a.k.a. Round brackets) -- done.  Start of
+   next sentence.  Sentence with brackets [i.e. Square brackets] --
+   done.  Start of next sentence.

--- a/tests/valid/indexes.pages.text
+++ b/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          January 10, 2025
+Internet-Draft                                          January 23, 2025
 Intended status: Experimental                                           
-Expires: July 14, 2025
+Expires: July 27, 2025
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 14, 2025.
+   This Internet-Draft will expire on July 27, 2025.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                    Expires July 14, 2025                 [Page 1]
+Person                    Expires July 27, 2025                 [Page 1]
 
 Internet-Draft             xml2rfc index tests              January 2025
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                    Expires July 14, 2025                 [Page 2]
+Person                    Expires July 27, 2025                 [Page 2]
 
 Internet-Draft             xml2rfc index tests              January 2025
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                    Expires July 14, 2025                 [Page 3]
+Person                    Expires July 27, 2025                 [Page 3]

--- a/tests/valid/indexes.prepped.xml
+++ b/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2025-01-10T04:34:27" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="indexes-00" indexInclude="true" prepTime="2025-01-23T02:08:12" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.25.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="10" month="01" year="2025"/>
+    <date day="23" month="01" year="2025"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 14 July 2025.
+        This Internet-Draft will expire on 27 July 2025.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/indexes.text
+++ b/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          January 10, 2025
+Internet-Draft                                          January 23, 2025
 Intended status: Experimental                                           
-Expires: July 14, 2025
+Expires: July 27, 2025
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 14, 2025.
+   This Internet-Draft will expire on July 27, 2025.
 
 Copyright Notice
 

--- a/tests/valid/indexes.v3.html
+++ b/tests/valid/indexes.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires July 14, 2025</td>
+<td class="center">Expires July 27, 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2025-01-10" class="published">January 10, 2025</time>
+<time datetime="2025-01-23" class="published">January 23, 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-07-14">July 14, 2025</time></dd>
+<dd class="expires"><time datetime="2025-07-27">July 27, 2025</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on July 14, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on July 27, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/tests/valid/manpage.txt
+++ b/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                         10 January 2025
+                                                         23 January 2025
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          January 10, 2025
+Internet-Draft                                          January 23, 2025
 Intended status: Experimental                                           
-Expires: July 14, 2025
+Expires: July 27, 2025
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 14, 2025.
+   This Internet-Draft will expire on July 27, 2025.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                    Expires July 14, 2025                 [Page 1]
+Person                    Expires July 27, 2025                 [Page 1]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2025
 
@@ -109,7 +109,7 @@ Internet-Draft          xml2rfc sourcecode tests            January 2025
 
 
 
-Person                    Expires July 14, 2025                 [Page 2]
+Person                    Expires July 27, 2025                 [Page 2]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2025
 
@@ -165,7 +165,7 @@ Internet-Draft          xml2rfc sourcecode tests            January 2025
 
 
 
-Person                    Expires July 14, 2025                 [Page 3]
+Person                    Expires July 27, 2025                 [Page 3]
 
 Internet-Draft          xml2rfc sourcecode tests            January 2025
 
@@ -221,4 +221,4 @@ Author's Address
 
 
 
-Person                    Expires July 14, 2025                 [Page 4]
+Person                    Expires July 27, 2025                 [Page 4]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2025-01-10T04:34:37" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2025-01-23T02:08:22" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.25.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="10" month="01" year="2025"/>
+    <date day="23" month="01" year="2025"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 14 July 2025.
+        This Internet-Draft will expire on 27 July 2025.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                          January 10, 2025
+Internet-Draft                                          January 23, 2025
 Intended status: Experimental                                           
-Expires: July 14, 2025
+Expires: July 27, 2025
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 14, 2025.
+   This Internet-Draft will expire on July 27, 2025.
 
 Copyright Notice
 

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires July 14, 2025</td>
+<td class="center">Expires July 27, 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2025-01-10" class="published">January 10, 2025</time>
+<time datetime="2025-01-23" class="published">January 23, 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-07-14">July 14, 2025</time></dd>
+<dd class="expires"><time datetime="2025-07-27">July 27, 2025</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on July 14, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on July 27, 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/xml2rfc/utils.py
+++ b/xml2rfc/utils.py
@@ -60,7 +60,7 @@ class TextWrapper(textwrap.TextWrapper):
             # Tla with leading uppercase, and special cases
             # (Note: v1 spelled out Fig, Tbl, Mrs, Drs, Rep, Sen, Gov, Rev, Gen, Col, Maj and Cap,
             #  but those are redundant with the Tla regex.)
-            r'|([\(\[])?([A-Z][a-z][a-z]|Eq|[Cc]f|vs|resp|viz|ibid|[JS]r|M[rs]|Messrs|Mmes|Dr|Profs?|St|Lt|a\.k\.a|i\.e)\.'
+            r'|([\(\[])?([A-Z][a-z][a-z]|Eq|[Cc]f|vs|resp|viz|ibid|[JS]r|M[rs]|Messrs|Mmes|Dr|Profs?|St|Lt|a\.k\.a|i\.e|e\.g)\.'
             r')\Z' # trailing dot, end of group and end of chunk
             )
 

--- a/xml2rfc/utils.py
+++ b/xml2rfc/utils.py
@@ -60,7 +60,7 @@ class TextWrapper(textwrap.TextWrapper):
             # Tla with leading uppercase, and special cases
             # (Note: v1 spelled out Fig, Tbl, Mrs, Drs, Rep, Sen, Gov, Rev, Gen, Col, Maj and Cap,
             #  but those are redundant with the Tla regex.)
-            r'|([A-Z][a-z][a-z]|Eq|[Cc]f|vs|resp|viz|ibid|[JS]r|M[rs]|Messrs|Mmes|Dr|Profs?|St|Lt|i\.e)\.'
+            r'|([\(\[])?([A-Z][a-z][a-z]|Eq|[Cc]f|vs|resp|viz|ibid|[JS]r|M[rs]|Messrs|Mmes|Dr|Profs?|St|Lt|a\.k\.a|i\.e)\.'
             r')\Z' # trailing dot, end of group and end of chunk
             )
 


### PR DESCRIPTION
Fixes #1205

* This adds `a.k.a.` to list of strings that doesn't mark end of a sentence.
* This improves not sentence end text-chunk identification by identifying abbreviated chunks in `(a.k.a. Foo` or `[i.e. Bar` as not sentence ending text chunks.
* Add `e.g.` to to list of strings that doesn't mark end of a sentence.