### PR TITLE
setuptools is not needed at runtime anymore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "pycountry>=22.3.5",
     "pyyaml>=5.3.1",
     "requests>=2.5.0",
-    "setuptools>=24.2.0",
     "wcwidth>=0.2.5"
 ]
 


### PR DESCRIPTION
Hi,

Since this previous PR https://github.com/ietf-tools/xml2rfc/pull/1079, setuptools is not needed at runtime anymore.

Greetings
