### PR TITLE
Fix for #1204 - single letter names 

### DIFF
--- a/xml2rfc/util/name.py
+++ b/xml2rfc/util/name.py
@@ -37,7 +37,7 @@ def short_author_name_parts(a):
             if is_script(fullname, 'Latin'):
                 if len(fullname.split())>1:
                     parts = fullname.split()
-                    initials = ' '.join([ "%s."%n[0].upper() for n in parts[:-1] ])
+                    initials = ' '.join([ "%s."%n[0].upper() if len(n) > 1 else n.upper() for n in parts[:-1] ])
                     surname  = parts[-1]
                     parts = [initials, surname ]
                 else:
@@ -63,7 +63,7 @@ def short_author_ascii_name_parts(a):
         if fullname:
             if len(fullname.split())>1:
                 parts = fullname.split()
-                initials = ' '.join([ "%s."%n[0].upper() for n in parts[:-1] ])
+                initials = ' '.join([ "%s."%n[0].upper() if len(n) > 1 else n.upper() for n in parts[:-1] ])
                 surname  = parts[-1]
                 parts = [ initials, surname ]
             else:


### PR DESCRIPTION
This PR updates the logic that generates short author names such that when initials are not provided, and the name being initialed is only one character long, there is no period appended after the character. 

This addresses the problem raised in #1204 regarding the handling of my name. The output format for RFC-to-be 9799 is now:
```text
Internet Engineering Task Force (IETF)                     Q Misell, Ed.
Request for Comments: 9799                                      AS207960
Category: Standards Track                                      June 2025
ISSN: 2070-1721
```