### PR TITLE
fix(html): Update xml2rfc.css with sub/sup no wrapping

### DIFF
--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -320,6 +320,10 @@ table p {
      be allowed within tables more generally, it would be far better to select on a class. */
   margin: 0;
 }
+sub,
+sup {
+	white-space: nowrap;
+}
 
 /* pilcrow */
 a.pilcrow {


### PR DESCRIPTION
Apparently `<sub>`/`<sup>` shouldn't wrap, according to RPC.

I'd guess that most usage only has short text so this is probably ok to do.

Let me know if you'd accept the PR in principle and then I'll make the PR pass