### PR TITLE
ci: Fix GitHub publish issue

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -128,6 +128,11 @@ jobs:
       packages: write
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Fixes GitHub publishing issues[^1].

[^1]: https://github.com/ietf-tools/xml2rfc/actions/runs/13602887325/job/38030952801