### PR TITLE
feat(html): add copy unfolded button for RFC 8792 folded blocks

### DIFF
--- a/tests/input/sourcecode.xml
+++ b/tests/input/sourcecode.xml
@@ -127,6 +127,35 @@ print("49")
 print("50")
             </sourcecode>
         </section>
+        <section>
+            <name>RFC 8792 wrapping</name>
+            <t>Source code using the single backslash strategy:</t>
+            <sourcecode name="single-wrap.txt"><![CDATA[========== NOTE: '\' line wrapping per RFC 8792 ===========
+
+first folded line \
+continues here
+second folded line \
+also continues
+]]></sourcecode>
+            <t>Text artwork using the double backslash strategy:</t>
+            <artwork><![CDATA[[NOTE: '\\' line wrapping per RFC 8792]
+
+first folded line \
+  \continues here
+second folded line \
+  \also continues
+]]></artwork>
+            <t>Source code with renderer-added markers:</t>
+            <sourcecode name="marked-wrap.txt" markers="true"><![CDATA[NOTE: '\' line wrapping per RFC 8792
+
+marked folded line \
+continues here
+]]></sourcecode>
+            <t>A quoted header without folded content is not copyable:</t>
+            <sourcecode><![CDATA[NOTE: '\' line wrapping per RFC 8792
+This block mentions the header but does not use RFC 8792 folding.
+]]></sourcecode>
+        </section>
     </middle>
     <back>
         <references>

--- a/tests/valid/sourcecode.pages.text
+++ b/tests/valid/sourcecode.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            March 30, 2026
+Internet-Draft                                              May 14, 2026
 Intended status: Experimental                                           
-Expires: October 1, 2026
+Expires: November 15, 2026
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on October 1, 2026.
+   This Internet-Draft will expire on November 15, 2026.
 
 Copyright Notice
 
@@ -42,9 +42,10 @@ Copyright Notice
 Table of Contents
 
    1.  Less than 50 lines  . . . . . . . . . . . . . . . . . . . . .   1
-   2.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   2.  RFC 8792 wrapping . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   4
    Index . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .   4
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   5
 
 1.  Less than 50 lines
 
@@ -52,10 +53,9 @@ Table of Contents
 
 
 
-
-Person                   Expires October 1, 2026                [Page 1]
+Person                  Expires November 15, 2026               [Page 1]
 
-Internet-Draft          xml2rfc sourcecode tests              March 2026
+Internet-Draft          xml2rfc sourcecode tests                May 2026
 
 
    print("01")
@@ -109,9 +109,9 @@ Internet-Draft          xml2rfc sourcecode tests              March 2026
 
 
 
-Person                   Expires October 1, 2026                [Page 2]
+Person                  Expires November 15, 2026               [Page 2]
 
-Internet-Draft          xml2rfc sourcecode tests              March 2026
+Internet-Draft          xml2rfc sourcecode tests                May 2026
 
 
    print("49")
@@ -165,9 +165,9 @@ Internet-Draft          xml2rfc sourcecode tests              March 2026
 
 
 
-Person                   Expires October 1, 2026                [Page 3]
+Person                  Expires November 15, 2026               [Page 3]
 
-Internet-Draft          xml2rfc sourcecode tests              March 2026
+Internet-Draft          xml2rfc sourcecode tests                May 2026
 
 
    print("47")
@@ -175,7 +175,41 @@ Internet-Draft          xml2rfc sourcecode tests              March 2026
    print("49")
    print("50")
 
-2.  References
+2.  RFC 8792 wrapping
+
+   Source code using the single backslash strategy:
+
+   ========== NOTE: '\' line wrapping per RFC 8792 ===========
+
+   first folded line \
+   continues here
+   second folded line \
+   also continues
+
+   Text artwork using the double backslash strategy:
+
+   [NOTE: '\\' line wrapping per RFC 8792]
+
+   first folded line \
+     \continues here
+   second folded line \
+     \also continues
+
+   Source code with renderer-added markers:
+
+   <CODE BEGINS> file "marked-wrap.txt"
+   NOTE: '\' line wrapping per RFC 8792
+
+   marked folded line \
+   continues here
+   <CODE ENDS>
+
+   A quoted header without folded content is not copyable:
+
+   NOTE: '\' line wrapping per RFC 8792
+   This block mentions the header but does not use RFC 8792 folding.
+
+3.  References
 
    [ref0]     Author, R. Q., "Reference".  This is a reference not in a
               reference group.
@@ -183,6 +217,14 @@ Internet-Draft          xml2rfc sourcecode tests              March 2026
 Index
 
    A
+
+
+
+
+Person                  Expires November 15, 2026               [Page 4]
+
+Internet-Draft          xml2rfc sourcecode tests                May 2026
+
 
       A
 
@@ -221,4 +263,18 @@ Author's Address
 
 
 
-Person                   Expires October 1, 2026                [Page 4]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Person                  Expires November 15, 2026               [Page 5]

--- a/tests/valid/sourcecode.prepped.xml
+++ b/tests/valid/sourcecode.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2026-03-30T22:40:21" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.32.0 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" sortRefs="true" category="exp" submissionType="independent" ipr="trust200902" docName="sourcecode-00" prepTime="2026-05-14T10:47:17" indexInclude="true" scripts="Common,Latin" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.33.0 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="30" month="03" year="2026"/>
+    <date day="14" month="05" year="2026"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 1 October 2026.
+        This Internet-Draft will expire on 15 November 2026.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">
@@ -68,13 +68,16 @@
             <t indent="0" keepWithNext="true" pn="section-toc.1-1.1.1"><xref derivedContent="1" format="counter" sectionFormat="of" target="section-1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-less-than-50-lines">Less than 50 lines</xref></t>
           </li>
           <li pn="section-toc.1-1.2">
-            <t indent="0" keepWithNext="true" pn="section-toc.1-1.2.1"><xref derivedContent="2" format="counter" sectionFormat="of" target="section-2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-references">References</xref></t>
+            <t indent="0" keepWithNext="true" pn="section-toc.1-1.2.1"><xref derivedContent="2" format="counter" sectionFormat="of" target="section-2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-rfc-8792-wrapping">RFC 8792 wrapping</xref></t>
           </li>
           <li pn="section-toc.1-1.3">
-            <t indent="0" keepWithNext="true" pn="section-toc.1-1.3.1"><xref derivedContent="" format="none" sectionFormat="of" target="section-appendix.a"/><xref derivedContent="" format="title" sectionFormat="of" target="name-index">Index</xref></t>
+            <t indent="0" keepWithNext="true" pn="section-toc.1-1.3.1"><xref derivedContent="3" format="counter" sectionFormat="of" target="section-3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-references">References</xref></t>
           </li>
           <li pn="section-toc.1-1.4">
-            <t indent="0" pn="section-toc.1-1.4.1"><xref derivedContent="" format="none" sectionFormat="of" target="section-appendix.b"/><xref derivedContent="" format="title" sectionFormat="of" target="name-authors-address">Author's Address</xref></t>
+            <t indent="0" pn="section-toc.1-1.4.1"><xref derivedContent="" format="none" sectionFormat="of" target="section-appendix.a"/><xref derivedContent="" format="title" sectionFormat="of" target="name-index">Index</xref></t>
+          </li>
+          <li pn="section-toc.1-1.5">
+            <t indent="0" pn="section-toc.1-1.5.1"><xref derivedContent="" format="none" sectionFormat="of" target="section-appendix.b"/><xref derivedContent="" format="title" sectionFormat="of" target="name-authors-address">Author's Address</xref></t>
           </li>
         </ul>
       </section>
@@ -185,9 +188,38 @@ print("49")
 print("50")
 </sourcecode>
     </section>
+    <section numbered="true" removeInRFC="false" toc="include" pn="section-2">
+      <name slugifiedName="name-rfc-8792-wrapping">RFC 8792 wrapping</name>
+      <t indent="0" pn="section-2-1">Source code using the single backslash strategy:</t>
+      <sourcecode name="single-wrap.txt" markers="false" pn="section-2-2">========== NOTE: '\' line wrapping per RFC 8792 ===========
+
+first folded line \
+continues here
+second folded line \
+also continues
+</sourcecode>
+      <t indent="0" pn="section-2-3">Text artwork using the double backslash strategy:</t>
+      <artwork align="left" pn="section-2-4"><![CDATA[[NOTE: '\\' line wrapping per RFC 8792]
+
+first folded line \
+  \continues here
+second folded line \
+  \also continues
+]]></artwork>
+      <t indent="0" pn="section-2-5">Source code with renderer-added markers:</t>
+      <sourcecode name="marked-wrap.txt" markers="true" pn="section-2-6">NOTE: '\' line wrapping per RFC 8792
+
+marked folded line \
+continues here
+</sourcecode>
+      <t indent="0" pn="section-2-7">A quoted header without folded content is not copyable:</t>
+      <sourcecode markers="false" pn="section-2-8">NOTE: '\' line wrapping per RFC 8792
+This block mentions the header but does not use RFC 8792 folding.
+</sourcecode>
+    </section>
   </middle>
   <back>
-    <references pn="section-2">
+    <references pn="section-3">
       <name slugifiedName="name-references">References</name>
       <reference anchor="ref0" quoteTitle="true" derivedAnchor="ref0">
         <front>

--- a/tests/valid/sourcecode.text
+++ b/tests/valid/sourcecode.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                            March 30, 2026
+Internet-Draft                                              May 14, 2026
 Intended status: Experimental                                           
-Expires: October 1, 2026
+Expires: November 15, 2026
 
 
                         xml2rfc sourcecode tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on October 1, 2026.
+   This Internet-Draft will expire on November 15, 2026.
 
 Copyright Notice
 
@@ -42,7 +42,8 @@ Copyright Notice
 Table of Contents
 
    1.  Less than 50 lines
-   2.  References
+   2.  RFC 8792 wrapping
+   3.  References
    Index
    Author's Address
 
@@ -149,7 +150,41 @@ Table of Contents
    print("49")
    print("50")
 
-2.  References
+2.  RFC 8792 wrapping
+
+   Source code using the single backslash strategy:
+
+   ========== NOTE: '\' line wrapping per RFC 8792 ===========
+
+   first folded line \
+   continues here
+   second folded line \
+   also continues
+
+   Text artwork using the double backslash strategy:
+
+   [NOTE: '\\' line wrapping per RFC 8792]
+
+   first folded line \
+     \continues here
+   second folded line \
+     \also continues
+
+   Source code with renderer-added markers:
+
+   <CODE BEGINS> file "marked-wrap.txt"
+   NOTE: '\' line wrapping per RFC 8792
+
+   marked folded line \
+   continues here
+   <CODE ENDS>
+
+   A quoted header without folded content is not copyable:
+
+   NOTE: '\' line wrapping per RFC 8792
+   This block mentions the header but does not use RFC 8792 folding.
+
+3.  References
 
    [ref0]     Author, R. Q., "Reference".  This is a reference not in a
               reference group.

--- a/tests/valid/sourcecode.v3.html
+++ b/tests/valid/sourcecode.v3.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc sourcecode tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.32.0" name="generator">
+<meta content="xml2rfc 3.33.0" name="generator">
 <meta content="sourcecode-00" name="ietf.draft">
 <link href="sourcecode.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc sourcecode tests</td>
-<td class="right">March 2026</td>
+<td class="right">May 2026</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires October 1, 2026</td>
+<td class="center">Expires November 15, 2026</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">sourcecode-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2026-03-30" class="published">March 30, 2026</time>
+<time datetime="2026-05-14" class="published">May 14, 2026</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2026-10-01">October 1, 2026</time></dd>
+<dd class="expires"><time datetime="2026-11-15">November 15, 2026</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on October 1, 2026.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on November 15, 2026.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -101,13 +101,16 @@
             <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-less-than-50-lines" class="internal xref">Less than 50 lines</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-references" class="internal xref">References</a></p>
+            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-rfc-8792-wrapping" class="internal xref">RFC 8792 wrapping</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-index" class="internal xref">Index</a></p>
+            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-references" class="internal xref">References</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-authors-address" class="internal xref">Author's Address</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-index" class="internal xref">Index</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-authors-address" class="internal xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -224,8 +227,52 @@ print("50")
 </div>
 </section>
 <section id="section-2">
+      <h2 id="name-rfc-8792-wrapping">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-rfc-8792-wrapping" class="section-name selfRef">RFC 8792 wrapping</a>
+      </h2>
+<p id="section-2-1">Source code using the single backslash strategy:<a href="#section-2-1" class="pilcrow">¶</a></p>
+<div class="has-copy-unfolded sourcecode" id="section-2-2">
+<pre>========== NOTE: '\' line wrapping per RFC 8792 ===========
+
+first folded line \
+continues here
+second folded line \
+also continues
+</pre>
+<button type="button" class="copy-unfolded" aria-label="Copy unfolded">Copy unfolded</button><a href="#section-2-2" class="pilcrow">¶</a>
+</div>
+<p id="section-2-3">Text artwork using the double backslash strategy:<a href="#section-2-3" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork has-copy-unfolded" id="section-2-4">
+<pre>[NOTE: '\\' line wrapping per RFC 8792]
+
+first folded line \
+  \continues here
+second folded line \
+  \also continues
+</pre>
+<button type="button" class="copy-unfolded" aria-label="Copy unfolded">Copy unfolded</button><a href="#section-2-4" class="pilcrow">¶</a>
+</div>
+<p id="section-2-5">Source code with renderer-added markers:<a href="#section-2-5" class="pilcrow">¶</a></p>
+<div class="has-copy-unfolded sourcecode" id="section-2-6" data-sourcecode-markers="true">
+<pre>&lt;CODE BEGINS&gt; file "marked-wrap.txt"
+NOTE: '\' line wrapping per RFC 8792
+
+marked folded line \
+continues here
+
+&lt;CODE ENDS&gt;</pre>
+<button type="button" class="copy-unfolded" aria-label="Copy unfolded">Copy unfolded</button><a href="#section-2-6" class="pilcrow">¶</a>
+</div>
+<p id="section-2-7">A quoted header without folded content is not copyable:<a href="#section-2-7" class="pilcrow">¶</a></p>
+<div class="sourcecode" id="section-2-8">
+<pre>NOTE: '\' line wrapping per RFC 8792
+This block mentions the header but does not use RFC 8792 folding.
+</pre><a href="#section-2-8" class="pilcrow">¶</a>
+</div>
+</section>
+<section id="section-3">
       <h2 id="name-references">
-<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-references" class="section-name selfRef">References</a>
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-references" class="section-name selfRef">References</a>
       </h2>
 <dl class="references">
 <dt id="ref0">[ref0]</dt>
@@ -284,6 +331,125 @@ toc.querySelector("h2").addEventListener("click", e => {
 });
 toc.querySelector("nav").addEventListener("click", e => {
   toc.classList.remove("active");
+});
+</script>
+<script>function stripSourcecodeMarkers(text) {
+  const lines = text.split("\n");
+  if (lines.length && /^<CODE BEGINS>(?: file "[^"]*")?$/.test(lines[0])) {
+    lines.shift();
+    if (lines.length && /^ file "[^"]*"$/.test(lines[0])) {
+      lines.shift();
+    }
+  }
+  if (lines.length && lines[lines.length - 1] === "<CODE ENDS>") {
+    lines.pop();
+  }
+  return lines.join("\n");
+}
+
+function findHeader(lines) {
+  const headers = [
+    { strategy: "double", text: "NOTE: '\\\\' line wrapping per RFC 8792" },
+    { strategy: "single", text: "NOTE: '\\' line wrapping per RFC 8792" },
+  ];
+  for (const header of headers) {
+    if (lines[0].includes(header.text)) {
+      return { strategy: header.strategy, index: 0 };
+    }
+    if (lines.length > 1 && lines[0].startsWith("<CODE BEGINS>") && lines[1].includes(header.text)) {
+      return { strategy: header.strategy, index: 1 };
+    }
+    if (lines.length > 2 && lines[0].startsWith("<CODE BEGINS>") && lines[1].startsWith(" file \"") && lines[2].includes(header.text)) {
+      return { strategy: header.strategy, index: 2 };
+    }
+  }
+  return null;
+}
+
+function unfoldText(text, stripMarkers) {
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const header = findHeader(lines);
+
+  if (!header) {
+    return text;
+  }
+
+  const before = lines.slice(0, header.index);
+  if (lines[header.index].startsWith("<CODE BEGINS>")) {
+    before.push("<CODE BEGINS>");
+  }
+  const after = lines.slice(header.index + 1);
+  if (after.length && /^[ ]*$/.test(after[0])) {
+    after.shift();
+  }
+
+  const folded = after.join("\n");
+  const unwrapped = header.strategy === "double"
+    ? folded.replace(/\\\n[ ]*\\/g, "")
+    : folded.replace(/\\\n[ ]*/g, "");
+
+  if (before.length) {
+    const result = `${before.join("\n")}\n${unwrapped}`;
+    return stripMarkers ? stripSourcecodeMarkers(result) : result;
+  }
+  return stripMarkers ? stripSourcecodeMarkers(unwrapped) : unwrapped;
+}
+
+function copyTextWithTextarea(text) {
+  return new Promise((resolve, reject) => {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-1000px";
+    textarea.style.left = "-1000px";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    try {
+      if (document.execCommand("copy")) {
+        resolve();
+      } else {
+        reject(new Error("copy command failed"));
+      }
+    } catch (error) {
+      reject(error);
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  });
+}
+
+function copyText(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text).catch(() => copyTextWithTextarea(text));
+  }
+  return copyTextWithTextarea(text);
+}
+
+document.querySelectorAll(".copy-unfolded").forEach(button => {
+  button.addEventListener("click", () => {
+    const block = button.closest(".has-copy-unfolded");
+    const pre = block ? block.querySelector("pre") : null;
+    if (!block || !pre) {
+      return;
+    }
+
+    const text = unfoldText(pre.textContent, block.dataset.sourcecodeMarkers === "true");
+    copyText(text).then(() => {
+      button.textContent = "Copied";
+      button.setAttribute("aria-label", "Copied");
+      window.setTimeout(() => {
+        button.textContent = "Copy unfolded";
+        button.setAttribute("aria-label", "Copy unfolded");
+      }, 1600);
+    }).catch(() => {
+      button.textContent = "Error";
+      window.setTimeout(() => {
+        button.textContent = "Copy unfolded";
+      }, 1600);
+    });
+  });
 });
 </script>
 </body>

--- a/xml2rfc/data/xml2rfc-copy-unfolded.js
+++ b/xml2rfc/data/xml2rfc-copy-unfolded.js
@@ -1,0 +1,118 @@
+function stripSourcecodeMarkers(text) {
+  const lines = text.split("\n");
+  if (lines.length && /^<CODE BEGINS>(?: file "[^"]*")?$/.test(lines[0])) {
+    lines.shift();
+    if (lines.length && /^ file "[^"]*"$/.test(lines[0])) {
+      lines.shift();
+    }
+  }
+  if (lines.length && lines[lines.length - 1] === "<CODE ENDS>") {
+    lines.pop();
+  }
+  return lines.join("\n");
+}
+
+function findHeader(lines) {
+  const headers = [
+    { strategy: "double", text: "NOTE: '\\\\' line wrapping per RFC 8792" },
+    { strategy: "single", text: "NOTE: '\\' line wrapping per RFC 8792" },
+  ];
+  for (const header of headers) {
+    if (lines[0].includes(header.text)) {
+      return { strategy: header.strategy, index: 0 };
+    }
+    if (lines.length > 1 && lines[0].startsWith("<CODE BEGINS>") && lines[1].includes(header.text)) {
+      return { strategy: header.strategy, index: 1 };
+    }
+    if (lines.length > 2 && lines[0].startsWith("<CODE BEGINS>") && lines[1].startsWith(" file \"") && lines[2].includes(header.text)) {
+      return { strategy: header.strategy, index: 2 };
+    }
+  }
+  return null;
+}
+
+function unfoldText(text, stripMarkers) {
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const header = findHeader(lines);
+
+  if (!header) {
+    return text;
+  }
+
+  const before = lines.slice(0, header.index);
+  if (lines[header.index].startsWith("<CODE BEGINS>")) {
+    before.push("<CODE BEGINS>");
+  }
+  const after = lines.slice(header.index + 1);
+  if (after.length && /^[ ]*$/.test(after[0])) {
+    after.shift();
+  }
+
+  const folded = after.join("\n");
+  const unwrapped = header.strategy === "double"
+    ? folded.replace(/\\\n[ ]*\\/g, "")
+    : folded.replace(/\\\n[ ]*/g, "");
+
+  if (before.length) {
+    const result = `${before.join("\n")}\n${unwrapped}`;
+    return stripMarkers ? stripSourcecodeMarkers(result) : result;
+  }
+  return stripMarkers ? stripSourcecodeMarkers(unwrapped) : unwrapped;
+}
+
+function copyTextWithTextarea(text) {
+  return new Promise((resolve, reject) => {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-1000px";
+    textarea.style.left = "-1000px";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    try {
+      if (document.execCommand("copy")) {
+        resolve();
+      } else {
+        reject(new Error("copy command failed"));
+      }
+    } catch (error) {
+      reject(error);
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  });
+}
+
+function copyText(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text).catch(() => copyTextWithTextarea(text));
+  }
+  return copyTextWithTextarea(text);
+}
+
+document.querySelectorAll(".copy-unfolded").forEach(button => {
+  button.addEventListener("click", () => {
+    const block = button.closest(".has-copy-unfolded");
+    const pre = block ? block.querySelector("pre") : null;
+    if (!block || !pre) {
+      return;
+    }
+
+    const text = unfoldText(pre.textContent, block.dataset.sourcecodeMarkers === "true");
+    copyText(text).then(() => {
+      button.textContent = "Copied";
+      button.setAttribute("aria-label", "Copied");
+      window.setTimeout(() => {
+        button.textContent = "Copy unfolded";
+        button.setAttribute("aria-label", "Copy unfolded");
+      }, 1600);
+    }).catch(() => {
+      button.textContent = "Error";
+      window.setTimeout(() => {
+        button.textContent = "Copy unfolded";
+      }, 1600);
+    });
+  });
+});

--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -827,6 +827,42 @@ tt, code, pre {
   line-height: 1.12;
 }
 
+/* Copy unfolded text from RFC 8792-style folded sourcecode/artwork blocks. */
+.has-copy-unfolded {
+  position: relative;
+}
+.copy-unfolded {
+  position: absolute;
+  top: 0.35em;
+  right: 0.35em;
+  z-index: 3;
+  opacity: 0;
+  pointer-events: none;
+  padding: 0.25em 0.5em;
+  border: 1px solid #777;
+  border-radius: 3px;
+  color: #fff;
+  background: #444;
+  font-family: var(--font-sans);
+  font-size: 0.85em;
+  line-height: 1.2;
+  cursor: pointer;
+}
+.copy-unfolded:hover,
+.copy-unfolded:focus {
+  background: #222;
+}
+.has-copy-unfolded:hover > .copy-unfolded,
+.has-copy-unfolded:focus-within > .copy-unfolded,
+.copy-unfolded:focus {
+  opacity: 1;
+  pointer-events: auto;
+}
+@media print {
+  .copy-unfolded {
+    display: none;
+  }
+}
 
 /* Add styling for a link in the ToC that points to the top of the document */
 a.toplink {

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -230,6 +230,7 @@ class HtmlWriter(BaseV3Writer):
         self.duplicate_html_ids = set()
         self.filename = None
         self.refname_mapping = self.get_refname_mapping()
+        self.has_copy_unfolded = False
             
     def html_tree(self):
         if not self.root.get('prepTime'):
@@ -358,6 +359,43 @@ class HtmlWriter(BaseV3Writer):
 
     def part_of_table_of_contents(self, e):
         return( len(e.xpath('ancestor::*[contains(@class, "toc")]')) > 0 )
+
+    def has_line_unfolding(self, text):
+        if not text:
+            return False
+        headers = [
+            ('double', r"NOTE: '\\' line wrapping per RFC 8792"),
+            ('single', r"NOTE: '\' line wrapping per RFC 8792"),
+        ]
+        lines = text.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+        for kind, header in headers:
+            if header in lines[0]:
+                body = lines[1:]
+            elif len(lines) > 1 and lines[0].startswith('<CODE BEGINS>') and header in lines[1]:
+                body = lines[2:]
+            elif len(lines) > 2 and lines[0].startswith('<CODE BEGINS>') and lines[1].startswith(' file "') and header in lines[2]:
+                body = lines[3:]
+            else:
+                continue
+            if kind == 'double':
+                for j, body_line in enumerate(body[:-1]):
+                    if body_line.endswith('\\') and body[j + 1].lstrip(' ').startswith('\\'):
+                        return True
+            elif any(body_line.endswith('\\') for body_line in body):
+                return True
+        return False
+
+    def maybe_add_copy_unfolded_button(self, e, text, strip_sourcecode_markers=False):
+        if not self.has_line_unfolding(text):
+            return
+        classes = e.get('class', '')
+        e.set('class', ' '.join(s for s in [classes, 'has-copy-unfolded'] if s))
+        if strip_sourcecode_markers:
+            e.set('data-sourcecode-markers', 'true')
+        button = build.button('Copy unfolded', type='button', classes='copy-unfolded')
+        button.set('aria-label', 'Copy unfolded')
+        e.append(button)
+        self.has_copy_unfolded = True
     
     def maybe_add_pilcrow(self, e, first=False):
         if not self.contains_pilcrow_in_sub_element(e) and not self.part_of_table_of_contents(e):
@@ -662,6 +700,7 @@ class HtmlWriter(BaseV3Writer):
             )
         )
 
+        self.has_copy_unfolded = False
         for c in [ e for e in [ x.find('front'), x.find('middle'), x.find('back') ] if e != None]:
             self.part = c.tag
             self.render(body, c)
@@ -669,6 +708,10 @@ class HtmlWriter(BaseV3Writer):
         with open(self.css_js, encoding='utf-8') as f:
             js = f.read()
         add.script(body, None, js)
+        if self.has_copy_unfolded:
+            with open(os.path.join(data_dir, 'xml2rfc-copy-unfolded.js'), encoding='utf-8') as f:
+                js = f.read()
+            add.script(body, None, js)
 
         return html
 
@@ -847,6 +890,7 @@ class HtmlWriter(BaseV3Writer):
                     classes += ' art-%s' % type
                 div = add.div(h, x, pre, classes=classes)
                 div.text = None
+                self.maybe_add_copy_unfolded_button(div, pre.text)
                 if x.getparent().tag != 'figure':
                     self.maybe_add_pilcrow(div)
                 return div
@@ -2464,6 +2508,7 @@ class HtmlWriter(BaseV3Writer):
                 text = (' file "%s"\n%s' % (file, text)) if text else '\n%s' % text
             text = "<CODE BEGINS>%s\n<CODE ENDS>" % text
             pre.text = text
+        self.maybe_add_copy_unfolded_button(div, pre.text, strip_sourcecode_markers=mark)
         if x.getparent().tag != 'figure':
             self.maybe_add_pilcrow(div)
         return div


### PR DESCRIPTION
Detect [RFC 8792](https://www.rfc-editor.org/rfc/rfc8792.html) folded blocks in the v3 HTML renderer and add a hover/focus copy control that copies the block text unfolded.

This makes RFC 8792-folded examples usable directly from HTML RFCs: readers can copy the original unfolded source without needing to know or manually apply the folding rules.

<img width="1450" height="284" alt="rfc8792-sourcecode-hover" src="https://github.com/user-attachments/assets/b49f11f7-e0c0-47f9-9da5-82a5e1dce6b4" />
<img width="1450" height="284" alt="rfc8792-sourcecode-copied" src="https://github.com/user-attachments/assets/054e6f40-7f1b-4639-8030-0569a6303948" />

Note that I am in no way shape or form a frontend stylesheet proficient, nor knowledgeable of aria-* accessibility attributes. The style, text, and attributes need some bashing and I'm happy to accomodate any requested changes.