### PR TITLE
fix(pdf): Avoid page breaks inside tables

### DIFF
--- a/xml2rfc/data/xml2rfc.css
+++ b/xml2rfc/data/xml2rfc.css
@@ -1031,6 +1031,9 @@ aside > p {
   figcaption, table caption {
     page-break-before: avoid;
   }
+  table {
+    page-break-inside: avoid;
+  }
 }
 /* Font size adjustments for print */
 @media print {


### PR DESCRIPTION
Fixes #1329 

This is a fix to avoid page break inside table.