### PR TITLE
Add lax-validation flag

### DIFF
--- a/xml2rfc/run.py
+++ b/xml2rfc/run.py
@@ -233,6 +233,8 @@ def main():
                             help='generate utf8 output')
     plain_options.add_argument('-v', '--verbose', action='store_true',
                             help='print extra information')
+    plain_options.add_argument('--lax-validation', action='store_true', default=False,
+                            help='Treat schema validation errors as warnings (v3 writers)')
 
 
     value_options = optionparser.add_argument_group('Generic Options with Values')

--- a/xml2rfc/writers/base.py
+++ b/xml2rfc/writers/base.py
@@ -81,6 +81,7 @@ default_options.__dict__ = {
         'info': False,
         'info_base_url': 'https://www.rfc-editor.org/info/',
         'inline_version_info': True,
+        'lax_validation': False,
         'legacy': False,
         'legacy_date_format': False,
         'legacy_list_symbols': False,
@@ -2158,7 +2159,7 @@ class BaseV3Writer(object):
         version = self.root.get('version', '3')
         if version not in ['3', ]:
             self.die(self.root, 'Expected <rfc> version="3", but found "%s"' % version)
-        if not self.validate('before'):
+        if not self.validate('before', warn=self.options.lax_validation):
             self.note(None, "Schema validation failed for input document")
 
         self.validate_draft_name()
@@ -2186,7 +2187,7 @@ class BaseV3Writer(object):
         attrib = copy.deepcopy(e.attrib)
         e.attrib.clear()
         #
-        if not self.validate('after', warn=True):
+        if not self.validate('after', warn=self.options.lax_validation):
             self.note(None, "Schema validation failed for input document")
         else:
             self.root.set('version', '3')

--- a/xml2rfc/writers/preptool.py
+++ b/xml2rfc/writers/preptool.py
@@ -1532,7 +1532,7 @@ class PrepToolWriter(BaseV3Writer):
     #       of the "target" attribute with no other adornment.  Issue a
     #       warning if the "derivedContent" attribute already exists and has a
     #       different value from what was being filled in.
-    def build_derived_content(self, e):
+    def build_derived_content(self, e, lax_validation=False):
         def split_pn(t, pn):
             if pn is None:
                 self.die(e, "Expected to find a pn= attribute on <%s anchor='%s'> when processing <xref>, but found none" % (t.tag, t.get('anchor')), trace=True)
@@ -1554,7 +1554,9 @@ class PrepToolWriter(BaseV3Writer):
             t = self.root.find('.//*[@pn="%s"]'%(target, ))
             if t is None:
                 t = self.root.find('.//*[@slugifiedName="%s"]'%(target, ))
-                if t is None:
+                if t is None and lax_validation:
+                    return e, "[PLACEHOLDER: %s]" % target
+                elif t is None:
                     self.die(e, "Found no element to match the <xref> target attribute '%s'" % (target, ))
         #
         p = t
@@ -1636,7 +1638,7 @@ class PrepToolWriter(BaseV3Writer):
     def element_xref(self, e, p):
         section = e.get('section')
         relative = e.get('relative')
-        t, content = self.build_derived_content(e)
+        t, content = self.build_derived_content(e, lax_validation=self.options.lax_validation)
         is_toc = p.get('pn', '').startswith('section-toc')
         if not (section or relative):
             attr = e.get('derivedContent')


### PR DESCRIPTION
Just a first effort here, I'm sure the tools team can improve it. In particular, the return value from "Build derived content" is a little hacky, but I wasn't sure what to do under --lax-validation if the xref didn't find a target.