### PR TITLE
chore: Add ACKNOWLEDGMENTS.md file

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -57,4 +57,4 @@ contributors:
  - Brian E Carpenter
  - Robert Kieffer
 
-[^1]: https://datatracker.ietf.org/doc/html/rfc2629
+[^1]: https://www.rfc-editor.org/rfc/rfc2629

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -1,0 +1,29 @@
+# Acknowledgements
+
+`xml2rfc` was originally created in 1999 by Marshall Rose who presented an XML
+markup language for RFCs and Internet-Drafts[^1]. The current implementation of
+the `xml2rfc` was originally authored by Henrik Levkowetz.
+
+Here is an inevitably incomplete list of much appreciated contributors:
+
+ - Marshall Rose
+ - Henrik Levkowetz
+ - Josh Bothun
+ - Kesara Rathnayake
+ - Robert Sparks
+ - Wiggins
+ - Tony Hansen
+ - Jim Schaad
+ - Nicolas Giard
+ - Julian Reschke
+ - Martin Thomson
+ - Carsten Bormann
+ - Jennifer Richards
+ - Florian Schmaus
+ - Daniel Kahn Gillmor
+ - Benson Muite
+ - Josh Soref
+ - Justus Winter
+ - Scott Kitterman
+
+[^1]: https://datatracker.ietf.org/doc/html/rfc2629

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -26,5 +26,35 @@ contributors:
  - Josh Soref
  - Justus Winter
  - Scott Kitterman
+ - Jean Mahoney
+ - Alice Russo
+ - Asbjørn Ulsberg
+ - Kent Watsen
+ - Madison Church
+ - Lynne Bartholomew
+ - Tom Haynes
+ - Alanna Paloma
+ - Sandy Ginoza
+ - Sarah Tarrant
+ - John Scudder
+ - Paul Hoffman
+ - Mark Nottingham
+ - Rahul Gupta
+ - Bob Hinden
+ - John Preuß Mattsson
+ - Rebecca VanRheenen
+ - John C Klensin
+ - Randy Bush
+ - Florian Schmaus
+ - Adrian Farrel
+ - Valery Smyslov
+ - Bill P. Godfrey
+ - Miek Gieben
+ - Benoît Claise
+ - Lars Eggert
+ - John Levine
+ - David von Oheimb
+ - Brian E Carpenter
+ - Robert Kieffer
 
 [^1]: https://datatracker.ietf.org/doc/html/rfc2629

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -4,7 +4,8 @@
 markup language for RFCs and Internet-Drafts[^1]. The current implementation of
 the `xml2rfc` was originally authored by Henrik Levkowetz.
 
-Here is an inevitably incomplete list of much appreciated contributors:
+Here is an inevitably incomplete and unmaintained list of much appreciated
+contributors:
 
  - Marshall Rose
  - Henrik Levkowetz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ description = "xml2rfc generates RFCs and IETF drafts from document source in XM
 readme = "README.md"
 requires-python = ">=3.9"
 license = {file = "LICENSE"}
-authors = [{name = "Henrik Levkowetz"}]
-maintainers = [{name = "IETF Tools", email = "tools-help@ietf.org"}]
+authors = [{name = "IETF Tools", email = "tools-help@ietf.org"}]
 keywords = ["ietf", "rfc", "id", "internet-draft", "xml", "xml2rfc", "xmlrfc"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
The list of names were compiled by using:
* `git shortlog -sne` command (e6a55c57b1272bfa5b72bbf5e2eb87a7259b280d)
* authors from GitHub issues (7292a0bab3c7e7a9cc4a92b4da9d4e574c4ba60a)

This PR also removes `maintainers` entry from the `pyproject.toml` and replaces `IETF Tools` as the author.