### PR TITLE
fix: Local PIs need to override global ones, not the other way around

### DIFF
--- a/test.py
+++ b/test.py
@@ -947,6 +947,52 @@ class BaseV3WriterTest(unittest.TestCase):
         table = self.writer.root.xpath("//table")[0]
         self.assertEqual(self.writer.get_relevant_pi(table, "table_borders"), "min")
 
+    def test_get_relavent_pis_siblings(self):
+        xml = lxml.etree.fromstring(
+            """
+<rfc
+    ipr="trust200902"
+    submissionType="editorial"
+    category="info">
+    <?v3xml2rfc table_borders="light" ?>
+    <front>
+        <section>
+          <?v3xml2rfc table_borders="full" ?>
+          <table>
+            <thead>
+              <tr>
+                <th>Column 1</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Value 1</td>
+              </tr>
+            </tbody>
+          </table>
+          <?v3xml2rfc table_borders="min" ?>
+          <table>
+            <thead>
+              <tr>
+                <th>Column 2</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Value 2</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+    </front>
+</rfc>"""
+        )
+        self.writer.root = xml
+        table_1 = self.writer.root.xpath("//table")[0]
+        self.assertEqual(self.writer.get_relevant_pi(table_1, "table_borders"), "full")
+        table_2 = self.writer.root.xpath("//table")[1]
+        self.assertEqual(self.writer.get_relevant_pi(table_2, "table_borders"), "min")
+
 
 class DatatrackerToBibConverterTest(unittest.TestCase):
     """DatatrackerToBibConverter tests"""

--- a/test.py
+++ b/test.py
@@ -848,6 +848,105 @@ class BaseV3WriterTest(unittest.TestCase):
         with self.assertRaises(RfcWriterError):
             self.writer.validate_draft_name()
 
+    def test_get_relavent_pis_root(self):
+        xml = lxml.etree.fromstring(
+            """
+<rfc
+    ipr="trust200902"
+    submissionType="editorial"
+    category="info">
+    <?v3xml2rfc table_borders="light" ?>
+    <front>
+        <section>
+          <table>
+            <thead>
+              <tr>
+                <th>Column 1</th>
+                <th>Column 2</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Value 1</td>
+                <td>Value 2</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+    </front>
+</rfc>"""
+        )
+        self.writer.root = xml
+        table = self.writer.root.xpath("//table")[0]
+        self.assertEqual(self.writer.get_relevant_pi(table, "table_borders"), "light")
+
+    def test_get_relavent_pis_before(self):
+        xml = lxml.etree.fromstring(
+            """
+<rfc
+    ipr="trust200902"
+    submissionType="editorial"
+    category="info">
+    <?v3xml2rfc table_borders="light" ?>
+    <front>
+        <section>
+        <?v3xml2rfc table_borders="full" ?>
+          <table>
+            <thead>
+              <tr>
+                <th>Column 1</th>
+                <th>Column 2</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Value 1</td>
+                <td>Value 2</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+    </front>
+</rfc>"""
+        )
+        self.writer.root = xml
+        table = self.writer.root.xpath("//table")[0]
+        self.assertEqual(self.writer.get_relevant_pi(table, "table_borders"), "full")
+
+    def test_get_relavent_pis_inside(self):
+        xml = lxml.etree.fromstring(
+            """
+<rfc
+    ipr="trust200902"
+    submissionType="editorial"
+    category="info">
+    <?v3xml2rfc table_borders="light" ?>
+    <front>
+        <section>
+        <?v3xml2rfc table_borders="full" ?>
+          <table>
+            <?v3xml2rfc table_borders="min" ?>
+            <thead>
+              <tr>
+                <th>Column 1</th>
+                <th>Column 2</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Value 1</td>
+                <td>Value 2</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+    </front>
+</rfc>"""
+        )
+        self.writer.root = xml
+        table = self.writer.root.xpath("//table")[0]
+        self.assertEqual(self.writer.get_relevant_pi(table, "table_borders"), "min")
+
 
 class DatatrackerToBibConverterTest(unittest.TestCase):
     """DatatrackerToBibConverter tests"""

--- a/xml2rfc/writers/base.py
+++ b/xml2rfc/writers/base.py
@@ -1804,7 +1804,7 @@ class BaseV3Writer(object):
     def get_relevant_pi(self, e, name):
         pis = self.get_relevant_pis(e)
         pi_list = list(filter(None, [ pi.get(name) for pi in pis ]))
-        return pi_list[-1] if pi_list else None
+        return pi_list[0] if pi_list else None
 
     def silenced(self, e, text):
         text = text.strip()


### PR DESCRIPTION
`get_relevant_pis` searches from local to global, but then uses the most global PI, so a local override doesn't work.
