### PR TITLE
build: Update Python publish GHA

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,28 +7,23 @@ on:
         description: 'Create Production Release'
         required: true
         type: boolean
-      skip_test_pypi:
-        description: "Skip publishing to test PyPI"
-        required: false
-        type: boolean
-        default: "false"
 
 jobs:
-  publish:
-    environment: release
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
-    outputs:
-      pkg_version: ${{ steps.semver.outputs.next }}
 
     steps:
     - uses: actions/checkout@v4
       with:
+        persist-credentials: false
         fetch-depth: 0
-        
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
     - name: Get Next Version
       if: ${{ inputs.publish_release }}
       id: semver
@@ -37,14 +32,14 @@ jobs:
         patchList: fix, bugfix, perf, refactor, test, tests, chore, revert
         token: ${{ github.token }}
         branch: main
-        
+
     - name: Set Next Version Env Var
       if: ${{ inputs.publish_release }}
       env:
         NEXT_VERSION: ${{ steps.semver.outputs.next }}
       run: |
         echo "NEXT_VERSION=$next" >> $GITHUB_ENV
-        
+
     - name: Create Draft Release
       uses: ncipollo/release-action@v1
       if: ${{ inputs.publish_release }}
@@ -56,7 +51,7 @@ jobs:
         name: ${{ env.NEXT_VERSION }}
         body: '*pending*'
         token: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - name: Set Build Variables
       run: |
         if [[ $NEXT_VERSION ]]; then
@@ -75,28 +70,69 @@ jobs:
           echo "PKG_VERSION=v3.0.0-dev.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
           echo "PKG_VERSION_STRICT=3.0.0-dev.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
         fi
-    
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-        
-    - name: Install Python dependencies
-      env:
-        DEBIAN_FRONTEND: noninteractive
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        setuptools
+        --user
+
+    - name: Build a binary wheel and a source tarball
       run: |
-        python -m venv venv
-        source venv/bin/activate
-        python -m pip install --upgrade pip setuptools wheel twine build
-        sudo apt update
-        sudo apt install -y twine
-        
-    - name: Build Python package
-      run: |
-        source venv/bin/activate
+        python3 -m build
         echo "Using version $PKG_VERSION_STRICT"
         sed -i -r -e "s/^__version__ += '.*'$/__version__ = '$PKG_VERSION_STRICT'/" xml2rfc/__init__.py
-        python -m build
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/xml2rfc
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
+    outputs:
+      pkg_version: ${{ steps.semver.outputs.next }}
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
 
     - name: Update CHANGELOG
       id: changelog
@@ -114,7 +150,14 @@ jobs:
         branch: main
         commit_message: 'docs: update CHANGELOG.md + py file versions for ${{ env.PKG_VERSION }} [skip ci]'
         file_pattern: CHANGELOG.md setup.cfg xml2rfc/__init__.py
-        
+
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+
     - name: Create Release
       uses: ncipollo/release-action@v1
       if: env.SHOULD_DEPLOY == 'true'
@@ -127,23 +170,35 @@ jobs:
         artifacts: "dist/**"
         token: ${{ secrets.GITHUB_TOKEN }}
         makeLatest: true
-        
-    - name: Publish to Test PyPI
-      if: ${{ !inputs.skip_test_pypi }}
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: publish
+      url: https://test.pypi.org/p/xml2rfc
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
 
-    - name: Publish to PyPI
-      if: env.SHOULD_DEPLOY == 'true'
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        attestations: false
-
   build-base:
     runs-on: ubuntu-latest
     if: ${{ inputs.publish_release }}
-    needs: [publish]
+    needs:
+    - github-release
     permissions:
       contents: read
       packages: write
@@ -153,7 +208,7 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-    
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
This PR is following [Publishing package distribution releases using GitHub Actions CI/CD workflows](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#signing-the-distribution-packages) guide.

This separates PyPI production publish and PyPI test publishing into two different jobs.
This also separates building to it's own job.
This also introduces distribution signing with Sigstore.

Fixes #1193