### PR TITLE
chore(pdf): Update WeasyPrint to v65.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,7 +102,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing test dependencies..."
-        python -m pip install tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==64.1"
+        python -m pip install tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==65.0"
 
     - name: Generate Valid Tests
       run: |
@@ -158,7 +158,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing test dependencies..."
-        python -m pip install tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==64.1"
+        python -m pip install tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==65.0"
 
     - name: Generate Valid Tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ documentation = "https://ietf-tools.github.io/xml2rfc/"
 issues = "https://github.com/ietf-tools/xml2rfc/issues"
 
 [project.optional-dependencies]
-pdf = ["weasyprint==64.1"]
+pdf = ["weasyprint==65.0"]
 
 [project.scripts]
 xml2rfc = "xml2rfc.run:main"


### PR DESCRIPTION
This PR updates `xml2rfc` `pdf` extra requirement to v65.0[^1].
Fixes #1226 

[^1]: https://github.com/Kozea/WeasyPrint/releases/tag/v65.0