### PR TITLE
fix(html): --css cannot read a local absolute path on Windows, or a UTF-8 stylesheet anywhere

### DIFF
--- a/test.py
+++ b/test.py
@@ -3,8 +3,10 @@
 import copy
 import difflib
 import lxml
+import os
 import re
 import sys
+import tempfile
 import unittest
 import xml2rfc
 import xml2rfc.utils
@@ -590,6 +592,26 @@ class HtmlWriterTest(unittest.TestCase):
         result_svg = self.writer.set_font_family(input_svg)
         result = lxml.etree.tostring(result_svg)
         self.assertEqual(result, expected_svg)
+
+
+    def test_read_css_local_absolute_path(self):
+        """--css takes a file path, and on Windows that path has a drive letter.
+
+        urlparse() reads the drive letter as a URL scheme, so the absolute path
+        went to urlopen() and failed with "unknown url type: c". The stylesheet
+        is also read with the locale encoding rather than as UTF-8, which is
+        what the builtin one five lines below already uses.
+        """
+        stylesheet = 'body { color: \u2014 red }\n'
+        with tempfile.TemporaryDirectory() as scratch:
+            path = os.path.join(scratch, 'custom.css')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(stylesheet)
+
+            css, cssin = self.writer.read_css(scratch, path)
+
+        self.assertEqual(css, stylesheet)
+        self.assertEqual(cssin, path)
 
 
 class PrepToolWriterTest(unittest.TestCase):

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -280,7 +280,7 @@ class HtmlWriter(BaseV3Writer):
 
     def read_css(self, data_dir, fn):
         try:
-            if urlparse(fn).scheme:
+            if urlparse(fn).scheme in ['http', 'https', 'ftp', 'file', ]:
                 with closing(urlopen(fn)) as f:
                     return f.read(), fn
             else:

--- a/xml2rfc/writers/html.py
+++ b/xml2rfc/writers/html.py
@@ -288,7 +288,7 @@ class HtmlWriter(BaseV3Writer):
                     for ext in ['', '.css', ]:
                         cssin = os.path.join(path, fn + ext)
                         if os.path.exists(cssin):
-                            with open(cssin) as f:
+                            with open(cssin, encoding='utf-8') as f:
                                 return f.read(), cssin
         except IOError as e:
             self.err(self.root, "Error when trying to read external css: %s" % e)


### PR DESCRIPTION
`--css` is documented as taking a file (`metavar="FILE"`, "Use the given CSS file instead of the builtin"), but `HtmlWriter.read_css` cannot read one from an absolute path on Windows, and cannot read a UTF-8 one anywhere. Two independent defects in the same eight lines, one commit each.

**1. A drive letter parses as a URL scheme.** `urlparse('C:/work/custom.css').scheme` is `'c'`, so every Windows absolute path takes the `urlopen` branch:

```
Error when trying to read external css: <urlopen error unknown url type: c>
```

`self.err()` aborts the run rather than falling back to the builtin sheet. The fix restricts that branch to the same scheme list already used for `--metadata-js-url` at html.py:579.

**2. The stylesheet is decoded with the locale encoding.** With the path problem out of the way, a UTF-8 sheet containing any non-ASCII byte raises:

```
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 14
```

That is a `ValueError`, so the `except IOError` below does not catch it and the user gets a traceback. The builtin stylesheet five lines further on is already read with `encoding='utf-8'`; this makes the external one match.

I verified the two separately: with only the first fix applied, the second still raises. Reproduced on Windows 10, cp950, CPython 3.11.6, editable install of f448bd2d.

The test asserts the returned text and path. Worth knowing before you read the CI: **it fails only on the `tests-windows` job.** On Linux and macOS a POSIX path has no scheme and the runners are UTF-8, so it passes there both before and after the change. Neither line has been touched since 2019.

No new dependencies. `CHANGELOG.md` is written by the release automation, so I have not edited it.
