### PR TITLE
fix(pdf): For monospaced text, Add Noto Sans Mono before NOTO_SYMBOLS

### DIFF
--- a/xml2rfc/writers/pdf.py
+++ b/xml2rfc/writers/pdf.py
@@ -133,10 +133,11 @@ class PdfWriter(BaseV3Writer):
         fonts = set()
         scripts = self.root.get('scripts').split(',')
         roboto_mono = "Roboto Mono"
+        noto_sans_mono = "Noto Sans Mono"
         for script in scripts:
             family = get_noto_serif_family_for_script(script)
             fonts.add("%s" % family)
-        fonts = [ roboto_mono, ] + NOTO_SYMBOLS + list(fonts)
+        fonts = [ roboto_mono, noto_sans_mono, ] + NOTO_SYMBOLS + list(fonts)
         self.note(None, "Found installed font: %s" % ', '.join(fonts))
         return fonts
 


### PR DESCRIPTION
This is an attempt to address #1245