### PR TITLE
chore(deps): Update Weasyprint to 70.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -85,7 +85,7 @@ jobs:
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing test dependencies..."
-        python -m pip install tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==68.0"
+        python -m pip install tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==70.0"
 
     - name: Generate Valid Tests
       run: |
@@ -131,12 +131,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew install make diffutils
-        # Install WeasyPrint 69.0
+        # Install WeasyPrint 70.0
         brew install weasyprint
         echo "Installing pip + wheel..."
         python -m pip install --upgrade pip wheel
         echo "Installing test dependencies..."
-        python -m pip install tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==69.0"
+        python -m pip install tox tox-gh-actions certifi decorator dict2xml pyflakes "pypdf>=4.1.0" "weasyprint==70.0"
 
     - name: Generate Valid Tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ issues = "https://github.com/ietf-tools/xml2rfc/issues"
 
 [project.optional-dependencies]
 pdf = [
-    "weasyprint==69.0",
+    "weasyprint==70.0",
 ]
 tests = [
     "decorator",


### PR DESCRIPTION
Bump weasyprint from 69.0 to 70.0 in pyproject.toml and the CI workflow. Also update the stale Linux job pin (was 68.0) that the previous bump missed, so all jobs use 70.0.


Model: claude-opus-4-8 (thinking: medium)